### PR TITLE
Increased max chat message length from 500 characters to 2000 characters

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -85,7 +85,7 @@ CREATE TABLE game_chat_log (
     chat_time          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     chatting_player    SMALLINT UNSIGNED NOT NULL,
     -- A chat message is limited to 2000 Unicode characters (see
-    -- GAME_CHAT_MAX_LENGTH in BMInterface and Game.js). Since a Unicode
+    -- GAME_CHAT_MAX_LENGTH in ApiSpec.php and Game.js). Since a Unicode
     -- character can be up to four bytes, this requires a varchar(8000).
     message            VARCHAR(8000)
 );

--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -84,10 +84,10 @@ CREATE TABLE game_chat_log (
     game_id            MEDIUMINT UNSIGNED NOT NULL,
     chat_time          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     chatting_player    SMALLINT UNSIGNED NOT NULL,
-    -- A chat message is limited to 500 Unicode characters (see
+    -- A chat message is limited to 2000 Unicode characters (see
     -- GAME_CHAT_MAX_LENGTH in BMInterface and Game.js). Since a Unicode
-    -- character can be up to four bytes, this requires a varchar(2000).
-    message            VARCHAR(2000)
+    -- character can be up to four bytes, this requires a varchar(8000).
+    message            VARCHAR(8000)
 );
 
 DROP TABLE IF EXISTS die;

--- a/deploy/database/updates/00367_chat_length.sql
+++ b/deploy/database/updates/00367_chat_length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE game_chat_log MODIFY message VARCHAR(8000);

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -12,7 +12,7 @@
  */
 class ApiSpec {
     // constants
-    const GAME_CHAT_MAX_LENGTH = 500;
+    const GAME_CHAT_MAX_LENGTH = 2000;
     const FORUM_BODY_MAX_LENGTH = 16000;
     const FORUM_TITLE_MAX_LENGTH = 100;
     const GENDER_MAX_LENGTH = 100;

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -29,7 +29,7 @@ Game.SPACE_BULLET = ' &nbsp;&bull;&nbsp; ';
 Game.logEntryLimit = 10;
 
 // Maximum number of characters permitted in a given chat message
-Game.GAME_CHAT_MAX_LENGTH = 500;
+Game.GAME_CHAT_MAX_LENGTH = 2000;
 
 ////////////////////////////////////////////////////////////////////////
 // Action flow through this page:


### PR DESCRIPTION
Fixes #367.

Requires database update 00367_chat_length.sql.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/576/