### PR TITLE
Fixed bug with courtesy auxiliary dice having the wrong original owner

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -253,7 +253,10 @@ class BMGame {
             foreach ($havePlayersAuxDice as $playerIdx => $hasAuxDice) {
                 if (!$hasAuxDice) {
                     foreach ($auxiliaryDice as $die) {
-                        $this->activeDieArrayArray[$playerIdx][] = clone $die;
+                        $newdie = clone $die;
+                        $newdie->playerIdx = $playerIdx;
+                        $newdie->originalPlayerIdx = $playerIdx;
+                        $this->activeDieArrayArray[$playerIdx][] = $newdie;
                     }
                 }
             }

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -207,8 +207,15 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         foreach ($button2->dieArray as $die) {
             $dieArray2[] = clone $die;
         }
-        $dieArray2[] = clone $button1->dieArray[2];
-        $dieArray2[] = clone $button1->dieArray[4];
+        $firstAuxDie = clone $button1->dieArray[2];
+        $firstAuxDie->playerIdx = 1;
+        $firstAuxDie->originalPlayerIdx = 1;
+        $dieArray2[] = $firstAuxDie;
+
+        $secondAuxDie = clone $button1->dieArray[4];
+        $secondAuxDie->playerIdx = 1;
+        $secondAuxDie->originalPlayerIdx = 1;
+        $dieArray2[] = $secondAuxDie;
 
         $this->assertEquals(array($dieArray1, $dieArray2),
                             $this->object->activeDieArrayArray);


### PR DESCRIPTION
http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/110/

Fixes #592.

This will not retroactively fix broken games affected by this bug.
