### PR TITLE
Fixed bug in reserve swing unit test

### DIFF
--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -7716,6 +7716,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $activeDieArrayArray = $game->activeDieArrayArray;
         $activeDieArrayArray[1][0]->value = 1;
         $game->waitingOnActionArray = array(TRUE, FALSE);
+        $game->activePlayerIdx = 0;
 
         // player 1 attacks and wins round 1
         $this->assertNULL($game->attack);


### PR DESCRIPTION
Fixes #679.

After putting this fix in, I was able to run the unit tests 40 times in a row without a failure.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/128/
