### PR TITLE
jenkins should allow only one simultaneous executor, not two

### DIFF
--- a/deploy/vagrant/modules/jenkins/templates/config.xml.erb
+++ b/deploy/vagrant/modules/jenkins/templates/config.xml.erb
@@ -2,7 +2,7 @@
 <hudson>
   <disabledAdministrativeMonitors/>
   <version>1.0</version>
-  <numExecutors>2</numExecutors>
+  <numExecutors>1</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">


### PR DESCRIPTION
Config change for jenkins to allow only one simultaneous job execution across all projects.
- Successful build of this code: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/52/
- This addresses #424, but doesn't fix it, because i need to actually deploy to jenkins once it's approved
