### PR TITLE
Fleshing out swing request logic

### DIFF
--- a/src/engine/BMButton.php
+++ b/src/engine/BMButton.php
@@ -85,6 +85,12 @@ class BMButton {
         $this->dieArray[] = $die;
     }
 
+    public function request_swing_values($swingtype, $die = NULL) {
+        if (isset($this->ownerObject)) {
+            $this->ownerObject->request_swing_values($swingtype);
+        }
+    }
+
     private function validate_recipe($recipe) {
         $dieArray = preg_split('/[[:space:]]+/', $recipe,
                                NULL, PREG_SPLIT_NO_EMPTY);

--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -607,7 +607,7 @@ class BMSwingDie extends BMDie {
 
         // The clone is the one going into the game, so it's the one
         // that needs a swing value to be set.
-        $this->ownerObject->request_swing_values($newDie, $newDie->swingType);
+        $this->ownerObject->request_swing_values($newDie->swingType, $newDie);
         $newDie->valueRequested = TRUE;
 
         $this->ownerObject->add_die($newDie, $playerIdx);
@@ -628,7 +628,7 @@ class BMSwingDie extends BMDie {
     {
         if ($this->needsValue) {
             if (!$this->valueRequested) {
-                $this->ownerObject->request_swing_values($this, $this->swingType);
+                $this->ownerObject->request_swing_values($this->swingType, $this);
                 $this->valueRequested = TRUE;
             }
             $this->ownerObject->require_values();

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -40,8 +40,14 @@ class BMGame {
 
     public $swingrequest;
 
-    public function request_swing_values($die, $swingtype) {
-        $this->swingrequest = array($die, $swingtype);
+    public function request_swing_values($swingtype, $die = NULL) {
+        if (isset($this->swingrequest[$swingtype])) {
+            if (isset($die)) {
+                $die->max = $this->swingrequest[$swingtype];
+            }
+        } else {
+            $this->swingrequest[$swingtype] = NULL;
+        }
     }
 
     public $all_values_specified = FALSE;

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -1410,8 +1410,8 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(BMGameState::specifyDice, $game->gameState);
 
         // specify dice
-        var_dump($game->buttonArray[0]->dieArray[4]);
         $this->assertEquals('X', $game->buttonArray[0]->dieArray[4]->recipe);
+
 
         // round 1
 

--- a/test/src/engine/BMSwingDieTest.php
+++ b/test/src/engine/BMSwingDieTest.php
@@ -193,8 +193,8 @@ class BMSwingDieTest extends PHPUnit_Framework_TestCase {
             $this->assertFalse($newDie === $this->object);
             $this->assertTrue($game === $newDie->ownerObject);
 
-            $this->assertEquals($newDie, $game->swingrequest[0]);
-            $this->assertEquals($swing, $game->swingrequest[1]);
+            $this->assertEquals($swing, $game->swingrequest[0]);
+            $this->assertEquals($newDie, $game->swingrequest[1]);
         }
 
     }

--- a/test/src/engine/testdummies.php
+++ b/test/src/engine/testdummies.php
@@ -110,8 +110,8 @@ class DummyGame {
 
     public $swingrequest;
 
-    public function request_swing_values($die, $swingtype) {
-        $this->swingrequest = array($die, $swingtype);
+    public function request_swing_values($swingtype, $die) {
+        $this->swingrequest = array($swingtype, $die);
     }
 
     public $all_values_specified = FALSE;


### PR DESCRIPTION
I have started working on how BMGame and BMButton handle swing requests. The reason for the pull request is to pass on the change in syntax, which changes the order of input parameters for request_swing_value(). I also cache the BMDie recipe in a public $recipe variable.
