### PR TITLE
for attack types, use the longer text as "label" as well as "text",

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -439,7 +439,7 @@ Game.actionPlayTurnActive = function() {
     }
     var attacktypeopts = {
       'value': typevalue,
-      'label': typename,
+      'label': typetext,
       'text': typetext,
     };
     if (('attackType' in Game.activity) &&


### PR DESCRIPTION
- Fixes #490
- Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/112/
