### PR TITLE
Removed unnecessary double-encoding of swing values in die table

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -78,7 +78,6 @@ CREATE TABLE die (
     game_id            MEDIUMINT UNSIGNED NOT NULL,
     status_id          TINYINT UNSIGNED NOT NULL,
     recipe             VARCHAR(20) NOT NULL,
-    swing_value        TINYINT UNSIGNED,
     position           TINYINT UNSIGNED NOT NULL,
     value              SMALLINT
 );

--- a/deploy/database/updates/swing_double_encoding_001.sql
+++ b/deploy/database/updates/swing_double_encoding_001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE die DROP COLUMN swing_value;

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -363,13 +363,7 @@ class BMInterface {
 
                 if (isset($die->swingType)) {
                     $game->request_swing_values($die, $die->swingType, $originalPlayerIdx);
-
-                    if (isset($row['swing_value'])) {
-                        $swingSetSuccess = $die->set_swingValue($game->swingValueArrayArray[$originalPlayerIdx]);
-                        if (!$swingSetSuccess) {
-                            throw new LogicException('Swing value set failed.');
-                        }
-                    }
+                    $die->set_swingValue($game->swingValueArrayArray[$originalPlayerIdx]);
                 }
 
                 switch ($row['status']) {
@@ -636,7 +630,6 @@ class BMInterface {
                  '     game_id, '.
                  '     status_id, '.
                  '     recipe, '.
-                 '     swing_value, '.
                  '     position, '.
                  '     value) '.
                  'VALUES '.
@@ -645,7 +638,6 @@ class BMInterface {
                  '     :game_id, '.
                  '     (SELECT id FROM die_status WHERE name = :status), '.
                  '     :recipe, '.
-                 '     :swing_value, '.
                  '     :position, '.
                  '     :value);';
         $statement = self::$conn->prepare($query);
@@ -654,7 +646,6 @@ class BMInterface {
                                   ':game_id' => $game->gameId,
                                   ':status' => $status,
                                   ':recipe' => $activeDie->recipe,
-                                  ':swing_value' => $activeDie->swingValue,
                                   ':position' => $dieIdx,
                                   ':value' => $activeDie->value));
     }


### PR DESCRIPTION
Currently, we save the swing values of dice into both the die table and the game_swing_map table.

This pull request removes the swing_value column from die, and all the code that refers to it. All functionality with respect to swing values should remain unchanged.

This is preparing the code for the caching of the previous round's swing values in a new database table. 

DO NOT APPLY included database update swing_double_encoding_001.sql. This is now dealt with correctly by 93_option.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/161/
