### PR TITLE
update post-puppet instructions for jenkins to include moving to /mnt under AWS

### DIFF
--- a/deploy/jenkins/README.post-puppet
+++ b/deploy/jenkins/README.post-puppet
@@ -1,19 +1,25 @@
 Some of the configuration of Jenkins is easier done by hand, after
 puppet has finished running:
- 1. Manually enable Jenkins authentication (you can't setup users
+ 1. If you're deploying on AWS, move /var/lib/jenkins/jobs to /mnt
+cd /var/lib/jenkins
+sudo service jenkins stop
+sudo mv jobs /mnt/jenkins-jobs
+sudo ln -s /mnt/jenkins-jobs ./jobs
+sudo service jenkins start
+ 2. Manually enable Jenkins authentication (you can't setup users
     until you do this):
     * Browse to /configureSecurity
     * Check "Enable security".  The page should expand
     * Click "Jenkins’ own user database"
     * Click "Save"
- 2. Setup users:
+ 3. Setup users:
     * Setup configs and passwords for at least one user (yourself)
       by browsing to the UI /securityRealm/addUser item
     * You'll want to login as yourself and setup an SSH key at
       /me/configure.  Make sure to use a public key whose private
       key you don't mind bringing onto the jenkins system, since
       that's the easiest place to run the jenkins CLI.
- 3. Setup config that requires auth:
+ 4. Setup config that requires auth:
     * Copy the config file into place and restart jenkins
 sudo service jenkins stop
 sudo cp /usr/local/etc/jenkins_config.xml /var/lib/jenkins/config.xml


### PR DESCRIPTION
I could have chosen to have puppet make this change, but it would have been complicated and error-prone.  Since there is already manual post-puppet customization that needs to be done for a new jenkins install, IMO it's fine to treat the FS move that way too.
- Fixes #502
- Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/123/
