### PR TITLE
Time and Space now triggers correctly for twin dice

### DIFF
--- a/src/engine/BMDieTwin.php
+++ b/src/engine/BMDieTwin.php
@@ -92,7 +92,8 @@ class BMDieTwin extends BMDie {
 
         $this->value = $value;
 
-        //$this->run_hooks('post_roll', array('isTriggeredByAttack' => $isTriggeredByAttack));
+        $this->run_hooks('post_roll', array('die' => $this,
+                                            'isTriggeredByAttack' => $isTriggeredByAttack));
     }
 
     // Print long description

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -576,7 +576,7 @@ class BMGameAction {
                    ' gets another turn';
 
         if ('TimeAndSpace' == $this->params['cause']) {
-            $message .= ' because a TimeAndSpace die rolled odd';
+            $message .= ' because a Time and Space die rolled odd';
         }
 
         return $message;

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -9750,7 +9750,6 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @depends test_request_savePlayerInfo
-     * @group fulltest_deps
      *
      * This game reproduces a bug in which time and space is not triggered on a twin die
      * 0. Start a game with responder003 playing LadyJ and responder004 playing Giant
@@ -9847,7 +9846,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         $this->verify_api_submitTurn(
             array(1, 2, 3, 8),
-            'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3. responder003 gets another turn because a TimeAndSpace die rolled odd. responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8. ',
+            'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3. responder003 gets another turn because a Time and Space die rolled odd. responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8. ',
             $retval, array(array(0, 3), array(1, 0)),
             $gameId, 1, 'Power', 0, 1, '');
 
@@ -9866,7 +9865,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $expData['playerDataArray'][0]['waitingOnAction'] = TRUE;
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3'));
-        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 gets another turn because a TimeAndSpace die rolled odd'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 gets another turn because a Time and Space die rolled odd'));
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8'));
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -9847,12 +9847,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         $this->verify_api_submitTurn(
             array(1, 2, 3, 8),
-            'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3. responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8. ',
+            'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3. responder003 gets another turn because a TimeAndSpace die rolled odd. responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8. ',
             $retval, array(array(0, 3), array(1, 0)),
             $gameId, 1, 'Power', 0, 1, '');
 
         $this->update_expected_data_after_normal_attack(
-            $expData, 1, array('Power'),
+            $expData, 1, array('Power', 'Skill'),
             array(42, 50, -5.3, 5.3),
             array(array(0, 1, array('value' => 8, 'sides' => 12, 'description' => 'Mighty Ornery W Mood Swing Die (with 12 sides)', 'properties' => array('HasJustGrown', 'HasJustRerolledOrnery'))),
                   array(0, 3, array('value' => 3))),
@@ -9862,7 +9862,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
         $expData['playerDataArray'][0]['activeDieArray'][3]['subdieArray'][0]['value'] = 1;
         $expData['playerDataArray'][0]['activeDieArray'][3]['subdieArray'][1]['value'] = 2;
+        $expData['activePlayerIdx'] = 0;
+        $expData['playerDataArray'][0]['waitingOnAction'] = TRUE;
+        $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 gets another turn because a TimeAndSpace die rolled odd'));
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003\'s idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8'));
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -832,7 +832,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
     public function test_friendly_message_play_another_turn() {
         $this->object = new BMGameAction(BMGameState::END_TURN, 'play_another_turn', 1, array('cause' => 'TimeAndSpace'));
         $this->assertEquals(
-            'gameaction01 gets another turn because a TimeAndSpace die rolled odd',
+            'gameaction01 gets another turn because a Time and Space die rolled odd',
             $this->object->friendly_message($this->playerIdNames, 0, 0)
         );
     }


### PR DESCRIPTION
Fixes #1593. Also addresses the action logging wording left over from comments on #1583.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/678/