### PR TITLE
fix typo introduced into create_game

### DIFF
--- a/tools/api-client/python/create_game
+++ b/tools/api-client/python/create_game
@@ -114,6 +114,7 @@ def create_random_game(opponent, b, players=False, usebuttons=False):
     confirm = raw_input()
     if confirm.lower() in ['y', 'yes']:
       print b.wrap_create_game(pbutton, obutton, opponent)
+      return True
 
 def play_all_opponents(opts, b):
   players = lookup_other_players(b)


### PR DESCRIPTION
- Fixes #1047
- Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/298/

Since this is just another change to the example scripts, i don't think it needs to be tested before accepting unless y'all want to.  It affects the behavior of `create_game -p`, a utility method for creating games against each player you're not currently playing.
