### PR TITLE
If action log entry is empty, display $interface->message instead in the game message

### DIFF
--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -1101,7 +1101,7 @@ class DummyApiResponder {
     }
 
     protected function get_interface_response_reactToAuxiliary() {
-        return array(TRUE, 'Auxiliary die chosen successfully');
+        return array(TRUE, 'Chose to add auxiliary die');
     }
 
     protected function get_interface_response_reactToReserve() {

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -2789,14 +2789,22 @@ class BMInterface {
 
     // Create a status message based on recent game actions
     protected function load_message_from_game_actions(BMGame $game) {
-        $this->message = '';
+        $message = '';
         $playerIdNames = $this->get_player_name_mapping($game);
         foreach ($game->actionLog as $gameAction) {
-            $this->message .= $gameAction->friendly_message(
+            $messagePart = $gameAction->friendly_message(
                 $playerIdNames,
                 $game->roundNumber,
                 $game->gameState
-            ) . '. ';
+            );
+
+            if (!empty($messagePart)) {
+                $message .= $messagePart . '. ';
+            }
+        }
+
+        if (!empty($message)) {
+            $this->message = $message;
         }
     }
 
@@ -3579,7 +3587,7 @@ class BMInterface {
                             'die' => $die->get_action_log_data(),
                         )
                     );
-                    $this->message = 'Auxiliary die chosen successfully';
+                    $this->message = 'Chose to add auxiliary die';
                     break;
                 case 'decline':
                     $game->waitingOnActionArray = array_fill(0, $game->nPlayers, FALSE);

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -791,7 +791,7 @@ test("test_Game.formChooseAuxiliaryDiceActive", function(assert) {
     assert.deepEqual(
       Env.message,
       {"type": "success",
-       "text": "Auxiliary die chosen successfully"},
+       "text": "Chose to add auxiliary die"},
       "Game action succeeded when expected arguments were set");
     $.ajaxSetup({ async: true });
     start();


### PR DESCRIPTION
Fixes #1213.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/396/
