### PR TITLE
increase run-jscover-qunit.js timeout to 60 seconds

### DIFF
--- a/deploy/vagrant/modules/javascript/templates/run-jscover-qunit.js.erb
+++ b/deploy/vagrant/modules/javascript/templates/run-jscover-qunit.js.erb
@@ -19,7 +19,7 @@ var system = require('system');
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, onReady, timeOutMillis) {
-    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timout is 10s
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 60001, //< Default Max Timout is 60s
         start = new Date().getTime(),
         condition = false,
         interval = setInterval(function() {


### PR DESCRIPTION
- Fixes #500 (once deployed on jenkins)
- Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/119/
