### PR TITLE
always fill in some values in the action log params array to make json_decode happy

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1078,7 +1078,7 @@ class BMGame {
         $this->log_action(
             'init_decline',
             $this->playerIdArray[$playerIdx],
-            array()
+            array('initDecline' => TRUE)
         );
 
         if (0 == array_sum($this->waitingOnActionArray)) {

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -24,6 +24,9 @@ class BMGameAction {
         $actingPlayerId,
         $params
     ) {
+        if (!$params) {
+            throw new Exception("BMGameAction error: params can't be empty");
+        }
         $this->gameState = $gameState;
         $this->actionType = $actionType;
         $this->actingPlayerId = $actingPlayerId;

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1409,7 +1409,7 @@ class BMInterface {
                     $game->log_action(
                         'decline_auxiliary',
                         $game->playerIdArray[$playerIdx],
-                        array()
+                        array('declineAuxiliary' => TRUE)
                     );
                     $this->message = 'Declined auxiliary dice';
                     break;
@@ -1490,7 +1490,7 @@ class BMInterface {
                     $game->log_action(
                         'decline_reserve',
                         $game->playerIdArray[$playerIdx],
-                        array()
+                        array('declineReserve' => TRUE)
                     );
                     $this->message = 'Declined reserve dice';
                     break;

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -32,6 +32,13 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($this->object->actionType, 'attack');
         $this->assertEquals($this->object->actingPlayerId, 1);
         $this->assertEquals($this->object->params, $attackStr);
+
+        try {
+            $this->object = new BMGameAction(40, 'attack', 1, array());
+            $this->fail('BMGameAction should not accept empty params array');
+        }
+        catch (Exception $expected) {
+        }
     }
 
     /**
@@ -146,7 +153,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_init_decline()
      */
     public function test_friendly_message_init_decline() {
-        $this->object = new BMGameAction(27, 'init_decline', 2, array());
+        $this->object = new BMGameAction(27, 'init_decline', 2, array('initDecline' => TRUE));
         $this->assertEquals(
             $this->object->friendly_message($this->playerIdNames, 0, 0),
             "gameaction02 chose not to try to gain initiative using chance or focus dice"
@@ -170,7 +177,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_decline_reserve()
      */
     public function test_friendly_message_decline_reserve() {
-        $this->object = new BMGameAction(22, 'decline_reserve', 2, array());
+        $this->object = new BMGameAction(22, 'decline_reserve', 2, array('declineReserve' => TRUE));
         $this->assertEquals(
             $this->object->friendly_message($this->playerIdNames, 0, 0),
             "gameaction02 chose not to add a reserve die"
@@ -197,7 +204,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_decline_auxiliary()
      */
     public function test_friendly_message_decline_auxiliary() {
-        $this->object = new BMGameAction(20, 'decline_auxiliary', 2, array());
+        $this->object = new BMGameAction(20, 'decline_auxiliary', 2, array('declineAuxiliary' => TRUE));
         $this->assertEquals(
             $this->object->friendly_message($this->playerIdNames, 0, 0),
             "gameaction02 chose not to use auxiliary dice in this game: neither player will get an auxiliary die"


### PR DESCRIPTION
- Fixes #619
- Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/167/
