### PR TITLE
Set start time for inactive games predating them

### DIFF
--- a/deploy/database/updates/1088_game_creation_time_03.sql
+++ b/deploy/database/updates/1088_game_creation_time_03.sql
@@ -1,0 +1,5 @@
+-- For games that never had any turns taken, their last action time should be
+-- a reasonable approximation of the game start time.
+UPDATE game AS g
+SET g.start_time = g.last_action_time
+WHERE g.start_time = 0


### PR DESCRIPTION
Resolves #1088.

http://jenkins.buttonweavers.com:8080/job/buttonmen-AdmiralJota/388/

It looks like all the games without a start_time do at least have a last_action_time, and since no one has ever played any turns in any of them, that should be an adequate approximation.
