### PR TITLE
use dot notation for two new variable settings

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -298,10 +298,10 @@ Game.parseValidInitiativeActions = function() {
     });
 
     if (hasFocus) {
-      Game.api.player.initiativeActions['focus'] = focus;
+      Game.api.player.initiativeActions.focus = focus;
     }
     if (hasChance) {
-      Game.api.player.initiativeActions['chance'] = chance;
+      Game.api.player.initiativeActions.chance = chance;
     }
     Game.api.player.initiativeActions.decline = true;
   }


### PR DESCRIPTION
Two-liner change; unfortunately JSHint breaks the build when it fails, because it's not as cleanly integrated as the PHP stuff.
