### PR TITLE
current version of phpunit.phar likes to be executed explicitly rather than included

### DIFF
--- a/deploy/vagrant/modules/buttonmen/templates/phpunit.php.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/phpunit.php.erb
@@ -25,5 +25,3 @@ function bm_rand($min, $max) {
 
 // Unit tests use the same bootstrap file as the code itself
 require_once( "/buttonmen/src/lib/bootstrap.php" );
-
-include "phpunit.phar";

--- a/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
@@ -30,7 +30,7 @@ echo "------------------------------------------------------------------------"
 # Run PHP unit tests
 echo "Running PHP unit tests"
 cd /buttonmen/src
-php /usr/local/etc/buttonmen_phpunit.php /buttonmen/test
+php /etc/php5/deploy-includes/phpunit.phar --bootstrap /usr/local/etc/buttonmen_phpunit.php /buttonmen/test
 if [ "$?" = "0" ]; then
   echo "Passed"
 else


### PR DESCRIPTION
When i first setup vagrant/virtualbox, the version of phpunit that got downloaded as a phar from phpunit.de needed to be included from another script and executed that way.

Now, the version of phpunit.phar that i get on a new virtualbox instance wants to be executed directly, and take the bootstrap file as an argument.  This execution format is more similar to the way jenkins executes phpunit, so that's nice, but the new behavior isn't backwards compatible, so right now, if you get a new virtualbox and run `run_buttonmen_tests`, the phpunit tests simply don't happen.  (I've been working around this by copying in an older version of phpunit whenever i launch a new instance, but that's clearly dumb.)

Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/374/ (if it passes, but ideally it will since this change doesn't actually affect jenkins's executing of phpunit).
