### PR TITLE
Added button special information to game screens

### DIFF
--- a/src/engine/BMBtnSkill.php
+++ b/src/engine/BMBtnSkill.php
@@ -43,7 +43,7 @@ class BMBtnSkill {
         }
 
         $skillDescription = array(
-            'code' => $skill,
+            'code' => '',
             'description' => $description,
             'interacts' => array(),
         );

--- a/src/engine/BMBtnSkill.php
+++ b/src/engine/BMBtnSkill.php
@@ -36,8 +36,8 @@ class BMBtnSkill {
                 return NULL;
             }
 
-            $skill = new $skillClass;
-            if ($skill instanceof BMBtnSkillArtificialReenable) {
+            $skillInstance = new $skillClass;
+            if ($skillInstance instanceof BMBtnSkillArtificialReenable) {
                 return NULL;
             }
         }

--- a/src/engine/BMBtnSkill.php
+++ b/src/engine/BMBtnSkill.php
@@ -25,13 +25,26 @@ class BMBtnSkill {
      * Complete description of skill, packaged for front end
      *
      * @param string $skill
-     * @return array
+     * @return array|NULL
      */
-    public static function describe($skill) {
+    public static function describe($skill, $includeEmpty = TRUE) {
         $skillClass = "BMBtnSkill$skill";
+        $description = $skillClass::get_description();
+
+        if (!$includeEmpty) {
+            if (empty($description)) {
+                return NULL;
+            }
+
+            $skill = new $skillClass;
+            if ($skill instanceof BMBtnSkillArtificialReenable) {
+                return NULL;
+            }
+        }
+
         $skillDescription = array(
             'code' => $skill,
-            'description' => $skillClass::get_description(),
+            'description' => $description,
             'interacts' => array(),
         );
 

--- a/src/engine/BMBtnSkill.php
+++ b/src/engine/BMBtnSkill.php
@@ -20,4 +20,21 @@ class BMBtnSkill {
     public static function get_description() {
         return NULL;
     }
+
+    /**
+     * Complete description of skill, packaged for front end
+     *
+     * @param string $skill
+     * @return array
+     */
+    public static function describe($skill) {
+        $skillClass = "BMBtnSkill$skill";
+        $skillDescription = array(
+            'code' => $skill,
+            'description' => $skillClass::get_description(),
+            'interacts' => array(),
+        );
+
+        return $skillDescription;
+    }
 }

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -56,6 +56,7 @@
  * @property      array $hasPlayerAcceptedGameArray  Boolean array whether each player has accepted this game
  * @property      array $hasPlayerDismissedGameArray    Whether or not each player has dismissed this game
  *
+ * @SuppressWarnings(PMD.CouplingBetweenObjects)
  * @SuppressWarnings(PMD.TooManyFields)
  * @SuppressWarnings(PMD.TooManyMethods)
  * @SuppressWarnings(PMD.UnusedPrivateField)

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -3895,7 +3895,10 @@ class BMGame {
         $gameSkillsInfo = array();
         if (!empty($gameBtnSkillsList)) {
             foreach ($gameBtnSkillsList as $btnSkillType) {
-                $gameSkillsInfo[$btnSkillType] = BMBtnSkill::describe($btnSkillType);
+                $btnSkillDescription = BMBtnSkill::describe($btnSkillType, FALSE);
+                if (!empty($btnSkillDescription)) {
+                    $gameSkillsInfo[$btnSkillType] = $btnSkillDescription;
+                }
             }
         }
         if (!empty($gameSkillsList)) {
@@ -3903,7 +3906,7 @@ class BMGame {
                 $gameSkillsInfo[$skillType] = BMSkill::describe($skillType, $gameSkillsList);
             }
         }
-        
+
         return $gameSkillsInfo;
     }
 

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -3870,10 +3870,13 @@ class BMGame {
      */
     protected function get_gameSkillsInfo() {
         $gameSkillsWithKeysList = array();
+        $gameBtnSkillsWithKeysList = array();
 
         if (isset($this->buttonArray)) {
             foreach ($this->buttonArray as $playerButton) {
                 if (!is_null($playerButton) && count($playerButton->dieArray) > 0) {
+                    $gameBtnSkillsWithKeysList += $playerButton->skillList;
+
                     foreach ($playerButton->dieArray as $buttonDie) {
                         if (count($buttonDie->skillList) > 0) {
                             $gameSkillsWithKeysList += $buttonDie->skillList;
@@ -3886,10 +3889,21 @@ class BMGame {
         $gameSkillsList = array_keys($gameSkillsWithKeysList);
         sort($gameSkillsList);
 
+        $gameBtnSkillsList = array_keys($gameBtnSkillsWithKeysList);
+        sort($gameBtnSkillsList);
+
         $gameSkillsInfo = array();
-        foreach ($gameSkillsList as $skillType) {
-            $gameSkillsInfo[$skillType] = BMSkill::describe($skillType, $gameSkillsList);
+        if (!empty($gameBtnSkillsList)) {
+            foreach ($gameBtnSkillsList as $btnSkillType) {
+                $gameSkillsInfo[$btnSkillType] = BMBtnSkill::describe($btnSkillType);
+            }
         }
+        if (!empty($gameSkillsList)) {
+            foreach ($gameSkillsList as $skillType) {
+                $gameSkillsInfo[$skillType] = BMSkill::describe($skillType, $gameSkillsList);
+            }
+        }
+        
         return $gameSkillsInfo;
     }
 

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1630,7 +1630,11 @@ Game.pageAddSkillListFooter = function() {
   var firstInteract;
   var skillDesc;
   $.each(Api.game.gameSkillsInfo, function(skill, info) {
-    skillDesc = skill + ' (' + info.code + '): ' + info.description;
+    skillDesc = skill;
+    if (info.code) {
+      skillDesc += ' (' + info.code + ')';
+    }
+    skillDesc += ': ' + info.description;
 
     firstInteract = true;
     $.each(info.interacts, function(otherSkill, interactDesc) {

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1623,7 +1623,7 @@ Game.pageAddGameNavigationFooter = function() {
 // Display a footer-style message with the list of skills in this game
 Game.pageAddSkillListFooter = function() {
   var gameSkillDiv = $('<div>', {
-    'text': 'Die skills in this game: ',
+    'text': 'Skills in this game: ',
   });
 
   var firstSkill = true;

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -156,6 +156,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
                     'Konstant' => 'Dice with both Focus and Konstant skills may be turned down to gain initiative',
                 ),
             ),
+            'Giant' => array(
+                'code' => 'Giant',
+                'description' => 'Cannot win initiative.',
+                'interacts' => array(),
+            ),
             'Konstant' => array(
                 'code' => 'k',
                 'description' => 'These dice do not reroll after an attack; they keep their current value. Konstant dice can not Power Attack, and cannot perform a Skill Attack by themselves, but they can add OR subtract their value in a multi-dice Skill Attack. If another skill causes a Konstant die to reroll (e.g., Chance, Trip, Ornery), it continues to show the same value. If another skill causes the die to change its value without rerolling (e.g., Focus, Fire), the die\'s value does change and then continues to show that new value.',
@@ -241,6 +246,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
                     'Doppelganger' => 'Dice with both Radioactive and Doppelganger first decay, then each of the "decay products" are replaced by exact copies of the die they captured',
                     'Morphing' => 'Dice with both Radioactive and Morphing skills first morph into the size of the captured die, and then decay',
                 ),
+            ),
+            'RandomBMMixed' => array(
+                'code' => 'RandomBMMixed',
+                'description' => '5 dice, no swing dice, three skills chosen from all existing skills, with each skill dealt out twice randomly and independently over all dice.',
+                'interacts' => array(),
             ),
             'Rage' => array(
                 'code' => 'G',

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -157,7 +157,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
                 ),
             ),
             'Giant' => array(
-                'code' => 'Giant',
+                'code' => '',
                 'description' => 'Cannot win initiative.',
                 'interacts' => array(),
             ),
@@ -248,7 +248,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
                 ),
             ),
             'RandomBMMixed' => array(
-                'code' => 'RandomBMMixed',
+                'code' => '',
                 'description' => '5 dice, no swing dice, three skills chosen from all existing skills, with each skill dealt out twice randomly and independently over all dice.',
                 'interacts' => array(),
             ),

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -9204,7 +9204,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'responder003', 'responder004', 'RandomBMMixed', 'RandomBMMixed', 3);
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Chance', 'Maximum', 'Null', 'Ornery', 'Shadow', 'Trip', 'RandomBM'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Chance', 'Maximum', 'Null', 'Ornery', 'Shadow', 'Trip', 'RandomBMMixed'));
         $expData['validAttackTypeArray'] = array('Power', 'Skill', 'Trip');
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
@@ -10060,7 +10060,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'responder003', 'responder004', 'LadyJ', 'Giant', 3);
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'SPECIFY_DICE');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace', 'RandomBM'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace', 'RandomBMMixed'));
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][0]['swingRequestArray'] = array('W' => array(4, 12), 'T' => array(2, 12), 'X' => array(4, 20));
         $expData['playerDataArray'][0]['button'] = array('name' => 'LadyJ', 'recipe' => 'dG(17) Ho(W)? q(X) ^B(T,T) (5)', 'artFilename' => 'BMdefaultRound.png');
@@ -10304,7 +10304,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Konstant', 'Maximum', 'Null', 'Poison', 'Weak', 'RandomBM'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Konstant', 'Maximum', 'Null', 'Poison', 'Weak', 'RandomBMMixed'));
         $expData['validAttackTypeArray'] = array('Power', 'Skill');
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
@@ -11243,7 +11243,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Boom', 'Queer', 'Stealth', 'Value', 'Weak', 'RandomBM'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Boom', 'Queer', 'Stealth', 'Value', 'Weak', 'RandomBMMixed'));
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
         $expData['validAttackTypeArray'] = array('Power', 'Skill', 'Berserk');

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -9204,7 +9204,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'responder003', 'responder004', 'RandomBMMixed', 'RandomBMMixed', 3);
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Chance', 'Maximum', 'Null', 'Ornery', 'Shadow', 'Trip'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Chance', 'Maximum', 'Null', 'Ornery', 'Shadow', 'Trip', 'RandomBM'));
         $expData['validAttackTypeArray'] = array('Power', 'Skill', 'Trip');
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
@@ -10060,7 +10060,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'responder003', 'responder004', 'LadyJ', 'Giant', 3);
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'SPECIFY_DICE');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace', 'RandomBM'));
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][0]['swingRequestArray'] = array('W' => array(4, 12), 'T' => array(2, 12), 'X' => array(4, 20));
         $expData['playerDataArray'][0]['button'] = array('name' => 'LadyJ', 'recipe' => 'dG(17) Ho(W)? q(X) ^B(T,T) (5)', 'artFilename' => 'BMdefaultRound.png');
@@ -10304,7 +10304,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Konstant', 'Maximum', 'Null', 'Poison', 'Weak'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Konstant', 'Maximum', 'Null', 'Poison', 'Weak', 'RandomBM'));
         $expData['validAttackTypeArray'] = array('Power', 'Skill');
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
@@ -11243,7 +11243,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'START_TURN');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Boom', 'Queer', 'Stealth', 'Value', 'Weak'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Boom', 'Queer', 'Stealth', 'Value', 'Weak', 'RandomBM'));
         $expData['activePlayerIdx'] = 0;
         $expData['playerWithInitiativeIdx'] = 0;
         $expData['validAttackTypeArray'] = array('Power', 'Skill', 'Berserk');

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -10060,7 +10060,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'responder003', 'responder004', 'LadyJ', 'Giant', 3);
 
         $expData = $this->generate_init_expected_data_array($gameId, 'responder003', 'responder004', 3, 'SPECIFY_DICE');
-        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace', 'RandomBMMixed'));
+        $expData['gameSkillsInfo'] = $this->get_skill_info(array('Berserk', 'Mighty', 'Mood', 'Ornery', 'Queer', 'Rage', 'Stealth', 'TimeAndSpace', 'Giant'));
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][0]['swingRequestArray'] = array('W' => array(4, 12), 'T' => array(2, 12), 'X' => array(4, 20));
         $expData['playerDataArray'][0]['button'] = array('name' => 'LadyJ', 'recipe' => 'dG(17) Ho(W)? q(X) ^B(T,T) (5)', 'artFilename' => 'BMdefaultRound.png');

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1127,7 +1127,7 @@ test("test_Game.pageAddSkillListFooter", function(assert) {
     Game.pageAddSkillListFooter();
     var htmlout = Game.page.html();
     assert.ok(htmlout.match('<br>'), "Skill list footer should insert line break");
-    assert.ok(htmlout.match('<div>Die skills in this game: '),
+    assert.ok(htmlout.match('<div>Skills in this game: '),
       "Die skills footer text is present");
     assert.ok(htmlout.match('Focus'),
       "Die skills footer text lists the Focus skill");


### PR DESCRIPTION
Fixes #1200.

I have added the button skills before the die skills, but not otherwise discriminated them, because this was the easiest thing to implement.

Tested with Giant vs RandomBMMixed, Echo vs Temperance, and Washu vs Shadow Warriors.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/834/