### PR TITLE
504 add official bm sets

### DIFF
--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -306,7 +306,7 @@ INSERT INTO button (name, recipe, btn_special, tourn_legal, set_id) VALUES
 
 # FIGHTBALL (Cheapass Games) NOTE: special die selection rules - choose 5 dice out of all available (not implemented)
 # ASSUMED ALL TO BE TL
-INSERT INTO button (name, recipe, btn_special, tourn_legal, set_id) VALUES
+#INSERT INTO button (name, recipe, btn_special, tourn_legal, set_id) VALUES
 #('Brie',      '(4) (6) (8) (10) (12) (12) (20)',       0, 1, (SELECT id FROM buttonset WHERE name="Fightball")),
 #('Domino',    '(4) (4) (8) (8) (8) (10) (12)',         0, 1, (SELECT id FROM buttonset WHERE name="Fightball")),
 #('Echo(p)',   '(4) (6) (6) (6) (12) (12) (12) (20)',   0, 1, (SELECT id FROM buttonset WHERE name="Fightball")),


### PR DESCRIPTION
I see now why the pull request starts with compare.  This is definitely a better view of the changes I made.  Sorry about the previous mess.  Still learning, and being embarrassingly slow about it. : (

It might be nice to resolve the question of #510 Specialty dice before this is accepted, but it might be nicer just to get this done.  If my current interpretation of Specialty is incorrect an issue can always be made for it later. 

Also, I noticed some things in the comments - a failure to add the die code for Thief - and a note-to-self "(not implemented)" that I didn't remove - that could use improvement, but I don't see as anything pressing. 
