### PR TITLE
Roll new halved die after performing a berserk attack

### DIFF
--- a/src/engine/BMSkillBerserk.php
+++ b/src/engine/BMSkillBerserk.php
@@ -50,6 +50,7 @@ class BMSkillBerserk extends BMSkill {
         // force removal of swing, twin die, and option status
         $splitDieArray = $attacker->split();
         $newAttacker = $splitDieArray[0];
+        $newAttacker->roll(TRUE);
         $args['attackers'][0] = $newAttacker;
     }
 }

--- a/test/src/engine/BMAttackBerserkTest.php
+++ b/test/src/engine/BMAttackBerserkTest.php
@@ -24,7 +24,7 @@ class BMAttackBerserkTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @covers BMAttackSpeed::validate_attack
+     * @covers BMAttackBerserk::validate_attack
      */
     public function testValidate_attack()
     {

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -4403,6 +4403,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->assertArrayNotHasKey('Berserk', $skillList);
         $this->assertNotInstanceOf('BMDieSwing', $game->activeDieArrayArray[1][2]);
         $this->assertEquals(6, $game->activeDieArrayArray[1][2]->max);
+        $this->assertTrue(isset($game->activeDieArrayArray[1][2]->value));
 
         $this->assertEquals(array(40.5, 3.0), $game->roundScoreArray);
     }


### PR DESCRIPTION
Minor change to fix berserk swing die bug.

No database change required.

Fixes #290.
