### PR TITLE
Fixed case sensitivity bug in re-enabling buttons with BMBtnSkills

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -904,8 +904,7 @@ class BMInterface {
                     $button = new BMButton();
                     $button->load($row['recipe'], $row['name']);
 
-                    // james: put in temporary code to disable buttons with button specials
-                    $standardName = preg_replace('/[^a-z0-9]/', '', strtolower($button->name));
+                    $standardName = preg_replace('/[^a-zA-Z0-9]/', '', $button->name);
                     if ((1 == $row['btn_special']) &&
                         !class_exists('BMBtnSkill'.$standardName)) {
                         $button->hasUnimplementedSkill = TRUE;


### PR DESCRIPTION
Fixed #489 better. Now, also buttons with names containing punctuation and spaces should be handled correctly.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/116/
