### PR TITLE
pull changes from master to dev on 2014-06-20

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -623,11 +623,25 @@ class BMGame {
         $this->playerWithInitiativeIdx = $tempInitiativeIdx;
         $actionLogInfo['initiativeWinnerId'] = $this->playerIdArray[$this->playerWithInitiativeIdx];
 
-        $this->log_action(
-            'determine_initiative',
-            0,
-            $actionLogInfo
-        );
+        // if this is an initiative redetermination following a focus turndown or chance reroll,
+        // we don't need to make another log entry.  Inspect any previous log entries made during
+        // this player action to find out whether that is the case.
+        $initReactSeen = FALSE;
+        if (count($this->actionLog) > 0) {
+            foreach ($this->actionLog as $prevEntry) {
+                if ($prevEntry->actionType == 'turndown_focus' ||
+                    $prevEntry->actionType == 'reroll_chance') {
+                    $initReactSeen = TRUE;
+                }
+            }
+        }
+        if (!$initReactSeen) {
+            $this->log_action(
+                'determine_initiative',
+                0,
+                $actionLogInfo
+            );
+        }
     }
 
     protected function update_game_state_determine_initiative() {


### PR DESCRIPTION
This update brings these approved pulls to the dev branch:
- User visible:
  - #1021: fix bug which showed players redundant initial die roll information after focus and chance actions

No database updates.

Once this pull is merged, i will load the changes on dev.buttonweavers.com as part of #217.

Note: this pulls in the last of the code we're planning to load on the prod site on Sunday, so please test the dev site and tell us if anything is broken!
