### PR TITLE
Fixed handling of asymmetric twin swing/non-swing dice in BMGame->getJsonData()

### DIFF
--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -387,14 +387,10 @@ class BMDie extends BMCanHaveSkill {
         unset($this->value);
         $newdie = clone $this;
 
-        // james: reinstate the commented condition if we want a 1-sider to split into
-        //        two 1-siders
-//        if ($newdie->max > 1) {
         $remainder = $newdie->max % 2;
         $newdie->max -= $remainder;
         $newdie->max = $newdie->max / 2;
         $this->max -= $newdie->max;
-//        }
 
         if (0 == $this->max) {
             $this->min = 0;

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -3344,7 +3344,15 @@ class BMGame {
             isset($this->swingRequestArrayArray[$playerIdx])) {
             foreach ($this->swingRequestArrayArray[$playerIdx] as $swingtype => $swingdice) {
                 if ($swingdice[0] instanceof BMDieTwin) {
-                    $swingdie = $swingdice[0]->dice[0];
+                    if ($swingdice[0]->dice[0] instanceof BMDieSwing) {
+                        $swingdie = $swingdice[0]->dice[0];
+                    } elseif ($swingdice[0]->dice[1] instanceof BMDieSwing) {
+                        $swingdie = $swingdice[0]->dice[1];
+                    } else {
+                        throw new LogicException(
+                            'At least one of the subdice of a twin swing die should be a swing die'
+                        );
+                    }
                 } else {
                     $swingdie = $swingdice[0];
                 }
@@ -3352,7 +3360,7 @@ class BMGame {
                     $validRange = $swingdie->swing_range($swingtype);
                 } else {
                     throw new LogicException(
-                        "Tried to put die in swingRequestArray which is not a swing die: " . $swingdie
+                        'Tried to put die in swingRequestArray which is not a swing die: ' . $swingdie
                     );
                 }
                 $swingRequestArray[$swingtype] = array($validRange[0], $validRange[1]);

--- a/test/src/engine/BMDieTwinTest.php
+++ b/test/src/engine/BMDieTwinTest.php
@@ -68,6 +68,7 @@ class BMDieTwinTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue($this->object->has_skill("Testing2"));
         $this->assertCount(2, $this->object->dice);
         $this->assertInstanceOf('BMDie', $this->object->dice[0]);
+        $this->assertNotInstanceOf('BMDieSwing', $this->object->dice[0]);
         $this->assertInstanceOf('BMDieSwing', $this->object->dice[1]);
         $this->assertEquals(1, $this->object->dice[0]->min);
         $this->assertEquals(2, $this->object->dice[0]->max);
@@ -87,6 +88,7 @@ class BMDieTwinTest extends PHPUnit_Framework_TestCase {
         $this->assertCount(2, $this->object->dice);
         $this->assertInstanceOf('BMDieSwing', $this->object->dice[0]);
         $this->assertInstanceOf('BMDie', $this->object->dice[1]);
+        $this->assertNotInstanceOf('BMDieSwing', $this->object->dice[1]);
         $this->assertEquals(1, $this->object->dice[0]->min);
         $this->assertNull($this->object->dice[0]->max);
         $this->assertEquals(1, $this->object->dice[1]->min);

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -6858,6 +6858,93 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @covers BMGame::proceed_to_next_user_action
+     */
+    public function test_twin_asymmetric_swing_die() {
+        // load buttons
+        $button1 = new BMButton;
+        $button1->load('(1) (6,X)', 'Test1');
+        $this->assertEquals('(1) (6,X)', $button1->recipe);
+        // check dice in $button1->dieArray are correct
+        $this->assertCount(2, $button1->dieArray);
+        $this->assertEquals(1, $button1->dieArray[0]->max);
+        $this->assertFalse(isset($button1->dieArray[1]->max));
+        $this->assertInstanceOf('BMDieTwin', $button1->dieArray[1]);
+
+        $button2 = new BMButton;
+        $button2->load('(Y,8) (2)', 'Test2');
+        $this->assertEquals('(Y,8) (2)', $button2->recipe);
+        // check dice in $button2->dieArray are correct
+        $this->assertCount(2, $button2->dieArray);
+        $this->assertFalse(isset($button2->dieArray[0]->max));
+        $this->assertEquals(2, $button2->dieArray[1]->max);
+        $this->assertInstanceOf('BMDieTwin', $button2->dieArray[0]);
+
+        // load game
+        $game = new BMGame(535353, array(234, 567), array('', ''), 2);
+        $this->assertEquals(BMGameState::START_GAME, $game->gameState);
+        $this->assertEquals(2, $game->maxWins);
+        $game->buttonArray = array($button1, $button2);
+        $this->assertEquals($game, $game->buttonArray[0]->ownerObject);
+        $this->assertEquals($game, $game->buttonArray[1]->ownerObject);
+        $this->assertEquals($game, $game->buttonArray[0]->dieArray[0]->ownerObject);
+        $this->assertEquals($game, $game->buttonArray[0]->dieArray[1]->ownerObject);
+        $this->assertEquals($game, $game->buttonArray[1]->dieArray[0]->ownerObject);
+        $this->assertEquals($game, $game->buttonArray[1]->dieArray[1]->ownerObject);
+
+        $game->waitingOnActionArray = array(FALSE, FALSE);
+        $game->proceed_to_next_user_action();
+        $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
+        $this->assertEquals(array(TRUE, TRUE), $game->waitingOnActionArray);
+        $this->assertEquals(BMGameState::SPECIFY_DICE, $game->gameState);
+        $this->assertEquals(array(array('X' => NULL), array('Y' => NULL)),
+                            $game->swingValueArrayArray);
+
+        // specify swing dice correctly
+        $game->swingValueArrayArray = array(array('X' => 5), array('Y' => 9));
+        $game->proceed_to_next_user_action();
+        $this->assertNotInstanceOf('BMDieSwing', $game->activeDieArrayArray[0][1]->dice[0]);
+        $this->assertInstanceOf('BMDieSwing', $game->activeDieArrayArray[0][1]->dice[1]);
+        $this->assertFalse($game->activeDieArrayArray[0][1]->dice[1]->needsSwingValue);
+        $this->assertInstanceOf('BMDieSwing', $game->activeDieArrayArray[1][0]->dice[0]);
+        $this->assertFalse($game->activeDieArrayArray[1][0]->dice[0]->needsSwingValue);
+        $this->assertNotInstanceOf('BMDieSwing', $game->activeDieArrayArray[1][0]->dice[1]);
+
+        $this->assertEquals(1, array_sum($game->waitingOnActionArray));
+        $this->assertEquals(BMGameState::START_TURN, $game->gameState);
+        $this->assertEquals(array(array('X' => 5), array('Y' => 9)),
+                            $game->swingValueArrayArray);
+        $this->assertEquals( 1, $game->activeDieArrayArray[0][0]->min);
+        $this->assertEquals( 2, $game->activeDieArrayArray[0][1]->min);
+        $this->assertEquals( 2, $game->activeDieArrayArray[1][0]->min);
+        $this->assertEquals( 1, $game->activeDieArrayArray[1][1]->min);
+        $this->assertEquals( 1, $game->activeDieArrayArray[0][0]->max);
+        $this->assertEquals(11, $game->activeDieArrayArray[0][1]->max);
+        $this->assertEquals(17, $game->activeDieArrayArray[1][0]->max);
+        $this->assertEquals( 2, $game->activeDieArrayArray[1][1]->max);
+
+        $this->assertNotNull($game->activeDieArrayArray[0][0]->value);
+        $this->assertNotNull($game->activeDieArrayArray[0][1]->value);
+        $this->assertNotNull($game->activeDieArrayArray[1][0]->value);
+        $this->assertNotNull($game->activeDieArrayArray[1][1]->value);
+
+        // artificially set player 1 as winning initiative
+        $game->playerWithInitiativeIdx = 0;
+        $game->activePlayerIdx = 0;
+        $game->waitingOnActionArray = array(TRUE, FALSE);
+        // artificially set die values
+        $dieArrayArray = $game->activeDieArrayArray;
+        $dieArrayArray[0][0]->value = 1;
+        $dieArrayArray[0][1]->value = 2;
+        $dieArrayArray[1][0]->value = 3;
+        $dieArrayArray[1][1]->value = 2;
+
+        $data = $game->getJsonData(234);
+        $this->assertEquals(array('X' => array(4, 20)), $data['playerDataArray'][0]['swingRequestArray']);
+        $this->assertEquals(array('Y' => array(1, 20)), $data['playerDataArray'][1]['swingRequestArray']);
+    }
+
+    /**
      * @coversUpdate_game_state
      */
     public function test_focus_round() {


### PR DESCRIPTION
When digging for a solution to #1550, I noticed that the code in BMGame->getJsonData() assumed that the first subdie of a twin swing die would be a swing die. This pull request fixes the code for the case where the first subdie is not a swing die.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/655/