### PR TITLE
display expected swing die ranges to user when setting swing dice

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1492,11 +1492,22 @@ class BMGame {
                 $sidesArrayArray[] = array();
                 $dieRecipeArrayArray[] = array();
 
-                if (empty($this->swingRequestArrayArray[$playerIdx])) {
-                    $swingRequestArrayArray[] = array();
-                } else {
-                    $swingRequestArrayArray[] = array_keys($this->swingRequestArrayArray[$playerIdx]);
+                $playerSwingRequestArray = array();
+                foreach ($this->swingRequestArrayArray[$playerIdx] as $swingtype => $swingdice) {
+                    if ($swingdice[0] instanceof BMDieTwin) {
+                        $swingdie = $swingdice[0]->dice[0];
+                    } else {
+                        $swingdie = $swingdice[0];
+                    }
+                    if ($swingdie instanceof BMDieSwing) {
+                        $validRange = $swingdie->swing_range($swingtype);
+                    } else {
+                        throw new LogicException("Tried to put die in swingRequestArrayArray which is not a swing die: " . $swingdie);
+                    }
+                    $playerSwingRequestArray[$swingtype] = array(strval($validRange[0]), strval($validRange[1]));
                 }
+                $swingRequestArrayArray[] = $playerSwingRequestArray;
+
                 foreach ($activeDieArray as $die) {
                     // hide swing information if appropriate
                     $dieValue = $die->value;

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -875,19 +875,17 @@ class BMInterface {
             }
 
             // try to set swing values
-            $swingRequestArray = array_keys($game->swingRequestArrayArray[$currentPlayerIdx]);
+            $swingLettersRequested = array_keys($game->swingRequestArrayArray[$currentPlayerIdx]);
+            sort($swingLettersRequested);
+            $swingLettersSubmitted = array_keys($swingValueArray);
+            sort($swingLettersSubmitted);
 
-            if (count($swingRequestArray) != count($swingValueArray)) {
-                $this->message = 'Wrong number of swing values submitted';
+            if ($swingLettersRequested != $swingLettersSubmitted) {
+                $this->message = 'Wrong swing values submitted: expected ' . implode(',', $swingLettersRequested);
                 return NULL;
             }
 
-            $swingValueArrayWithKeys = array();
-            foreach ($swingRequestArray as $swingIdx => $swingRequest) {
-                $swingValueArrayWithKeys[$swingRequest] = $swingValueArray[$swingIdx];
-            }
-
-            $game->swingValueArrayArray[$currentPlayerIdx] = $swingValueArrayWithKeys;
+            $game->swingValueArrayArray[$currentPlayerIdx] = $swingValueArray;
 
             $game->proceed_to_next_user_action();
 

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -215,9 +215,15 @@ Game.parsePlayerData = function(playerIdx, playerNameArray) {
     'sidesArray': Game.api.gameData['data']['sidesArrayArray'][playerIdx],
     'dieRecipeArray':
       Game.api.gameData['data']['dieRecipeArrayArray'][playerIdx],
-    'swingRequestArray':
-      Game.api.gameData['data']['swingRequestArrayArray'][playerIdx],
+    'swingRequestArray': {},
   }
+  $.each(Game.api.gameData['data']['swingRequestArrayArray'][playerIdx],
+         function(letter, range) {
+           data['swingRequestArray'][letter] = {
+             'min': parseInt(range[0]),
+             'max': parseInt(range[1])
+           }
+         })
 
   // activePlayerIdx may be either player or may be null
   if (Game.api.gameData['data']['activePlayerIdx'] == playerIdx) {
@@ -256,14 +262,16 @@ Game.actionChooseSwingActive = function() {
                     });
   var swingtable = $('<table>', {'id': 'swing_table', });
   $.each (Game.api.player.swingRequestArray,
-          function(index, value) {
+          function(letter, range) {
             var swingrow = $('<tr>', {});
-            swingrow.append($('<td>', { 'text': value + ':', }));
+            var swingtext = letter + ': (' + range['min'] + '-' +
+                            range['max'] + ')'
+            swingrow.append($('<td>', { 'text': swingtext, }));
             var swinginput = $('<td>', {});
             swinginput.append($('<input>', {
                                'type': 'text',
                                'class': 'swing',
-                               'id': 'swing_' + index,
+                               'id': 'swing_' + letter,
                                'size': '2',
                                'maxlength': '2',
                               }));
@@ -404,12 +412,13 @@ Game.actionShowFinishedGame = function() {
 // Form submission action for choosing swing dice
 Game.formChooseSwingActive = function() {
   var textFieldsFilled = true;
-  var swingValueArray = [];
+  var swingValueArray = {};
 
-  $('input:text').each(function(index, element) {
-    var value = $(element).val();
+  // Iterate over expected swing values
+  $.each(Game.api.player.swingRequestArray, function(letter, range) {
+    var value = $('#swing_' + letter).val();
     if ($.isNumeric(value)) {
-      swingValueArray[index] = value;
+      swingValueArray[letter] = value;
     } else {
       textFieldsFilled = false;
     }

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -327,7 +327,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'type' => 'submitSwingValues',
             'roundNumber' => 1,
             'timestamp' => $timestamp,
-            'swingValueArray' => array('7'));
+            'swingValueArray' => array('X' => '7'));
         $args['game'] = $real_game_id;
         $retval = $this->object->process_request($args);
         $args['game'] = $dummy_game_id;

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -128,6 +128,10 @@ asyncTest("test_Game.parsePlayerData", function() {
   Game.getCurrentGame(function() {
     deepEqual(Game.api.player.dieRecipeArray, ["(4)","(4)","(10)","(12)","(X)"],
               "player die recipe array should be parsed correctly");
+    deepEqual(
+      Game.api.player.swingRequestArray['X'],
+      {'min': 4, 'max': 20},
+      "swing request array should contain X entry with correct min/max");
     start();
   });
 });
@@ -139,6 +143,8 @@ asyncTest("test_Game.actionChooseSwingActive", function() {
     item = document.getElementById('swing_table');
     equal(item.nodeName, "TABLE",
           "#swing_table is a table after actionChooseSwingActive() is called");
+    ok(item.innerHTML.match(/X: \(4-20\)/),
+       "swing table should contain request to set X swing");
     start();
   });
 });
@@ -195,7 +201,7 @@ asyncTest("test_Game.formChooseSwingActive", function() {
   BMTestUtils.GameType = 'newgame';
   Game.getCurrentGame(function() {
     Game.actionChooseSwingActive();
-    $('#swing_0').val('7');
+    $('#swing_X').val('7');
     $.ajaxSetup({ async: false });
     $('#game_action_button').trigger('click');
     deepEqual(


### PR DESCRIPTION
Changes needed to make this happen:
- when requesting swing dice, specify the valid range for each die value and show this to the user
- when submitting swing dice, specify each submitted swing die by type rather than by position

Fixes #215
