### PR TITLE
pull changes from dev to production on 2014-04-11

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -99,6 +99,10 @@ class ApiResponder {
     }
 
     protected function get_interface_response_loadActiveGames($interface) {
+        // Once we return to the list of active games, we no longer need to remember
+        // which ones we were skipping.
+        unset($_SESSION['skipped_games']);
+
         return $interface->get_all_active_games($_SESSION['user_id']);
     }
 
@@ -106,8 +110,24 @@ class ApiResponder {
         return $interface->get_all_completed_games($_SESSION['user_id']);
     }
 
-    protected function get_interface_response_loadNextPendingGame($interface) {
-        return $interface->get_next_pending_game($_SESSION['user_id']);
+    protected function get_interface_response_loadNextPendingGame($interface, $args) {
+        if (isset($args['currentGameId'])) {
+            if (isset($_SESSION['skipped_games'])) {
+                $_SESSION['skipped_games'] =
+                    $_SESSION['skipped_games'] . ',' . $args['currentGameId'];
+            } else {
+                $_SESSION['skipped_games'] = $args['currentGameId'];
+            }
+        }
+
+        $skippedGames = array();
+        if (isset($_SESSION['skipped_games'])) {
+            foreach (explode(',', $_SESSION['skipped_games']) as $gameId) {
+                $skippedGames[] = (int)$gameId;
+            }
+        }
+
+        return $interface->get_next_pending_game($_SESSION['user_id'], $skippedGames);
     }
 
     protected function get_interface_response_loadButtonNames($interface) {
@@ -116,7 +136,14 @@ class ApiResponder {
 
     protected function get_interface_response_loadGameData($interface, $args) {
         $data = NULL;
-        $game = $interface->load_game($args['game']);
+
+        if (isset($args['logEntryLimit'])) {
+            $logEntryLimit = $args['logEntryLimit'];
+        } else {
+            $logEntryLimit = NULL;
+        }
+
+        $game = $interface->load_game($args['game'], $logEntryLimit);
         if ($game) {
             $currentPlayerId = $_SESSION['user_id'];
             $currentPlayerIdx = array_search($currentPlayerId, $game->playerIdArray);
@@ -125,13 +152,17 @@ class ApiResponder {
                 $playerNameArray[] = $interface->get_player_name_from_id($playerId);
             }
 
+            // load_game will decide if the logEntryLimit should be overridden
+            // (e.g. if chat is private or for completed games)
+            $logEntryLimit = $game->logEntryLimit;
+
             $data = array(
                 'currentPlayerIdx' => $currentPlayerIdx,
                 'gameData' => $game->getJsonData($currentPlayerId),
                 'playerNameArray' => $playerNameArray,
                 'timestamp' => $interface->timestamp,
-                'gameActionLog' => $interface->load_game_action_log($game),
-                'gameChatLog' => $interface->load_game_chat_log($game),
+                'gameActionLog' => $interface->load_game_action_log($game, $logEntryLimit),
+                'gameChatLog' => $interface->load_game_chat_log($game, $logEntryLimit),
             );
         }
         return $data;

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -54,11 +54,15 @@ class ApiSpec {
             'mandatory' => array(
                 'game' => 'number',
             ),
-            'permitted' => array(),
+            'permitted' => array(
+                'logEntryLimit' => 'number',
+            ),
         ),
         'loadNextPendingGame' => array(
             'mandatory' => array(),
-            'permitted' => array(),
+            'permitted' => array(
+              'currentGameId' => 'number',
+            ),
         ),
         'loadPlayerInfo' => array(
             'mandatory' => array(),

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -318,9 +318,14 @@ class DummyApiResponder {
         return array($data, "All game details retrieved successfully.");
     }
 
-    protected function get_interface_response_loadNextPendingGame() {
-        // Assume that game IDs 7 is the next one waiting for tester1
-        $data = array('gameId' => 7);
+    protected function get_interface_response_loadNextPendingGame($args) {
+        // Assume that game IDs 7 is the next one waiting for tester1,
+        // and that 4 is next after that if 7 is being skipped
+        if (isset($args['currentGameId']) && $args['currentGameId'] == 7) {
+            $data = array('gameId' => 4);
+        } else {
+            $data = array('gameId' => 7);
+        }
         return array($data, 'Next game ID retrieved successfully.');
     }
 
@@ -701,7 +706,41 @@ class DummyApiResponder {
                               "Defender (12) was captured; Attacker (4) rerolled 1 => 4; " .
                               "Attacker (10) rerolled 5 => 3; Attacker (12) rerolled 5 => 1")
                 ),
-                'gameChatLog' => array(),
+                'gameChatLog' => array(
+                    array("timestamp" => 1387746541,
+                          "player" => "tester2",
+                          "message" => "Hello."),
+                    array("timestamp" => 1387746536,
+                          "player" => "tester1",
+                          "message" => "Hi."),
+                    array("timestamp" => 1387746232,
+                          "player" => "tester2",
+                          "message" => "Greetings."),
+                    array("timestamp" => 1387746219,
+                          "player" => "tester1",
+                          "message" => "Salutations."),
+                    array("timestamp" => 1387746192,
+                          "player" => "tester2",
+                          "message" => "Good morning."),
+                    array("timestamp" => 1387746092,
+                          "player" => "tester2",
+                          "message" => "Bonjour."),
+                    array("timestamp" => 1387745992,
+                          "player" => "tester1",
+                          "message" => "Yo."),
+                    array("timestamp" => 1387745892,
+                          "player" => "tester2",
+                          "message" => "How are you?"),
+                    array("timestamp" => 1387745792,
+                          "player" => "tester1",
+                          "message" => "Howdy."),
+                    array("timestamp" => 1387745692,
+                          "player" => "tester2",
+                          "message" => "Ping!"),
+                    array("timestamp" => 1387745592,
+                          "player" => "tester2",
+                          "message" => "G'day."),
+                ),
             );
             if ($args['game'] == '3') {
                 $data['currentPlayerIdx'] = 0;
@@ -770,7 +809,14 @@ class DummyApiResponder {
                               "tester2 performed Power attack using [(10):10] against [(4):4]; " .
                               "Defender (4) was captured; Attacker (10) rerolled 10 => 4"),
                 ),
-                'gameChatLog' => array(),
+                'gameChatLog' => array(
+                    array("timestamp" => "2013-12-20 00:52:42",
+                          "player" => "tester1",
+                          "message" => "Pong."),
+                    array("timestamp" => "2013-12-20 00:52:29",
+                          "player" => "tester2",
+                          "message" => "Ping!"),
+                ),
             );
         } elseif ($args['game'] == '6') {
             $gameData['gameId'] = 6;
@@ -988,6 +1034,13 @@ class DummyApiResponder {
         }
 
         if ($data) {
+            if (isset($args['logEntryLimit']) && $args['logEntryLimit'] > 0) {
+                $data['gameActionLog'] =
+                    array_slice($data['gameActionLog'], 0, $args['logEntryLimit']);
+                $data['gameChatLog'] =
+                    array_slice($data['gameChatLog'], 0, $args['logEntryLimit']);
+            }
+
             if (!(array_key_exists('playerNameArray', $data))) {
                 $data['playerNameArray'] = array('tester1', 'tester2');
             }

--- a/src/engine/BMAttack.php
+++ b/src/engine/BMAttack.php
@@ -16,6 +16,8 @@ abstract class BMAttack {
 
     public $type;
 
+    public $validationMessage = '';
+
     // Dice that effect or affect this attack
     protected $validDice = array();
 
@@ -147,6 +149,7 @@ abstract class BMAttack {
     public function has_dizzy_attackers(array $attackers) {
         foreach ($attackers as $attacker) {
             if ($attacker->dizzy) {
+                $this->validationMessage = 'Dizzy dice cannot be used as attacking dice.';
                 return TRUE;
             }
         }

--- a/src/engine/BMAttackBerserk.php
+++ b/src/engine/BMAttackBerserk.php
@@ -14,22 +14,23 @@ class BMAttackBerserk extends BMAttackSpeed {
 
         $att = $attArray[0];
 
-        $returnVal = TRUE;
-
         if (!$att->has_skill('Berserk')) {
-            $returnVal = FALSE;
+            $this->validationMessage = 'Dice without berserk cannot perform berserk attacks.';
+            return FALSE;
         }
 
         if ($att->has_skill('Stealth')) {
-            $returnVal = FALSE;
+            $this->validationMessage = 'Stealth dice cannot perform berserk attacks.';
+            return FALSE;
         }
 
         foreach ($defArray as $def) {
             if ($def->has_skill('Stealth')) {
-                $returnVal = FALSE;
+                $this->validationMessage = 'Stealth dice cannot be attacked by berserk attacks.';
+                return FALSE;
             }
         }
 
-        return $returnVal;
+        return TRUE;
     }
 }

--- a/src/engine/BMAttackPass.php
+++ b/src/engine/BMAttackPass.php
@@ -12,7 +12,15 @@ class BMAttackPass extends BMAttack {
     }
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        return (empty($attackers) && empty($defenders));
+        $this->validationMessage = '';
+
+        $isValid = empty($attackers) && empty($defenders);
+
+        if (!$isValid) {
+            $this->validationMessage = 'Please deselect all dice before passing.';
+        }
+
+        return $isValid;
     }
 
     protected function are_skills_compatible(array $attArray, array $defArray) {

--- a/src/engine/BMAttackPower.php
+++ b/src/engine/BMAttackPower.php
@@ -10,13 +10,25 @@ class BMAttackPower extends BMAttack {
     }
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        if (1 != count($attackers) ||
-            1 != count($defenders) ||
-            $this->has_dizzy_attackers($attackers)) {
+        $this->validationMessage = '';
+
+        if (1 != count($attackers)) {
+            $this->validationMessage = 'There must be exactly one attacking die for a power attack.';
+            return FALSE;
+        }
+
+        if (1 != count($defenders)) {
+            $this->validationMessage = 'There must be exactly one target die for a power attack.';
+            return FALSE;
+        }
+
+        if ($this->has_dizzy_attackers($attackers)) {
+            // validation message set within $this->has_dizzy_attackers()
             return FALSE;
         }
 
         if (!$this->are_skills_compatible($attackers, $defenders)) {
+            // validation message set within $this->are_skills_compatible()
             return FALSE;
         }
 
@@ -32,9 +44,14 @@ class BMAttackPower extends BMAttack {
             $isValidAttacker = $att->is_valid_attacker($this->type, $attackers);
             $isValidTarget = $def->is_valid_target($this->type, $defenders);
 
-            $isValidAttack = $isValLargeEnough && $isValidAttacker && $isValidTarget;
-
-            if ($isValidAttack) {
+            if (!$isValLargeEnough) {
+                $this->validationMessage = 'Attacking die value must be at least as large as target die value.';
+            } elseif (!$isValidAttacker) {
+                $this->validationMessage = 'Invalid attacking die';
+            } elseif (!$isValidTarget) {
+                $this->validationMessage = 'Invalid target die';
+            } else {
+                $this->validationMessage = '';
                 return TRUE;
             }
         }
@@ -54,20 +71,31 @@ class BMAttackPower extends BMAttack {
         $att = $attArray[0];
         $def = $defArray[0];
 
-        $returnVal = TRUE;
+        if ($att->has_skill('Shadow')) {
+            $this->validationMessage = 'Shadow dice cannot perform power attacks.';
+            return FALSE;
+        }
 
-        if ($att->has_skill('Shadow') ||
-            $att->has_skill('Konstant') ||
-            $att->has_skill('Stealth') ||
-            ($att->has_skill('Queer') && (1 == $att->value % 2))
-        ) {
-            $returnVal = FALSE;
+        if ($att->has_skill('Konstant')) {
+            $this->validationMessage = 'Konstant dice cannot perform power attacks.';
+            return FALSE;
+        }
+
+        if ($att->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot perform power attacks.';
+            return FALSE;
+        }
+
+        if ($att->has_skill('Queer') && (1 == $att->value % 2)) {
+            $this->validationMessage = 'Odd queer dice cannot perform power attacks.';
+            return FALSE;
         }
 
         if ($def->has_Skill('Stealth')) {
-            $returnVal = FALSE;
+            $this->validationMessage = 'Stealth dice cannot be attacked by power attacks.';
+            return FALSE;
         }
 
-        return $returnVal;
+        return TRUE;
     }
 }

--- a/src/engine/BMAttackShadow.php
+++ b/src/engine/BMAttackShadow.php
@@ -4,13 +4,25 @@ class BMAttackShadow extends BMAttackPower {
     public $type = 'Shadow';
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        if (1 != count($attackers) ||
-            1 != count($defenders) ||
-            $this->has_dizzy_attackers($attackers)) {
+        $this->validationMessage = '';
+
+        if (1 != count($attackers)) {
+            $this->validationMessage = 'There must be exactly one attacking die for a shadow attack.';
+            return FALSE;
+        }
+
+        if (1 != count($defenders)) {
+            $this->validationMessage = 'There must be exactly one target die for a shadow attack.';
+            return FALSE;
+        }
+
+        if ($this->has_dizzy_attackers($attackers)) {
+            // validation message set within $this->has_dizzy_attackers()
             return FALSE;
         }
 
         if (!$this->are_skills_compatible($attackers, $defenders)) {
+            // validation message set within $this->are_skills_compatible()
             return FALSE;
         }
 
@@ -19,24 +31,36 @@ class BMAttackShadow extends BMAttackPower {
 
         $isDieLargeEnough = $att->max >=
                             $def->defense_value('Shadow');
+        if (!$isDieLargeEnough) {
+            $this->validationMessage = 'Attacking die size must be at least as large as target die value.';
+            return FALSE;
+        }
 
         $attackValueArray = $att->attack_values($this->type);
         assert(1 == count($attackValueArray));
         $attackValue = $attackValueArray[0];
         $defenseValue = $def->defense_value($this->type);
         $isValueSmallEnough = $attackValue <= $defenseValue;
+        if (!$isValueSmallEnough) {
+            $this->validationMessage = 'Attacking die value must be no larger than the target die value.';
+            return FALSE;
+        }
 
         $canAttDoThisAttack =
             $att->is_valid_attacker($this->type, $attackers);
+        if (!$canAttDoThisAttack) {
+            $this->validationMessage = 'Invalid attacking die';
+            return FALSE;
+        }
+
         $isDefValidTarget =
             $def->is_valid_target($this->type, $defenders);
+        if (!$isDefValidTarget) {
+            $this->validationMessage = 'Invalid target die';
+            return FALSE;
+        }
 
-        $isValidAttack = $isDieLargeEnough &&
-                         $isValueSmallEnough &&
-                         $canAttDoThisAttack &&
-                         $isDefValidTarget;
-
-        return $isValidAttack;
+        return TRUE;
     }
 
     protected function are_skills_compatible(array $attArray, array $defArray) {
@@ -54,16 +78,18 @@ class BMAttackShadow extends BMAttackPower {
         $returnVal = TRUE;
 
         if ($att->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot perform shadow attacks.';
             return FALSE;
         }
 
         if ($def->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot be attacked by shadow attacks.';
             return FALSE;
         }
 
         if (!($att->has_skill('Shadow') ||
-            ($att->has_skill('Queer') && (1 == $att->value % 2)))
-        ) {
+              ($att->has_skill('Queer') && (1 == $att->value % 2)))) {
+            $this->validationMessage = 'Only shadow and odd queer dice can perform shadow attacks.';
             return FALSE;
         }
 

--- a/src/engine/BMAttackSkill.php
+++ b/src/engine/BMAttackSkill.php
@@ -64,15 +64,25 @@ class BMAttackSkill extends BMAttack {
     }
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        if (count($attackers) < 1 || count($defenders) != 1) {
+        $this->validationMessage = '';
+
+        if (count($attackers) < 1) {
+            $this->validationMessage = 'There must be at least one attacking die for a skill attack.';
+            return FALSE;
+        }
+
+        if (count($defenders) != 1) {
+            $this->validationMessage = 'There must be exactly one target die for a skill attack.';
             return FALSE;
         }
 
         if ($this->has_dizzy_attackers($attackers)) {
+            // validation message set within $this->has_dizzy_attackers()
             return FALSE;
         }
 
         if (!$this->are_skills_compatible($attackers, $defenders)) {
+            // validation message set within $this->are_skills_compatible()
             return FALSE;
         }
 
@@ -109,6 +119,7 @@ class BMAttackSkill extends BMAttack {
         $helpers = $this->collect_helpers($game, $attackers, $defenders);
         $bounds = $this->help_bounds($helpers);
         if ($bounds[0] == 0 && $bounds[1] == 0) {
+            $this->validationMessage = 'Attacking die values do not sum up to target die value.';
             return FALSE;
         }
         for ($i = $bounds[0]; $i <= $bounds[1]; $i++) {
@@ -123,6 +134,7 @@ class BMAttackSkill extends BMAttack {
                 }
             }
         }
+        $this->validationMessage = 'Attacking die values do not sum up to target die value.';
         return FALSE;
     }
 
@@ -135,34 +147,33 @@ class BMAttackSkill extends BMAttack {
             throw new InvalidArgumentException('defArray must have one element.');
         }
 
-        $returnVal = TRUE;
-
         $def = $defArray[0];
 
-        if (1 == count($attArray) &&
-            $attArray[0]->has_skill('Stealth')) {
-            $returnVal = FALSE;
+        if (1 == count($attArray)) {
+            if ($attArray[0]->has_skill('Stealth')) {
+                $this->validationMessage = 'Skill attacks involving a single attacking stealth die are invalid.';
+                return FALSE;
+            }
+
+            if ($attArray[0]->has_skill('Konstant')) {
+                $this->validationMessage = 'Skill attacks involving a single attacking konstant die are invalid.';
+                return FALSE;
+            }
         }
 
         if (1 == count($attArray) &&
             $def->has_skill('Stealth')) {
-            $returnVal = FALSE;
+            $this->validationMessage = 'Multiple attacking dice are required to skill attack a stealth die.';
+            return FALSE;
         }
 
         foreach ($attArray as $att) {
-            if ($att->has_skill('Berserk') ||
-                // do not allow single-die skill attacks from konstant dice
-                ($att->has_skill('Konstant') && (1 == count($attArray)))
-            ) {
-                $returnVal = FALSE;
+            if ($att->has_skill('Berserk')) {
+                $this->validationMessage = 'Berserk dice cannot perform skill attacks.';
+                return FALSE;
             }
         }
 
-        if ($def->has_skill('Stealth') &&
-            1 == count($attArray)) {
-            $returnVal = FALSE;
-        }
-
-        return $returnVal;
+        return TRUE;
     }
 }

--- a/src/engine/BMAttackSpeed.php
+++ b/src/engine/BMAttackSpeed.php
@@ -4,15 +4,25 @@ class BMAttackSpeed extends BMAttack {
     public $type = 'Speed';
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        if (1 != count($attackers) || count($defenders) < 1) {
+        $this->validationMessage = '';
+
+        if (1 != count($attackers)) {
+            $this->validationMessage = 'There must be exactly one attacking die for a speed attack.';
+            return FALSE;
+        }
+
+        if (count($defenders) < 1) {
+            $this->validationMessage = 'There must be at least one target die for a speed attack.';
             return FALSE;
         }
 
         if ($this->has_dizzy_attackers($attackers)) {
+            // validation message set within $this->has_dizzy_attackers()
             return FALSE;
         }
 
         if (!$this->are_skills_compatible($attackers, $defenders)) {
+            // validation message set within $this->are_skills_compatible()
             return FALSE;
         }
 
@@ -23,9 +33,18 @@ class BMAttackSpeed extends BMAttack {
             $defenderSum += $defender->value;
         }
         $areValuesEqual = $attacker->value == $defenderSum;
+        if (!$areValuesEqual) {
+            $this->validationMessage = 'Target die values do not sum up to attacking die value.';
+            return FALSE;
+        }
 
         $canAttDoThisAttack =
             $attacker->is_valid_attacker($this->type, $attackers);
+        if (!$canAttDoThisAttack) {
+            $this->validationMessage = 'Invalid attacking die';
+            return FALSE;
+        }
+
         $areDefValidTargets = TRUE;
         foreach ($defenders as $defender) {
             if (!($defender->is_valid_target($this->type, $defenders))) {
@@ -33,10 +52,12 @@ class BMAttackSpeed extends BMAttack {
                 break;
             }
         }
+        if (!$areDefValidTargets) {
+            $this->validationMessage = 'Invalid target die';
+            return FALSE;
+        }
 
-        return ($areValuesEqual &&
-                $canAttDoThisAttack &&
-                $areDefValidTargets);
+        return TRUE;
     }
 
     public function find_attack($game) {
@@ -61,15 +82,18 @@ class BMAttackSpeed extends BMAttack {
         $att = $attArray[0];
 
         if ($att->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot perform speed attacks.';
             $returnVal =  FALSE;
         }
 
         if (!$att->has_skill('Speed')) {
+            $this->validationMessage = 'Dice without speed cannot perform speed attacks.';
             $returnVal = FALSE;
         }
 
         foreach ($defArray as $def) {
             if ($def->has_skill('Stealth')) {
+                $this->validationMessage = 'Stealth dice cannot be attacked by speed attacks.';
                 $returnVal = FALSE;
             }
         }

--- a/src/engine/BMAttackSurrender.php
+++ b/src/engine/BMAttackSurrender.php
@@ -1,21 +1,15 @@
 <?php
 
-class BMAttackSurrender extends BMAttack {
+class BMAttackSurrender extends BMAttackPass {
     public $type = "Surrender";
 
-    public function find_attack($game) {
-        return $this->validate_attack(
-            $game,
-            $this->validDice,
-            $game->defenderAttackDieArray
-        );
-    }
-
     public function validate_attack($game, array $attackers, array $defenders) {
-        return (empty($attackers) && empty($defenders));
-    }
+        $isValid = parent::validate_attack($game, $attackers, $defenders);
 
-    protected function are_skills_compatible(array $attArray, array $defArray) {
-        return TRUE;
+        if (!$isValid) {
+            $this->validationMessage = 'Please deselect all dice before surrendering.';
+        }
+
+        return $isValid;
     }
 }

--- a/src/engine/BMAttackTrip.php
+++ b/src/engine/BMAttackTrip.php
@@ -10,15 +10,25 @@ class BMAttackTrip extends BMAttack {
     }
 
     public function validate_attack($game, array $attackers, array $defenders) {
-        if (count($attackers) != 1 || count($defenders) != 1) {
+        $this->validationMessage = '';
+
+        if (count($attackers) != 1) {
+            $this->validationMessage = 'There must be exactly one attacking die for a trip attack.';
+            return FALSE;
+        }
+
+        if (count($defenders) != 1) {
+            $this->validationMessage = 'There must be exactly one target die for a trip attack.';
             return FALSE;
         }
 
         if ($this->has_dizzy_attackers($attackers)) {
+            // validation message set within $this->has_dizzy_attackers()
             return FALSE;
         }
 
         if (!$this->are_skills_compatible($attackers, $defenders)) {
+            // validation message set within $this->are_skills_compatible()
             return FALSE;
         }
 
@@ -45,14 +55,17 @@ class BMAttackTrip extends BMAttack {
         $def = $defArray[0];
 
         if ($att->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot perform trip attacks.';
             $returnVal = FALSE;
         }
 
         if (!$att->has_skill('Trip')) {
+            $this->validationMessage = 'Dice without trip cannot perform trip attacks.';
             $returnVal = FALSE;
         }
 
         if ($def->has_skill('Stealth')) {
+            $this->validationMessage = 'Stealth dice cannot be the target of trip attacks.';
             $returnVal = FALSE;
         }
 

--- a/src/ui/js/Api.js
+++ b/src/ui/js/Api.js
@@ -301,10 +301,10 @@ var Api = (function () {
     return true;
   };
 
-  my.getGameData = function(game, callback) {
+  my.getGameData = function(game, logEntryLimit, callback) {
     activity.gameId = game;
     Api.apiParsePost(
-      { type: 'loadGameData', game: game, },
+      { type: 'loadGameData', game: game, logEntryLimit: logEntryLimit },
       'game',
       my.parseGameData,
       callback,
@@ -457,8 +457,19 @@ var Api = (function () {
   // Load and parse the ID of the player's next pending game
 
   my.getNextGameId = function(callbackfunc) {
+    var currentGameId;
+    if (Api.game !== undefined &&
+        Api.game.isParticipant && Api.game.player.waitingOnAction) {
+      // If you're viewing a game where it's your turn, pass the ID along as
+      // being skipped
+      currentGameId = Api.game.gameId;
+    }
+
     my.apiParsePost(
-      { 'type': 'loadNextPendingGame' },
+      {
+        'type': 'loadNextPendingGame',
+        'currentGameId': currentGameId,
+      },
       'gameNavigation',
       my.parseNextGameId,
       callbackfunc,

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -124,7 +124,11 @@ Overview.pageAddGameTable = function(gameType, sectionHeader) {
   headerRow.append($('<th>', {'text': 'Your Button', }));
   headerRow.append($('<th>', {'text': 'Opponent\'s Button', }));
   headerRow.append($('<th>', {'text': 'Score (W/L/T (Max))', }));
-  headerRow.append($('<th>', {'text': 'Inactivity', }));
+  if (gameType == 'finished') {
+    headerRow.append($('<th>', {'text': 'Completed', }));
+  } else {
+    headerRow.append($('<th>', {'text': 'Inactivity', }));
+  }
   table.append(headerRow);
   var i = 0;
   while (i < gamesource.length) {

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -344,6 +344,19 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $_SESSION = $this->mock_test_user_login();
         $this->verify_invalid_arg_rejected('loadNextPendingGame');
 
+        // loadGameData should fail if currentGameId is non-numeric
+        $retval = $this->object->process_request(
+            array('type' => 'loadNextPendingGame', 'currentGameId' => 'foobar'));
+        $this->assertEquals(
+            array(
+                'data' => NULL,
+                'message' => 'Argument (currentGameId) to function loadNextPendingGame is invalid',
+                'status' => 'failed',
+            ),
+            $retval,
+            "loadNextPendingGame should reject a non-numeric current game ID"
+        );
+
         $args = array('type' => 'loadNextPendingGame');
         $retval = $this->object->process_request($args);
         $dummyval = $this->dummy->process_request($args);
@@ -357,7 +370,22 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $dummydata = $dummyval['data'];
         $this->assertTrue(
             $this->object_structures_match($retdata, $dummydata, TRUE),
-            "Real and dummy button lists should have matching structures");
+            "Real and dummy pending game data should have matching structures");
+
+        $args['currentGameId'] = 7;
+        $retval = $this->object->process_request($args);
+        $dummyval = $this->dummy->process_request($args);
+
+        $this->assertEquals('ok', $retval['status'],
+            'Loading next pending game ID while skipping current game should succeed');
+        $this->assertEquals('ok', $dummyval['status'],
+            'Dummy load of next pending game ID while skipping current game should succeed');
+
+        $retdata = $retval['data'];
+        $dummydata = $dummyval['data'];
+        $this->assertTrue(
+            $this->object_structures_match($retdata, $dummydata, TRUE),
+            "Real and dummy pending game data should have matching structures");
     }
 
     public function test_request_loadButtonNames() {
@@ -405,8 +433,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $_SESSION = $this->mock_test_user_login();
         $this->verify_invalid_arg_rejected('loadGameData');
 
-        // loadGameData should fail if game is non-numeric
-        $retval = $this->object->process_request(array('type' => 'loadGameData', 'game' => 'foobar'));
+        // loadGameData should fail if game or logEntryLimit is non-numeric
+        $retval = $this->object->process_request(
+            array('type' => 'loadGameData', 'game' => 'foobar'));
         $this->assertEquals(
             array(
                 'data' => NULL,
@@ -415,6 +444,17 @@ class responderTest extends PHPUnit_Framework_TestCase {
             ),
             $retval,
             "loadGameData should reject a non-numeric game ID"
+        );
+        $retval = $this->object->process_request(
+            array('type' => 'loadGameData', 'game' => '3', 'logEntryLimit' => 'foobar'));
+        $this->assertEquals(
+            array(
+                'data' => NULL,
+                'message' => 'Argument (logEntryLimit) to function loadGameData is invalid',
+                'status' => 'failed',
+            ),
+            $retval,
+            "loadGameData should reject a non-numeric log entry limit"
         );
 
         // create a game so we have the ID to load
@@ -429,8 +469,10 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $dummy_game_id = '1';
 
         // now load real and dummy games
-        $retval = $this->object->process_request(array('type' => 'loadGameData', 'game' => $real_game_id));
-        $dummyval = $this->dummy->process_request(array('type' => 'loadGameData', 'game' => $dummy_game_id));
+        $retval = $this->object->process_request(
+            array('type' => 'loadGameData', 'game' => $real_game_id, 'logEntryLimit' => 10));
+        $dummyval = $this->dummy->process_request(
+            array('type' => 'loadGameData', 'game' => $dummy_game_id, 'logEntryLimit' => 10));
         $this->assertEquals('ok', $retval['status'], "responder should succeed");
         $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
 
@@ -534,7 +576,8 @@ class responderTest extends PHPUnit_Framework_TestCase {
         // now ask for the game data so we have the timestamp to return
         $args = array(
             'type' => 'loadGameData',
-            'game' => "$real_game_id");
+            'game' => "$real_game_id",
+            'logEntryLimit' => '10');
         $retval = $this->object->process_request($args);
         $timestamp = $retval['data']['timestamp'];
 
@@ -608,7 +651,8 @@ class responderTest extends PHPUnit_Framework_TestCase {
             // now ask for the game data so we have the timestamp to return
             $dataargs = array(
                 'type' => 'loadGameData',
-                'game' => "$real_game_id");
+                'game' => "$real_game_id",
+                'logEntryLimit' => '10');
             $retval = $this->object->process_request($dataargs);
             $timestamp = $retval['data']['timestamp'];
 

--- a/test/src/ui/js/test_Api.js
+++ b/test/src/ui/js/test_Api.js
@@ -177,7 +177,7 @@ asyncTest("test_Api.parseUserPrefsData", function() {
 
 asyncTest("test_Api.getGameData", function() {
   Game.game = '1';
-  Api.getGameData(Game.game, function() {
+  Api.getGameData(Game.game, 10, function() {
     equal(Api.game.gameId, '1', "parseGameData() set gameId");
     equal(Api.game.opponentIdx, 1, "parseGameData() set opponentIdx");
     delete Game.game;
@@ -187,9 +187,29 @@ asyncTest("test_Api.getGameData", function() {
 
 asyncTest("test_Api.getGameData_nonplayer", function() {
   Game.game = '10';
-  Api.getGameData(Game.game, function() {
+  Api.getGameData(Game.game, 10, function() {
     equal(Api.game.gameId, '10',
           "parseGameData() set gameId for nonparticipant");
+    delete Game.game;
+    start();
+  });
+});
+
+asyncTest("test_Api.getGameData_somelogs", function() {
+  Game.game = '3';
+  Api.getGameData(Game.game, 3, function() {
+    equal(Api.game.actionLog.length, 3, "getGameData() passed limited action log length");
+    equal(Api.game.chatLog.length, 3, "getGameData() passed limited chat log length");
+    delete Game.game;
+    start();
+  });
+});
+
+asyncTest("test_Api.getGameData_alllogs", function() {
+  Game.game = '3';
+  Api.getGameData(Game.game, 0, function() {
+    ok(Api.game.actionLog.length > 3, "getGameData() passed unlimited action log length");
+    ok(Api.game.chatLog.length > 3, "getGameData() passed unlimited chat log length");
     delete Game.game;
     start();
   });
@@ -199,7 +219,7 @@ asyncTest("test_Api.getGameData_nonplayer", function() {
 // test any details of parsePlayerData()'s processing here
 asyncTest("test_Api.parseGamePlayerData", function() {
   Game.game = '1';
-  Api.getGameData(Game.game, function() {
+  Api.getGameData(Game.game, 10, function() {
     deepEqual(Api.game.player.dieRecipeArray, ["(4)","(4)","(10)","(12)","(X)"],
               "player die recipe array should be parsed correctly");
     deepEqual(Api.game.player.capturedValueArray, [],
@@ -216,7 +236,7 @@ asyncTest("test_Api.parseGamePlayerData", function() {
 });
 
 asyncTest("test_Api.playerWLTText", function() {
-  Api.getGameData('5', function() {
+  Api.getGameData('5', 10, function() {
     var text = Api.playerWLTText('opponent');
     ok(text.match('2/3/0'),
        "opponent WLT text should contain opponent's view of WLT state");
@@ -248,6 +268,19 @@ asyncTest("test_Api.getNextGameId", function() {
 asyncTest("test_Api.parseNextGameId", function() {
   Api.getNextGameId(function() {
     equal(Api.gameNavigation.nextGameId, 7, "Successfully parsed next game ID");
+    start();
+  });
+});
+
+asyncTest("test_Api.parseNextGameId_skipping", function() {
+  Api.game =
+    {
+      'gameId': 7,
+      'isParticipant': true,
+      'player': { 'waitingOnAction': true },
+    };
+  Api.getNextGameId(function() {
+    equal(Api.gameNavigation.nextGameId, 4, "Successfully parsed next game ID");
     start();
   });
 });

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -545,7 +545,9 @@ asyncTest("test_Game.actionShowFinishedGame", function() {
   Game.getCurrentGame(function() {
     Game.actionShowFinishedGame();
     equal(Game.form, null, "Game.form is NULL");
+    equal(Game.logEntryLimit, undefined, "Log history is assumed to be full");
     start();
+    Game.logEntryLimit = 10;
   });
 });
 
@@ -674,6 +676,34 @@ asyncTest("test_Game.formPlayTurnActive", function() {
   });
 });
 
+asyncTest("test_Game.readCurrentGameActivity", function() {
+  BMTestUtils.GameType = 'turn_active';
+  Game.getCurrentGame(function() {
+    Game.actionPlayTurnActive();
+    $('#playerIdx_1_dieIdx_0').click();
+    $('#game_chat').val('hello world');
+    Game.readCurrentGameActivity();
+    ok(Game.activity.dieSelectStatus['playerIdx_1_dieIdx_0'],
+      "Player 1's die 0 is selected");
+    ok(!Game.activity.dieSelectStatus['playerIdx_0_dieIdx_0'],
+      "Player 0's die 0 is not selected");
+    equal(Game.activity.chat, 'hello world', "chat is correctly set");
+    start();
+  });
+});
+
+asyncTest("test_Game.showFullLogHistory", function() {
+  BMTestUtils.GameType = 'turn_active';
+  Game.getCurrentGame(function() {
+    $.ajaxSetup({ async: false });
+    Game.showFullLogHistory();
+    ok(Api.game.chatLog.length > 10, "Full chat log was returned");
+    $.ajaxSetup({ async: true });
+    start();
+    Game.logEntryLimit = 10;
+  });
+});
+
 asyncTest("test_Game.pageAddGameHeader", function() {
   BMTestUtils.GameType = 'newgame';
   Game.getCurrentGame(function() {
@@ -697,6 +727,43 @@ asyncTest("test_Game.pageAddFooter", function() {
     Game.page = $('<div>');
     Game.pageAddFooter();
     ok(true, "No special testing of pageAddFooter() as a whole is done");
+    start();
+  });
+});
+
+asyncTest("test_Game.pageAddGameNavigationFooter", function() {
+  BMTestUtils.GameType = 'turn_inactive';
+  Game.getCurrentGame(function() {
+    Game.page = $('<div>');
+    Game.pageAddGameNavigationFooter();
+    var htmlout = Game.page.html();
+    ok(htmlout.match('<br>'), "Game navigation footer should insert line break");
+    ok(htmlout.match('Go to your next pending game'),
+       "Next game link exists");
+    start();
+  });
+});
+
+asyncTest("test_Game.pageAddGameNavigationFooter_turn_active", function() {
+  BMTestUtils.GameType = 'turn_active';
+  Game.getCurrentGame(function() {
+    Game.page = $('<div>');
+    Game.pageAddGameNavigationFooter();
+    var htmlout = Game.page.html();
+    ok(!htmlout.match('Go to your next pending game'),
+       "Next game link is correctly suppressed");
+    start();
+  });
+});
+
+asyncTest("test_Game.pageAddGameNavigationFooter_turn_nonplayer", function() {
+  BMTestUtils.GameType = 'turn_nonplayer';
+  Game.getCurrentGame(function() {
+    Game.page = $('<div>');
+    Game.pageAddGameNavigationFooter();
+    var htmlout = Game.page.html();
+    ok(!htmlout.match('Go to your next pending game'),
+       "Next game link is correctly suppressed");
     start();
   });
 });


### PR DESCRIPTION
This update brings these pulls, already on dev, to production:
- #762: add a second "Next game" link on the game display page
- #755: allow players to view full action and chat logs during a game, and make "full logs" the default view for a completed game
- #771: rename the Inactivity column for completed games
- #775: add player-visible explanations for a subset of invalid attacks

There are no database updates associated with this update.
