### PR TITLE
* clarify error message when nonnumeric swing values are entered

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -405,7 +405,7 @@ Game.formChooseSwingActive = function() {
   } else {
     Env.message = { 
       'type': 'error',
-      'text': 'Not enough swing values specified',
+      'text': 'Some swing values missing or nonnumeric',
     };
     Game.showGamePage();
   }


### PR DESCRIPTION
Fixes #78

I clarified the error message to "Some swing values missing or nonnumeric".  The nonnumeric swing values are not sent to the server --- they're sanity-checked locally.  Good enough?
