### PR TITLE
pull changes from master to dev on 2014-12-01

### DIFF
--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -431,7 +431,7 @@ class BMDie extends BMCanHaveSkill {
 // some undesireable behavior there, but I cannot think
 // what. Radioactive removes T&S.)
     public function split() {
-        $oldRecipe = $this->get_recipe();
+        $oldRecipe = $this->get_recipe(TRUE);
         unset($this->value);
         $newdie = clone $this;
 

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -7797,7 +7797,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         // [f(3):3, Hog(4):3, (1):1, n(2):1, Bp(U=8):5] => [Hog%(6):5, Hog%(6):6, Hog%(6):5]
         $this->verify_api_submitTurn(
             array(1, 2, 4),
-            'responder003 performed Berserk attack using [Bp(U=8):5] against [Hog%(6):5]; Defender Hog%(6) was captured; Attacker Bp(U=8) showing 5 changed to p(U), which then split into: p(U=2) showing 1, and p(U=2) showing 2. responder003\'s idle ornery dice rerolled at end of turn: Hog(4) changed size from 4 to 6 sides, recipe changed from Hog(4) to Hog(6), rerolled 3 => 4. ',
+            'responder003 performed Berserk attack using [Bp(U=8):5] against [Hog%(6):5]; Defender Hog%(6) was captured; Attacker Bp(U=8) showing 5 changed to p(U=4), which then split into: p(U=2) showing 1, and p(U=2) showing 2. responder003\'s idle ornery dice rerolled at end of turn: Hog(4) changed size from 4 to 6 sides, recipe changed from Hog(4) to Hog(6), rerolled 3 => 4. ',
             $retval, array(array(0, 4), array(1, 2)),
             $gameId, 1, 'Berserk', 0, 1, '');
 
@@ -7813,7 +7813,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             array(array(0, array('value' => 5, 'sides' => 6, 'recipe' => 'Hog%(6)')))
         );
         $expData['playerDataArray'][0]['activeDieArray'][]= array('value' => 2, 'sides' => 2, 'recipe' => 'p(U)', 'description' => 'Poison U Swing Die (with 2 sides)', 'properties' => array('HasJustSplit'), 'skills' => array('Poison'));
-        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Berserk attack using [Bp(U=8):5] against [Hog%(6):5]; Defender Hog%(6) was captured; Attacker Bp(U=8) showing 5 changed to p(U), which then split into: p(U=2) showing 1, and p(U=2) showing 2'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Berserk attack using [Bp(U=8):5] against [Hog%(6):5]; Defender Hog%(6) was captured; Attacker Bp(U=8) showing 5 changed to p(U=4), which then split into: p(U=2) showing 1, and p(U=2) showing 2'));
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003\'s idle ornery dice rerolled at end of turn: Hog(4) changed size from 4 to 6 sides, recipe changed from Hog(4) to Hog(6), rerolled 3 => 4'));
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
@@ -7906,8 +7906,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         // [t(1):1, (10):1, (10):4, z(12):9, (Y=1):1] => [Hog%(4):3, Hog%(4):2, Hog%(4):1, Hog%(4):3]
         $this->verify_api_submitTurn(
             array(1, 0),
-            // #1444: this shouldn't have the "changed to (Y) business
-            'responder003 performed Power attack using [(Y=1):1] against [Hog%(4):1]; Defender Hog%(4) was captured; Attacker (Y=1) showing 1 changed to (Y), which then split into: (Y=1) showing 1, and (Y) showing 0. ',
+            'responder003 performed Power attack using [(Y=1):1] against [Hog%(4):1]; Defender Hog%(4) was captured; Attacker (Y=1) showing 1 split into: (Y=1) showing 1, and (Y) showing 0. ',
             $retval, array(array(0, 4), array(1, 2)),
             $gameId, 1, 'Power', 0, 1, '');
 
@@ -7921,7 +7920,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
         $expData['playerDataArray'][0]['activeDieArray'][4]['properties'] = array('HasJustSplit');
         $expData['playerDataArray'][0]['activeDieArray'][]= array('value' => 0, 'sides' => 0, 'recipe' => '(Y)', 'description' => 'Y Swing Die (with 0 sides)', 'properties' => array('HasJustSplit'), 'skills' => array());
-        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Power attack using [(Y=1):1] against [Hog%(4):1]; Defender Hog%(4) was captured; Attacker (Y=1) showing 1 changed to (Y), which then split into: (Y=1) showing 1, and (Y) showing 0'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Power attack using [(Y=1):1] against [Hog%(4):1]; Defender Hog%(4) was captured; Attacker (Y=1) showing 1 split into: (Y=1) showing 1, and (Y) showing 0'));
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
     }


### PR DESCRIPTION
This update brings these approved pulls to the dev branch:
- User-visible:
  - #1445: fix internal error bug with zero-sided swing dice
  - #1446: fix logging bug where the log wasn't showing swing values after berserk attacks before splitting
- Not user-visible:
  - #1438: more regression tests

Database updates: none

Once this pull is merged, i will load the changes on dev.buttonweavers.com as part of #217.
