### PR TITLE
Preserved non-trailing whitespace in chat/activity logs (#336, #633)

### DIFF
--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -709,7 +709,7 @@ class DummyApiResponder {
                 'gameChatLog' => array(
                     array("timestamp" => 1387746541,
                           "player" => "tester2",
-                          "message" => "Hello."),
+                          "message" => "Hello!\n    Ceci n'est pas une <script>tag</script>."),
                     array("timestamp" => 1387746536,
                           "player" => "tester1",
                           "message" => "Hi."),

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1155,7 +1155,11 @@ Game.readCurrentGameActivity = function() {
   Game.activity.attackType = $('#attack_type_select').val();
 
   // Store the game chat in recent activity (minus trailing whitespace)
-  Game.activity.chat = $('#game_chat').val().replace(/\s+$/, '');
+  var chat = $('#game_chat').val();
+  if (chat !== undefined && chat !== null) {
+    chat = chat.replace(/\s+$/, '');
+  }
+  Game.activity.chat = chat;
 };
 
 Game.showFullLogHistory = function() {
@@ -1265,6 +1269,9 @@ Game.pageAddLogFooter = function() {
             'nowrap': 'nowrap',
             'text': '(' + Env.formatTimestamp(logentry.timestamp) + ')',
           }));
+        // We add the log message as 'text' to ensure that jquery knows it's
+        // not already encoded as HTML. This way, jquery will encode it for us,
+        // automatically converting things like < to things like &lt;
         actionrow.append(
           $('<td>', {
             'class': 'left logmessage',
@@ -1295,6 +1302,9 @@ Game.pageAddLogFooter = function() {
           'text': logentry.player + ' (' +
             Env.formatTimestamp(logentry.timestamp) + ')',
         }));
+        // We add the log message as 'text' to ensure that jquery knows it's
+        // not already encoded as HTML. This way, jquery will encode it for us,
+        // automatically converting things like < to things like &lt;
         chatrow.append($('<td>', {
           'class': 'left logmessage',
           'text': logentry.message,
@@ -1308,10 +1318,20 @@ Game.pageAddLogFooter = function() {
     // Replace text-y whitespace with HTML whitespace to preserve things
     // like newlines and indentation in chat.
     logrow.find('.logmessage').each(function() {
+      // We originally added the log messages to the page as text; by reading
+      // them back as HTML now, we're getting the version of them that's
+      // already been safely HTML-encoded.
       var messagehtml = $(this).html();
-      messagehtml =
-        messagehtml.replace(/^ /, '&nbsp;').replace(/\n /, '\n&nbsp;')
-        .replace(/  /g, ' &nbsp;').replace(/\n/g, '<br />');
+
+      // HTML-ify initial spaces, to preserve indentation
+      messagehtml = messagehtml.replace(/^ /, '&nbsp;');
+      // Likewise for spaces at the start of each line
+      messagehtml = messagehtml.replace(/\n /, '\n&nbsp;');
+      // Preserve strings of multiple spaces
+      messagehtml = messagehtml.replace(/  /g, '&nbsp;&nbsp;');
+      // HTML-ify line breaks to preserve newlines
+      messagehtml = messagehtml.replace(/\n/g, '<br />');
+
       $(this).html(messagehtml);
     });
 

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -804,6 +804,20 @@ asyncTest("test_Game.pageAddLogFooter_actionlog", function() {
   });
 });
 
+asyncTest("test_Game.pageAddLogFooter_chatlog", function() {
+  BMTestUtils.GameType = 'turn_active';
+  Game.getCurrentGame(function() {
+    Game.page = $('<div>');
+    Game.pageAddLogFooter();
+    var htmlout = Game.page.html();
+    ok(!htmlout.match("<script"), "Chat log does not contain unencoded HTML.");
+    ok(htmlout.match("&lt;script"), "Chat log does contain encoded HTML.");
+    ok(htmlout.match("<br"), "Chat log contain HTML newlines.");
+    ok(htmlout.match("&nbsp;&nbsp;&nbsp;"), "Chat contains HTML spaces.");
+    start();
+  });
+});
+
 asyncTest("test_Game.dieRecipeTable", function() {
   BMTestUtils.GameType = 'newgame';
   Game.getCurrentGame(function() {


### PR DESCRIPTION
Preserved newlines and indentations in chat/activity logs, while trimming trailing whitespace.

Resolves #336.
Resolves #633.

http://jenkins.buttonweavers.com:8080/job/buttonmen-AdmiralJota/14/
