### PR TITLE
Added logic to disable "Mark thread as read" button when there is text in the reply box

### DIFF
--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -323,7 +323,7 @@ Forum.showThread = function() {
     'maxlength': Forum.FORUM_BODY_MAX_LENGTH,
   });
   replyBodyTextArea.on('change keyup paste', function() {
-    if ('' == $(this).val().trim()) {
+    if ('' === $(this).val().trim()) {
       if ('disabled' == $('#markReadButton').attr('disabled')) {
         $('#markReadButton').removeAttr('disabled');
         $('#markReadButton').removeAttr('title');
@@ -331,10 +331,11 @@ Forum.showThread = function() {
     } else {
       if ('disabled' != $('#markReadButton').attr('disabled')) {
         $('#markReadButton').attr('disabled', 'disabled');
-        $('#markReadButton').attr('title', 'Disabled because there is text in the reply box')
+        $('#markReadButton').attr('title',
+          'Disabled because there is text in the reply box');
       }
     }
-  })
+  });
   replyBodyTd.append(replyBodyTextArea);
 
   var replyButton = $('<input>', {

--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -318,20 +318,37 @@ Forum.showThread = function() {
 
   var replyBodyTd = $('<td>', { 'class': 'body' });
   replyTr.append(replyBodyTd);
-  replyBodyTd.append($('<textarea>', {
+  var replyBodyTextArea = $('<textarea>', {
     'placeholder': 'Reply to thread...',
     'maxlength': Forum.FORUM_BODY_MAX_LENGTH,
-  }));
+  });
+  replyBodyTextArea.on('change keyup paste', function() {
+    if ('' == $(this).val().trim()) {
+      if ('disabled' == $('#markReadButton').attr('disabled')) {
+        $('#markReadButton').removeAttr('disabled');
+        $('#markReadButton').removeAttr('title');
+      }
+    } else {
+      if ('disabled' != $('#markReadButton').attr('disabled')) {
+        $('#markReadButton').attr('disabled', 'disabled');
+        $('#markReadButton').attr('title', 'Disabled because there is text in the reply box')
+      }
+    }
+  })
+  replyBodyTd.append(replyBodyTextArea);
+
   var replyButton = $('<input>', {
     'type': 'button',
     'value': 'Post reply',
   });
   replyBodyTd.append(replyButton);
+
   replyButton.click(Forum.formReplyToThread);
 
   var markReadTd = $('<td>', { 'class': 'markRead', 'colspan': 2, });
   table.append($('<tr>').append(markReadTd));
   var markReadButton = $('<input>', {
+    'id': 'markReadButton',
     'type': 'button',
     'value': 'Mark thread as read',
   });


### PR DESCRIPTION
Fixes #1336.

I'm thinking that there should probably be a QUnit test for this, but I don't yet know how to construct one.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/745/ (if it passes)