### PR TITLE
Boom attacks now do not trigger side-effects from other skills

### DIFF
--- a/src/engine/BMSkill.php
+++ b/src/engine/BMSkill.php
@@ -221,6 +221,7 @@ class BMSkill {
                      'BMSkillReserve',
                      'BMSkillChance',
                      'BMSkillFocus',
+                     'BMSkillBoom',
                      'BMSkillSpeed',
                      'BMSkillTrip',
                      'BMSkillQueer',
@@ -244,8 +245,7 @@ class BMSkill {
                      'BMSkillNull',
                      'BMSkillMaximum',
                      'BMSkillTimeAndSpace',
-                     'BMSkillWarrior',
-                     'BMSkillBoom');
+                     'BMSkillWarrior');
         // fires last
     }
 

--- a/src/engine/BMSkillMighty.php
+++ b/src/engine/BMSkillMighty.php
@@ -42,6 +42,11 @@ class BMSkillMighty extends BMSkill {
             return;
         }
 
+        // don't trigger skil if the die has already left play
+        if ($die->outOfPlay) {
+            return;
+        }
+
         $die->grow();
     }
 

--- a/src/engine/BMSkillMighty.php
+++ b/src/engine/BMSkillMighty.php
@@ -42,7 +42,7 @@ class BMSkillMighty extends BMSkill {
             return;
         }
 
-        // don't trigger skil if the die has already left play
+        // don't trigger skill if the die has already left play
         if ($die->outOfPlay) {
             return;
         }

--- a/src/engine/BMSkillMood.php
+++ b/src/engine/BMSkillMood.php
@@ -40,6 +40,10 @@ class BMSkillMood extends BMSkill {
             return FALSE;
         }
 
+        if ($args['die']->outOfPlay) {
+            return FALSE;
+        }
+
         // do nothing if the die is not a swing die or a
         // twin die with swing components
         $die = $args['die'];

--- a/src/engine/BMSkillMood.php
+++ b/src/engine/BMSkillMood.php
@@ -24,32 +24,11 @@ class BMSkillMood extends BMSkill {
      * @return boolean
      */
     public static function pre_roll(&$args) {
-        if (!($args['die'] instanceof BMDie)) {
+        if (!self::does_skill_trigger_on_pre_roll($args)) {
             return FALSE;
         }
 
-        if (empty($args['die']->value) && !$args['die']->has_flag('HasJustSplit')) {
-            return FALSE;
-        }
-
-        if (array_key_exists('isSubdie', $args) && $args['isSubdie']) {
-            return FALSE;
-        }
-
-        if (!$args['die']->doesReroll) {
-            return FALSE;
-        }
-
-        if ($args['die']->outOfPlay) {
-            return FALSE;
-        }
-
-        // do nothing if the die is not a swing die or a
-        // twin die with swing components
         $die = $args['die'];
-        if (!static::can_have_mood($die)) {
-            return FALSE;
-        }
 
         $swingRange = BMDieSwing::swing_range($die->swingType);
         $validSwingValueArray = static::valid_die_sizes($swingRange);
@@ -67,6 +46,38 @@ class BMSkillMood extends BMSkill {
             $die->recalc_max_min();
         } else {
             throw new LogicException('Mood applied to non-swing die.');
+        }
+
+        return TRUE;
+    }
+
+    protected static function does_skill_trigger_on_pre_roll($args) {
+        if (!($args['die'] instanceof BMDie)) {
+            return FALSE;
+        }
+
+        $die = $args['die'];
+
+        if (empty($die->value) && !$die->has_flag('HasJustSplit')) {
+            return FALSE;
+        }
+
+        if (array_key_exists('isSubdie', $args) && $args['isSubdie']) {
+            return FALSE;
+        }
+
+        if (!$die->doesReroll) {
+            return FALSE;
+        }
+
+        if ($die->outOfPlay) {
+            return FALSE;
+        }
+
+        // do nothing if the die is not a swing die or a
+        // twin die with swing components
+        if (!static::can_have_mood($die)) {
+            return FALSE;
         }
 
         return TRUE;

--- a/src/engine/BMSkillMorphing.php
+++ b/src/engine/BMSkillMorphing.php
@@ -32,6 +32,10 @@ class BMSkillMorphing extends BMSkill {
             return;
         }
 
+        if ($attacker->outOfPlay) {
+            return;
+        }
+
         $game = $attacker->ownerObject;
         $activeDieArrayArray = $game->activeDieArrayArray;
 
@@ -83,7 +87,7 @@ class BMSkillMorphing extends BMSkill {
         $newDie->doesReroll = TRUE;
         $newDie->captured = FALSE;
         $newDie->outOfPlay = FALSE;
-        
+
         $newDie->ownerObject = $att->ownerObject;
         $newDie->playerIdx = $att->playerIdx;
         $newDie->originalPlayerIdx = $att->originalPlayerIdx;

--- a/src/engine/BMSkillNull.php
+++ b/src/engine/BMSkillNull.php
@@ -44,7 +44,9 @@ class BMSkillNull extends BMSkill {
         }
 
         foreach ($args['defenders'] as $defender) {
-            $defender->add_skill('Null');
+            if ($defender->captured) {
+                $defender->add_skill('Null');
+            }
         }
     }
 

--- a/src/engine/BMSkillOrnery.php
+++ b/src/engine/BMSkillOrnery.php
@@ -53,6 +53,10 @@ class BMSkillOrnery extends BMSkill {
             return;
         }
 
+        if ($die->outOfPlay) {
+            return;
+        }
+
         $die->roll(FALSE);
         $die->add_flag('HasJustRerolledOrnery');
         return TRUE;

--- a/src/engine/BMSkillRadioactive.php
+++ b/src/engine/BMSkillRadioactive.php
@@ -62,6 +62,11 @@ class BMSkillRadioactive extends BMSkill {
         }
 
         $attacker = &$args['attackers'][0];
+
+        if ($attacker->outOfPlay) {
+            return;
+        }
+
         $game = $attacker->ownerObject;
         $activeDieArrayArray = $game->activeDieArrayArray;
 

--- a/src/engine/BMSkillValue.php
+++ b/src/engine/BMSkillValue.php
@@ -70,7 +70,9 @@ class BMSkillValue extends BMSkill {
         assert(array_key_exists('defenders', $args));
 
         foreach ($args['defenders'] as $defender) {
-            $defender->add_skill('Value');
+            if ($defender->captured) {
+                $defender->add_skill('Value');
+            }
         }
     }
 

--- a/src/engine/BMSkillWeak.php
+++ b/src/engine/BMSkillWeak.php
@@ -42,7 +42,7 @@ class BMSkillWeak extends BMSkill {
             return;
         }
 
-        // don't trigger skil if the die has already left play
+        // don't trigger skill if the die has already left play
         if ($die->outOfPlay) {
             return;
         }

--- a/src/engine/BMSkillWeak.php
+++ b/src/engine/BMSkillWeak.php
@@ -42,6 +42,11 @@ class BMSkillWeak extends BMSkill {
             return;
         }
 
+        // don't trigger skil if the die has already left play
+        if ($die->outOfPlay) {
+            return;
+        }
+
         $die->shrink();
     }
 

--- a/test/src/engine/BMSkillTest.php
+++ b/test/src/engine/BMSkillTest.php
@@ -233,15 +233,7 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_capture_order() {
-        // boom occurs before all other capture events
-        $this->assertEquals(-1,
-            BMSkill::skill_order_comparator('BMSkillBoom',
-                                            'BMSkillBerserk'));
-
-        $this->assertEquals(-1,
-            BMSkill::skill_order_comparator('BMSkillBoom',
-                                            'BMSkillDoppelganger'));
-
+        // boom occurs before all other conflicting capture events
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillBoom',
                                             'BMSkillMorphing'));
@@ -256,15 +248,7 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillBoom',
-                                            'BMSkillTrip'));
-
-        $this->assertEquals(-1,
-            BMSkill::skill_order_comparator('BMSkillBoom',
                                             'BMSkillValue'));
-
-        $this->assertEquals(-1,
-            BMSkill::skill_order_comparator('BMSkillBoom',
-                                            'BMSkillWarrior'));
 
         // doppelganger occurs before null
         $this->assertEquals(-1,

--- a/test/src/engine/BMSkillTest.php
+++ b/test/src/engine/BMSkillTest.php
@@ -233,7 +233,7 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_capture_order() {
-        // boom occurs before all other conflicting capture events
+        // boom occurs before all other conflicting skills
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillBoom',
                                             'BMSkillMorphing'));
@@ -249,6 +249,14 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillBoom',
                                             'BMSkillValue'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillMighty'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillWeak'));
 
         // doppelganger occurs before null
         $this->assertEquals(-1,

--- a/test/src/engine/BMSkillTest.php
+++ b/test/src/engine/BMSkillTest.php
@@ -258,6 +258,18 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
             BMSkill::skill_order_comparator('BMSkillBoom',
                                             'BMSkillWeak'));
 
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillMood'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillMad'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillOrnery'));
+
         // doppelganger occurs before null
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillDoppelganger',

--- a/test/src/engine/BMSkillTest.php
+++ b/test/src/engine/BMSkillTest.php
@@ -233,6 +233,39 @@ class BMSkillTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_capture_order() {
+        // boom occurs before all other capture events
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillBerserk'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillDoppelganger'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillMorphing'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillNull'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillRadioactive'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillTrip'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillValue'));
+
+        $this->assertEquals(-1,
+            BMSkill::skill_order_comparator('BMSkillBoom',
+                                            'BMSkillWarrior'));
+
         // doppelganger occurs before null
         $this->assertEquals(-1,
             BMSkill::skill_order_comparator('BMSkillDoppelganger',


### PR DESCRIPTION
Fixes #1645.

This addresses the interactions between boom and the following skills: 
- morphing
- null
- radioactive
- value
- mighty
- weak
- mood
- mad
- ornery

This will need quite a bit of testing by the testers, I expect.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/762/