### PR TITLE
* set puppet hostname for jenkins node so it can run puppet

### DIFF
--- a/deploy/jenkins/manifests/init.pp
+++ b/deploy/jenkins/manifests/init.pp
@@ -7,6 +7,9 @@ node default {
     require => Exec["apt_client_update"],
   }
 
+  # jenkins hostname is always jenkins.buttonweavers.com
+  $puppet_hostname = "jenkins.buttonweavers.com"
+
   # Generic node configuration
   include "apt::client"
   include "postfix::base"


### PR DESCRIPTION
- More work for #733
- Again, this is only deploy code to run puppet _on_ the jenkins server, so no jenkins test
