### PR TITLE
add jota account permissions to jenkins config

### DIFF
--- a/deploy/vagrant/modules/jenkins/templates/config.xml.erb
+++ b/deploy/vagrant/modules/jenkins/templates/config.xml.erb
@@ -13,6 +13,7 @@
     <permission>hudson.model.Item.Workspace:anonymous</permission>
     <permission>hudson.model.Item.Build:chaos</permission>
     <permission>hudson.model.Item.Build:james</permission>
+    <permission>hudson.model.Item.Build:jota</permission>
     <permission>hudson.model.Item.Build:manvillefog</permission>
   </authorizationStrategy>
   <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">


### PR DESCRIPTION
- Needed for #733
- No jenkins, because it's a change in deploy/ only
