### PR TITLE
Sped up Overview page by adding indices to database table game_player_map

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -43,7 +43,8 @@ CREATE TABLE game_player_map (
     last_action_time   TIMESTAMP DEFAULT 0,
     was_game_dismissed BOOLEAN DEFAULT FALSE NOT NULL,
     is_button_random   BOOLEAN DEFAULT FALSE NOT NULL,
-    has_player_accepted BOOLEAN DEFAULT TRUE NOT NULL
+    has_player_accepted BOOLEAN DEFAULT TRUE NOT NULL,
+    INDEX (game_id, player_id)
 );
 
 CREATE TABLE game_swing_map (

--- a/deploy/database/updates/01580_database_index_02.sql
+++ b/deploy/database/updates/01580_database_index_02.sql
@@ -1,0 +1,1 @@
+ALTER TABLE game_player_map ADD INDEX (game_id, player_id);


### PR DESCRIPTION
Continues to address #1580.

Requires database update 01580_database_index_02.sql

Tested with Aug 2 backup of live site, logged in as irilyth (with a password manually copied across from my account). Load times drop from 5 seconds to 1 second.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/839/ (if it passes)