### PR TITLE
Added logic to validate 'decline' action when responding to initiative, both with focus and chance dice

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1240,6 +1240,8 @@ class BMInterface {
                     }
                     break;
                 case 'decline':
+                    $argArray['dieIdxArray'] = $dieIdxArray;
+                    $argArray['dieValueArray'] = $dieValueArray;
                     break;
                 default:
                     $this->message = 'Invalid action to respond to initiative.';

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -313,13 +313,24 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         // test invalid action
         $this->assertFalse(
             $game->react_to_initiative(array('action' => 'blargl',
-                                             'playerIdx' => 0)));
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => NULL,
+                                             'dieValueArray' => NULL)));
 
-        // test 'decline' action
+        // test invalid 'decline' action
+        $this->assertFalse(
+            $game->react_to_initiative(array('action' => 'decline',
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => array(3),
+                                             'dieValueArray' => NULL)));
+
+        // test valid 'decline' action
         $this->assertEquals(
             array('gained_initiative' => FALSE),
             $game->react_to_initiative(array('action' => 'decline',
-                                             'playerIdx' => 0)));
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => NULL,
+                                             'dieValueArray' => NULL)));
         $game->proceed_to_next_user_action();
         $this->assertEquals(BMGameState::START_TURN, $game->gameState);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
@@ -607,13 +618,24 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         // test invalid action
         $this->assertFalse(
             $game->react_to_initiative(array('action' => 'blargl',
-                                             'playerIdx' => 0)));
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => NULL,
+                                             'dieValueArray' => NULL)));
 
-        // test 'decline' action
+        // test invalid 'decline' action
+        $this->assertFalse(
+            $game->react_to_initiative(array('action' => 'decline',
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => array(1, 3),
+                                             'dieValueArray' => array(3, 4))));
+
+        // test valid 'decline' action
         $this->assertEquals(
             array('gained_initiative' => FALSE),
             $game->react_to_initiative(array('action' => 'decline',
-                                             'playerIdx' => 0)));
+                                             'playerIdx' => 0,
+                                             'dieIdxArray' => NULL,
+                                             'dieValueArray' => NULL)));
         $game->proceed_to_next_user_action();
         $this->assertEquals(BMGameState::START_TURN, $game->gameState);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
@@ -828,7 +850,9 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(
             array('gained_initiative' => FALSE),
             $game->react_to_initiative(array('action' => 'decline',
-                                             'playerIdx' => 1)));
+                                             'playerIdx' => 1,
+                                             'dieIdxArray' => NULL,
+                                             'dieValueArray' => NULL)));
         $this->assertEquals(4, $game->activeDieArrayArray[0][0]->value);
         $this->assertEquals(1, $game->activeDieArrayArray[0][1]->value);
         $this->assertEquals(4, $game->activeDieArrayArray[0][2]->value);


### PR DESCRIPTION
http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/19/

I'll address most of the cyclomatic complexity warnings in my next pull request.
