### PR TITLE
Passed History state differently in Forum

### DIFF
--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -22,8 +22,8 @@ Forum.SCROLL_ANIMATION_MILLISECONDS = 200;
 //   the current board, thread and/or post, which it sets in Env.history.state.
 //   It also binds Forum.showPage() to the page event that triggers on the
 //   forward/backward button. Then it calls Forum.showPage() directly.
-// * Forum.showPage() reads Env.history.state to find out what it should be
-//   displaying. Then it calls the API to set either Api.forum_overview,
+// * Forum.showPage() reads the state it was passed to find out what it should
+//   be displaying. Then it calls the API to set either Api.forum_overview,
 //   Api.forum_board or Api.forum_thread as appropriate, then passes control
 //   to Forum.showOverview(), Forum.showBoard() or Forum.showThread().
 // * Forum.showOverview() builds a version of Forum.page that includes a list
@@ -71,10 +71,10 @@ Forum.showForumPage = function() {
   };
   Env.history.replaceState(state, 'Button Men Online &mdash; Forum',
     Env.window.location.hash);
-  Forum.showPage();
+  Forum.showPage(state);
 };
 
-Forum.showPage = function() {
+Forum.showPage = function(state) {
   if (!Login.logged_in) {
     Env.message = {
       'type': 'error',
@@ -84,8 +84,15 @@ Forum.showPage = function() {
     return;
   }
 
+  // If this was called from a popState event, the parameter might be an event
+  // object containing a state rather than the state itself
+  if (state.state !== undefined) {
+    state = state.state;
+  }
+  if (state.originalEvent !== undefined) {
+    state = state.originalEvent.state;
+  }
   // Display the appropriate version of the page depending on the current state
-  var state = Env.history.state;
   if (state.threadId) {
     Api.loadForumThread(state.threadId, state.postId, Forum.showThread);
   } else if (state.boardId) {
@@ -373,7 +380,7 @@ Forum.formLinkToSubPage = function(e) {
   Env.history.pushState(state, 'Button Men Online &mdash; Forum',
     Forum.buildUrlHash(state));
   Env.message = null;
-  Forum.showPage();
+  Forum.showPage(state);
 };
 
 Forum.toggleNewThreadForm = function() {

--- a/test/src/ui/js/test_Forum.js
+++ b/test/src/ui/js/test_Forum.js
@@ -56,10 +56,10 @@ test("test_Forum.showForumPage", function() {
   expect(3); // tests plus teardown test
   $('div#forum_page').remove();
   Env.window.location.hash = '#!threadId=6';
-  Forum.showPage = function() {
+  Forum.showPage = function(state) {
     equal($('div#forum_page').length, 1,
       '#forum_page should exist after showForumPage() is called');
-    equal(Env.history.state.threadId, 6,
+    equal(state.threadId, 6,
       'History state should be set to match location hash');
   };
   Forum.showForumPage();
@@ -68,7 +68,6 @@ test("test_Forum.showForumPage", function() {
 asyncTest("test_Forum.showPage", function() {
   expect(2); // tests plus teardown test
 
-  Env.history.state = { };
   Forum.arrangePage = Forum.showBoard = Forum.showThread =
     function() {
       ok(false, 'Forum.showPage() should call Forum.showOverview()');
@@ -78,13 +77,12 @@ asyncTest("test_Forum.showPage", function() {
     ok(true, 'Forum.showPage() should call the Forum.showOverview()');
     start();
   };
-  Forum.showPage();
+  Forum.showPage({ });
 });
 
 asyncTest("test_Forum.showPage_board", function() {
   expect(2); // tests plus teardown test
 
-  Env.history.state = { 'boardId': 3 };
   Forum.arrangePage = Forum.showOverview = Forum.showThread =
     function() {
       ok(false, 'Forum.showPage() should call Forum.showBoard()');
@@ -94,13 +92,12 @@ asyncTest("test_Forum.showPage_board", function() {
     ok(true, 'Forum.showPage() should call the Forum.showBoard()');
     start();
   };
-  Forum.showPage();
+  Forum.showPage({ 'boardId': 3 });
 });
 
 asyncTest("test_Forum.showPage_thread", function() {
   expect(2); // tests plus teardown test
 
-  Env.history.state = { 'threadId': 6 };
   Forum.arrangePage = Forum.showOverview = Forum.showBoard =
     function() {
       ok(false, 'Forum.showPage() should call Forum.showThread()');
@@ -110,7 +107,7 @@ asyncTest("test_Forum.showPage_thread", function() {
     ok(true, 'Forum.showPage() should call the Forum.showThread()');
     start();
   };
-  Forum.showPage();
+  Forum.showPage({ 'threadId': 6 });
 });
 
 asyncTest("test_Forum.showOverview", function() {


### PR DESCRIPTION
Hopefully resolves #1034.

http://jenkins.buttonweavers.com:8080/job/buttonmen-AdmiralJota/237/

I can't test this myself, since I don't have an affected device. Could someone who does have a pre-4.2 Android device try this out and see if it does fix the problem? (Both that you can view the forum, and that after you've clicked through to a board/thread a couple times, that the back button works as expected.)
