### PR TITLE
install database in pagoda Boxfile, and clean up database init code

### DIFF
--- a/Boxfile
+++ b/Boxfile
@@ -10,3 +10,7 @@ web1:
   - "php deploy/pagodabox/phpunit.php /var/www/test"
   shared_writable_dirs:
   - /bmgame
+
+db1:
+  name: buttonmen
+  type: mysql

--- a/deploy/database/README
+++ b/deploy/database/README
@@ -1,0 +1,8 @@
+SQL files for the Buttonmen database
+
+To regenerate schemas, views, and data, source:
+  initialize_all.sql
+
+To drop and recreate all data only, source:
+  initialize_data.sql
+

--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -1,40 +1,9 @@
-# CREATE DATABASE buttonmen CHARACTER SET utf8;
-# USE buttonmen;
-
-DROP VIEW  IF EXISTS button_view;
-DROP TABLE IF EXISTS button_definitions,
-                     button_sets;
-
-CREATE TABLE button_sets (
-    id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    /* 'Chicagoland Games Enclave' has 27 characters */
-    name        VARCHAR(40) NOT NULL
-);
-
-CREATE TABLE button_definitions (
-    id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    /* 'The Fictitious Alan Clark' has 25 characters */
-    name        VARCHAR(40) UNIQUE NOT NULL,
-    /* 'Gryphon' has a recipe of:
-       P{g,sF}10 P{f,z}12 P{f,z}12 X! +`R! ro@Z? rz(V,V) rP{m,D}8 grP{h,o,n}Y
-       which has 70 characters */
-    recipe      VARCHAR(100) NOT NULL,
-    tourn_legal BOOLEAN NOT NULL,
-    image_path  VARCHAR(100),
-    set_id      SMALLINT UNSIGNED,
-    INDEX (name)
-);
-
-CREATE VIEW button_view
-AS SELECT d.name, d.recipe, d.tourn_legal, d.image_path, s.name AS set_name
-FROM button_definitions AS d
-LEFT JOIN button_sets AS s
-ON d.set_id = s.id;
-
+DELETE FROM button_sets;
 INSERT INTO button_sets (name) VALUES
 ('Soldiers'),
 ('Brom');
 
+DELETE FROM button_definitions;
 INSERT INTO button_definitions (name, recipe, tourn_legal, set_id) VALUES
 ('Avis', '4 4 10 12 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
 ('Hammer', '6 12 20 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),

--- a/deploy/database/data.game.sql
+++ b/deploy/database/data.game.sql
@@ -1,0 +1,17 @@
+
+
+DELETE FROM game_details;
+
+DELETE FROM game_player_map;
+
+DELETE FROM die_details;
+
+DELETE FROM open_game_possible_buttons;
+
+DELETE FROM open_game_possible_button_sets;
+
+DELETE FROM last_attack;
+
+DELETE FROM last_attack_die_map;
+
+DELETE FROM tournament_details;

--- a/deploy/database/data.player.sql
+++ b/deploy/database/data.player.sql
@@ -1,0 +1,8 @@
+# Prepopulated data for player-related tables
+
+DELETE FROM player_info;
+INSERT INTO player_info (name_ingame, name_irl) VALUES
+('blackshadowshade', 'James'),
+('glassonion', 'Chaos'),
+('jl8e', 'Julian'),
+('midnightlightning', 'Brooks');

--- a/deploy/database/initialize_all.sql
+++ b/deploy/database/initialize_all.sql
@@ -1,0 +1,7 @@
+# Initialize all buttonmen database data (schema, views, and data)
+
+use buttonmen;
+
+source initialize_schema.sql;
+source initialize_views.sql;
+source initialize_data.sql;

--- a/deploy/database/initialize_data.sql
+++ b/deploy/database/initialize_data.sql
@@ -1,0 +1,5 @@
+# Reset data in all buttonmen databases
+
+source data.button.sql;
+source data.game.sql;
+source data.player.sql;

--- a/deploy/database/initialize_schema.sql
+++ b/deploy/database/initialize_schema.sql
@@ -1,0 +1,8 @@
+# Drop and reinitialize schemas for all database tables
+
+use buttonmen;
+
+# Initialize schemas
+source schema.button.sql;
+source schema.player.sql;
+source schema.game.sql;

--- a/deploy/database/initialize_views.sql
+++ b/deploy/database/initialize_views.sql
@@ -1,0 +1,5 @@
+# Initialize views for all table types
+
+source views.button.sql;
+source views.player.sql;
+source views.game.sql;

--- a/deploy/database/schema.button.sql
+++ b/deploy/database/schema.button.sql
@@ -1,0 +1,23 @@
+# Table definitions for button-related tables
+
+DROP TABLE IF EXISTS button_sets;
+CREATE TABLE button_sets (
+    id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    /* 'Chicagoland Games Enclave' has 27 characters */
+    name        VARCHAR(40) NOT NULL
+);
+
+DROP TABLE IF EXISTS button_definitions;
+CREATE TABLE button_definitions (
+    id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    /* 'The Fictitious Alan Clark' has 25 characters */
+    name        VARCHAR(40) UNIQUE NOT NULL,
+    /* 'Gryphon' has a recipe of:
+       P{g,sF}10 P{f,z}12 P{f,z}12 X! +`R! ro@Z? rz(V,V) rP{m,D}8 grP{h,o,n}Y
+       which has 70 characters */
+    recipe      VARCHAR(100) NOT NULL,
+    tourn_legal BOOLEAN NOT NULL,
+    image_path  VARCHAR(100),
+    set_id      SMALLINT UNSIGNED,
+    INDEX (name)
+);

--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -1,11 +1,6 @@
-DROP VIEW  IF EXISTS game_player_view, open_game_possible_button_view;
-DROP TABLE IF EXISTS game_details,
-                     game_player_map,
-                     die_details,
-                     open_game_possible_buttons,
-                     open_game_possible_button_sets,
-                     tournament_details;
+# Table schemas for game-related tables
 
+DROP TABLE IF EXISTS game_details;
 CREATE TABLE game_details (
     id                 MEDIUMINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     last_action_time   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -24,6 +19,7 @@ CREATE TABLE game_details (
     chat               TEXT
 );
 
+DROP TABLE IF EXISTS game_player_map;
 CREATE TABLE game_player_map (
     game_id            MEDIUMINT UNSIGNED NOT NULL,
     player_id          SMALLINT UNSIGNED NOT NULL,
@@ -37,6 +33,7 @@ CREATE TABLE game_player_map (
     is_player_hidden   BOOLEAN DEFAULT FALSE
 );
 
+DROP TABLE IF EXISTS die_details;
 CREATE TABLE die_details (
     id                 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     owner_id           TINYINT UNSIGNED NOT NULL,
@@ -48,16 +45,19 @@ CREATE TABLE die_details (
     value              SMALLINT
 );
 
+DROP TABLE IF EXISTS open_game_possible_buttons;
 CREATE TABLE open_game_possible_buttons (
     game_id            MEDIUMINT UNSIGNED PRIMARY KEY,
     button_id          SMALLINT UNSIGNED NOT NULL
 );
 
+DROP TABLE IF EXISTS open_game_possible_button_sets;
 CREATE TABLE open_game_possible_button_sets (
     game_id            MEDIUMINT UNSIGNED PRIMARY KEY,
     set_id             SMALLINT UNSIGNED NOT NULL
 );
 
+DROP TABLE IF EXISTS last_attack;
 CREATE TABLE last_attack (
     game_id            MEDIUMINT UNSIGNED PRIMARY KEY,
     attacker_id        SMALLINT UNSIGNED NOT NULL,
@@ -66,6 +66,7 @@ CREATE TABLE last_attack (
     attack_type        VARCHAR(20) NOT NULL
 );
 
+DROP TABLE IF EXISTS last_attack_die_map;
 CREATE TABLE last_attack_die_map (
    game_id             MEDIUMINT UNSIGNED PRIMARY KEY,
    die_id              INT UNSIGNED NOT NULL,
@@ -74,6 +75,7 @@ CREATE TABLE last_attack_die_map (
    was_captured        BOOLEAN NOT NULL
 );
 
+DROP TABLE IF EXISTS tournament_details;
 CREATE TABLE tournament_details (
     id                 SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     status             ENUM ('OPEN', 'ACTIVE', 'COMPLETE') NOT NULL,
@@ -84,24 +86,3 @@ CREATE TABLE tournament_details (
     creator_id         SMALLINT UNSIGNED NOT NULL,
     description        VARCHAR(255) NOT NULL
 );
-
-CREATE VIEW game_player_view
-AS SELECT m.*, p.name_ingame AS player_name, b.name AS button_name
-FROM game_player_map AS m
-LEFT JOIN player_info AS p
-ON m.player_id = p.id
-LEFT JOIN button_definitions AS b
-ON m.button_id = b.id;
-
-CREATE VIEW open_game_possible_button_view
-AS SELECT g.id, pb.button_id, ps.set_id, b.name AS button_name, s.name AS set_name
-FROM game_details AS g
-LEFT JOIN open_game_possible_buttons AS pb
-ON g.id = pb.game_id
-LEFT JOIN open_game_possible_button_sets AS ps
-ON g.id = ps.game_id
-LEFT JOIN button_definitions AS b
-ON pb.button_id = b.id
-LEFT JOIN button_sets AS s
-ON ps.set_id = s.id
-WHERE g.status = "OPEN";

--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS player_info;
-
 CREATE TABLE player_info (
     id                  SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name_ingame         VARCHAR(25) NOT NULL UNIQUE,
@@ -17,9 +16,3 @@ CREATE TABLE player_info (
     n_games_lost        SMALLINT UNSIGNED DEFAULT 0,
     INDEX (name_ingame)
 );
-
-INSERT INTO player_info (name_ingame, name_irl) VALUES
-('blackshadowshade', 'James'),
-('glassonion', 'Chaos'),
-('jl8e', 'Julian'),
-('midnightlightning', 'Brooks');

--- a/deploy/database/views.button.sql
+++ b/deploy/database/views.button.sql
@@ -1,0 +1,8 @@
+# Table view definitions for button-related tables
+
+DROP VIEW  IF EXISTS button_view;
+CREATE VIEW button_view
+AS SELECT d.name, d.recipe, d.tourn_legal, d.image_path, s.name AS set_name
+FROM button_definitions AS d
+LEFT JOIN button_sets AS s
+ON d.set_id = s.id;

--- a/deploy/database/views.game.sql
+++ b/deploy/database/views.game.sql
@@ -1,0 +1,24 @@
+# Database views for game-related tables
+
+DROP VIEW IF EXISTS game_player_view;
+CREATE VIEW game_player_view
+AS SELECT m.*, p.name_ingame AS player_name, b.name AS button_name
+FROM game_player_map AS m
+LEFT JOIN player_info AS p
+ON m.player_id = p.id
+LEFT JOIN button_definitions AS b
+ON m.button_id = b.id;
+
+DROP VIEW IF EXISTS open_game_possible_button_view;
+CREATE VIEW open_game_possible_button_view
+AS SELECT g.id, pb.button_id, ps.set_id, b.name AS button_name, s.name AS set_name
+FROM game_details AS g
+LEFT JOIN open_game_possible_buttons AS pb
+ON g.id = pb.game_id
+LEFT JOIN open_game_possible_button_sets AS ps
+ON g.id = ps.game_id
+LEFT JOIN button_definitions AS b
+ON pb.button_id = b.id
+LEFT JOIN button_sets AS s
+ON ps.set_id = s.id
+WHERE g.status = "OPEN";

--- a/deploy/database/views.player.sql
+++ b/deploy/database/views.player.sql
@@ -1,0 +1,1 @@
+# Views for player-related tables

--- a/src/database/README
+++ b/src/database/README
@@ -1,6 +1,0 @@
-SQL code for creating and PHP code for interfacing with the ButtonMen database
-
-Run the SQL code in the following order to create the database correctly:
-  create_button_definitions.sql
-  create_player_tables.sql
-  create_game_tables.sql


### PR DESCRIPTION
Moved the init code into deploy/, split up schemas and data (and views for good measure) as is standard practice, and made some wrapper sql files to source the various files in the right order.  I didn't change any data, except to have the data inits start with DELETE statements, so that if you want to reset the data in the tables only, you don't wind up with duplicate rows.
