### PR TITLE
Changed order of unit tests run by Jenkins

### DIFF
--- a/deploy/jenkins/build.xml
+++ b/deploy/jenkins/build.xml
@@ -187,5 +187,5 @@
   <antcall target="jstest-jenkins-report"/>
  </target>
 
- <target name="build" depends="clean,newline-audit,php-audit,js-audit,pdepend,phpmd,phpcpd,phpcs,phpdoc,phploc,phpcb,phpunit,jstest"/>
+ <target name="build" depends="clean,newline-audit,php-audit,js-audit,jstest,pdepend,phpmd,phpcpd,phpcs,phpdoc,phploc,phpcb,phpunit"/>
 </project>


### PR DESCRIPTION
This brings the Javascript tests to near the beginning of the Jenkins run, meaning that we can pick up QUnit failures after only a minute.

Unfortunately, I couldn't get a clean Jenkins run with this.
