### PR TITLE
* make the database field for password_hashed longer

### DIFF
--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS player;
 CREATE TABLE player (
     id                  SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name_ingame         VARCHAR(25) UNIQUE NOT NULL,
-    password_hashed     VARCHAR(40),
+    password_hashed     VARCHAR(128),
     name_irl            VARCHAR(40) NOT NULL,
     email               VARCHAR(254),
     dob                 DATE,


### PR DESCRIPTION
  This is to support systems which default to sha512 as the algorithm used by PHP crypt(), and thus have longer password hashes
