### PR TITLE
a different method for getting the version for version.html, which should give nonzero exit status even if /buttonmen/.git/FETCH_HEAD doesn't exist

### DIFF
--- a/deploy/vagrant/bootstrap.sh
+++ b/deploy/vagrant/bootstrap.sh
@@ -11,9 +11,3 @@ else
   apt-get -y install puppet
 fi
 
-# grab the git tag and put it in a version file
-if [ -f /buttonmen/.git/FETCH_HEAD ]; then
-  cut -f 1 /buttonmen/.git/FETCH_HEAD /etc/buttonmen_version
-else
-  touch /etc/buttonmen_version
-fi 

--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -8,8 +8,6 @@ class buttonmen::server {
   $buttonmen_db2_user = "root"
   $buttonmen_db2_pass = "root"
 
-  $buttonmen_code_githash = file("/etc/buttonmen_version")
-
   file {
 
     # Install a .htaccess file containing buttonmen variables
@@ -27,11 +25,6 @@ class buttonmen::server {
     "/usr/local/etc/buttonmen_phpunit.php":
       ensure => file,
       content => template("buttonmen/phpunit.php.erb");
-
-    "/var/www/version.html":
-      ensure => file,
-      content => template("buttonmen/version.html.erb"),
-      require => Exec["buttonmen_src_rsync"];
   }
 
   exec {


### PR DESCRIPTION
Sorry about this.  Wanted to get a fix in before any other devs trip over it.
