### PR TITLE
make database table names shorter and more consistent

### DIFF
--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -1,20 +1,20 @@
-DELETE FROM button_sets;
-INSERT INTO button_sets (name) VALUES
+DELETE FROM buttonset;
+INSERT INTO buttonset (name) VALUES
 ('Soldiers'),
 ('Brom');
 
-DELETE FROM button_definitions;
-INSERT INTO button_definitions (name, recipe, tourn_legal, set_id) VALUES
-('Avis', '4 4 10 12 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Hammer', '6 12 20 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Bauer', '8 10 12 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Stark', '4 6 8 X X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Clare', '6 8 8 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Kith', '6 8 12 12 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Karl', '4 6 6 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Iago', '20 20 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Niles', '6 10 10 12 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Shore', '4 4 20 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Hannah', '8 10 10 10 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Kublai', '4 8 12 20 X', 1, (SELECT id FROM button_sets WHERE name="Soldiers")),
-('Changeling', 'X X X X X', 0, (SELECT id FROM button_sets WHERE name="Soldiers"));
+DELETE FROM button;
+INSERT INTO button (name, recipe, tourn_legal, set_id) VALUES
+('Avis', '4 4 10 12 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Hammer', '6 12 20 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Bauer', '8 10 12 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Stark', '4 6 8 X X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Clare', '6 8 8 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Kith', '6 8 12 12 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Karl', '4 6 6 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Iago', '20 20 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Niles', '6 10 10 12 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Shore', '4 4 20 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Hannah', '8 10 10 10 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Kublai', '4 8 12 20 X', 1, (SELECT id FROM buttonset WHERE name="Soldiers")),
+('Changeling', 'X X X X X', 0, (SELECT id FROM buttonset WHERE name="Soldiers"));

--- a/deploy/database/data.game.sql
+++ b/deploy/database/data.game.sql
@@ -1,17 +1,17 @@
 
 
-DELETE FROM game_details;
+DELETE FROM game;
 
 DELETE FROM game_player_map;
 
-DELETE FROM die_details;
+DELETE FROM die;
 
 DELETE FROM open_game_possible_buttons;
 
-DELETE FROM open_game_possible_button_sets;
+DELETE FROM open_game_possible_buttonsets;
 
 DELETE FROM last_attack;
 
 DELETE FROM last_attack_die_map;
 
-DELETE FROM tournament_details;
+DELETE FROM tournament;

--- a/deploy/database/data.player.sql
+++ b/deploy/database/data.player.sql
@@ -1,7 +1,7 @@
 # Prepopulated data for player-related tables
 
-DELETE FROM player_info;
-INSERT INTO player_info (name_ingame, name_irl) VALUES
+DELETE FROM player;
+INSERT INTO player (name_ingame, name_irl) VALUES
 ('blackshadowshade', 'James'),
 ('glassonion', 'Chaos'),
 ('jl8e', 'Julian'),

--- a/deploy/database/initialize_data.sql
+++ b/deploy/database/initialize_data.sql
@@ -1,5 +1,8 @@
 # Reset data in all buttonmen databases
 
+# Pagoda defaults to auto_increment of 4, which isn't what we want
+set auto_increment_increment=1;
+
 source data.button.sql;
 source data.game.sql;
 source data.player.sql;

--- a/deploy/database/schema.button.sql
+++ b/deploy/database/schema.button.sql
@@ -1,14 +1,14 @@
 # Table definitions for button-related tables
 
-DROP TABLE IF EXISTS button_sets;
-CREATE TABLE button_sets (
+DROP TABLE IF EXISTS buttonset;
+CREATE TABLE buttonset (
     id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     /* 'Chicagoland Games Enclave' has 27 characters */
     name        VARCHAR(40) NOT NULL
 );
 
-DROP TABLE IF EXISTS button_definitions;
-CREATE TABLE button_definitions (
+DROP TABLE IF EXISTS button;
+CREATE TABLE button (
     id          SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     /* 'The Fictitious Alan Clark' has 25 characters */
     name        VARCHAR(40) UNIQUE NOT NULL,

--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -1,7 +1,7 @@
 # Table schemas for game-related tables
 
-DROP TABLE IF EXISTS game_details;
-CREATE TABLE game_details (
+DROP TABLE IF EXISTS game;
+CREATE TABLE game (
     id                 MEDIUMINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     last_action_time   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     status             ENUM ('OPEN', 'ACTIVE', 'COMPLETE') NOT NULL,
@@ -33,8 +33,8 @@ CREATE TABLE game_player_map (
     is_player_hidden   BOOLEAN DEFAULT FALSE
 );
 
-DROP TABLE IF EXISTS die_details;
-CREATE TABLE die_details (
+DROP TABLE IF EXISTS die;
+CREATE TABLE die (
     id                 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     owner_id           TINYINT UNSIGNED NOT NULL,
     game_id            MEDIUMINT UNSIGNED NOT NULL,
@@ -51,8 +51,8 @@ CREATE TABLE open_game_possible_buttons (
     button_id          SMALLINT UNSIGNED NOT NULL
 );
 
-DROP TABLE IF EXISTS open_game_possible_button_sets;
-CREATE TABLE open_game_possible_button_sets (
+DROP TABLE IF EXISTS open_game_possible_buttonsets;
+CREATE TABLE open_game_possible_buttonsets (
     game_id            MEDIUMINT UNSIGNED NOT NULL,
     set_id             SMALLINT UNSIGNED NOT NULL
 );
@@ -75,8 +75,8 @@ CREATE TABLE last_attack_die_map (
    was_captured        BOOLEAN NOT NULL
 );
 
-DROP TABLE IF EXISTS tournament_details;
-CREATE TABLE tournament_details (
+DROP TABLE IF EXISTS tournament;
+CREATE TABLE tournament (
     id                 SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     status             ENUM ('OPEN', 'ACTIVE', 'COMPLETE') NOT NULL,
     current_round      TINYINT UNSIGNED DEFAULT 1,

--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS player_info;
-CREATE TABLE player_info (
+DROP TABLE IF EXISTS player;
+CREATE TABLE player (
     id                  SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name_ingame         VARCHAR(25) NOT NULL UNIQUE,
     password_hashed     VARCHAR(40),

--- a/deploy/database/updates/001_drop_old_table_names.sql
+++ b/deploy/database/updates/001_drop_old_table_names.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS button_definitions;
+DROP TABLE IF EXISTS button_sets;
+DROP TABLE IF EXISTS die_details;
+DROP TABLE IF EXISTS game_details;
+DROP TABLE IF EXISTS open_game_possible_button_sets;
+DROP TABLE IF EXISTS player_info;
+DROP TABLE IF EXISTS tournament_details;

--- a/deploy/database/views.button.sql
+++ b/deploy/database/views.button.sql
@@ -3,6 +3,6 @@
 DROP VIEW IF EXISTS button_view;
 CREATE VIEW button_view
 AS SELECT d.name, d.recipe, d.tourn_legal, d.image_path, s.name AS set_name
-FROM button_definitions AS d
-LEFT JOIN button_sets AS s
+FROM button AS d
+LEFT JOIN buttonset AS s
 ON d.set_id = s.id;

--- a/deploy/database/views.game.sql
+++ b/deploy/database/views.game.sql
@@ -4,21 +4,21 @@ DROP VIEW IF EXISTS game_player_view;
 CREATE VIEW game_player_view
 AS SELECT m.*, p.name_ingame AS player_name, b.name AS button_name
 FROM game_player_map AS m
-LEFT JOIN player_info AS p
+LEFT JOIN player AS p
 ON m.player_id = p.id
-LEFT JOIN button_definitions AS b
+LEFT JOIN button AS b
 ON m.button_id = b.id;
 
 DROP VIEW IF EXISTS open_game_possible_button_view;
 CREATE VIEW open_game_possible_button_view
 AS SELECT g.id, pb.button_id, ps.set_id, b.name AS button_name, s.name AS set_name
-FROM game_details AS g
+FROM game AS g
 LEFT JOIN open_game_possible_buttons AS pb
 ON g.id = pb.game_id
-LEFT JOIN open_game_possible_button_sets AS ps
+LEFT JOIN open_game_possible_buttonsets AS ps
 ON g.id = ps.game_id
-LEFT JOIN button_definitions AS b
+LEFT JOIN button AS b
 ON pb.button_id = b.id
-LEFT JOIN button_sets AS s
+LEFT JOIN buttonset AS s
 ON ps.set_id = s.id
 WHERE g.status = "OPEN";

--- a/src/database/mysql.inc.php
+++ b/src/database/mysql.inc.php
@@ -18,6 +18,10 @@
     try {
         $conn = new PDO("mysql:host=$host;port=$port;dbname=$name", $user, $pass);
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        // Make sure auto_increment_increment is 1 
+        $statement = $conn->prepare('SET AUTO_INCREMENT_INCREMENT=1');
+        $statement->execute();
     } catch(PDOException $e) {
         echo 'ERROR: ' . $e->getMessage();
     }

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 //require_once 'BMButton.php';
-require_once 'BMGame.php';
+//require_once 'BMGame.php';
 
 /**
  * BMInterface: interface between GUI and BMGame
@@ -35,7 +35,7 @@ class BMInterface {
             }
 
             // create basic game details
-            $query = 'INSERT INTO game_details '.
+            $query = 'INSERT INTO game '.
                      '(n_players, n_target_wins, creator_id) '.
                      'VALUES '.
                      '(:n_players, :n_target_wins, :creator_id)';
@@ -53,7 +53,7 @@ class BMInterface {
                 // get button ID
                 $buttonName = $buttonNameArray[$position];
                 if (!is_null($buttonName)) {
-                    $query = 'SELECT id FROM button_definitions '.
+                    $query = 'SELECT id FROM button '.
                              'WHERE name = :button_name';
                     $statement = self::$conn->prepare($query);
                     $statement->execute(array(':button_name' => $buttonName));
@@ -115,7 +115,7 @@ class BMInterface {
 //            $gamefile = "/var/www/bmgame/$game->gameId.data";
 //            $gameInt = serialize($game);
 //            file_put_contents($gamefile, $gameInt);
-            $query = "INSERT INTO game_details () ".
+            $query = "INSERT INTO game () ".
                      "VALUES ".
                      "()";
             $statement = self::$conn->prepare($query);
@@ -151,7 +151,7 @@ class BMInterface {
 
     public function get_player_names_like($input = '') {
         try {
-            $query = 'SELECT name_ingame FROM player_info '.
+            $query = 'SELECT name_ingame FROM player '.
                      'WHERE name_ingame LIKE :input '.
                      'ORDER BY name_ingame';
             $statement = self::$conn->prepare($query);
@@ -175,7 +175,7 @@ class BMInterface {
 //            $idArray = array('blackshadowshade' => '1',
 //                             'glassonion' => '3',
 //                             'jl8e' => '2');
-            $query = 'SELECT id FROM player_info '.
+            $query = 'SELECT id FROM player '.
                      'WHERE name_ingame = :input';
             $statement = self::$conn->prepare($query);
             $statement->execute(array(':input' => $name));

--- a/util/grunt/README
+++ b/util/grunt/README
@@ -15,10 +15,12 @@ Please do not check ./node_modules into git!
 Once you have grunt installed in your working directory, to run the
 lint check, use:
   ./node_modules/grunt-cli/bin/grunt
+(or simply "grunt", if you have grunt centrally installed on this
+system.)
 
-A copy of the .jshintrc config file used to set lint parameters is also
-present. This file can either go anywhere in the search path for JSHint,
-i.e. (1) in the directory with the Javascript files to be linted,
-     (2) in directories above the files to be linted, or
-     (3) in ~
-(see https://github.com/mctenshi/jshint/pull/2)
+
+Note: this should work correctly if you execute grunt while in this
+directory, but is not guaranteed to work if you cd elsewhere.  The
+.jshintrc file and node_modules which grunt uses will be here, and
+the config files specify the directories to lint relative to this
+directory.


### PR DESCRIPTION
Also:
- Try to fix a pagodabox issue i noticed in which auto_increment adds an increment of 4 rather than 1 to each index.  That's apparently useful for some sorts of database replication scenarios, but i'm pretty sure it's not what we want.
- clarify grunt README

Important note: when you apply this update, if you have an existing database, you must run the SQL file:
deploy/database/updates/001_drop_old_table_names.sql
This file removes tables which are no longer used.  If you are creating a fresh database from scratch, you do _not_ need to run this file, which is why i didn't add it to initialize_all.sql
