### PR TITLE
Actively swallow a space character when there is an explicit handler for it

### DIFF
--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -212,14 +212,15 @@ Env.addClickKeyboardHandlers = function(
   if (spaceHandlerCallback || returnHandlerCallback) {
     element.keydown(function(eventData) {
 
-      // if a space handler was specified, invoke it on spacebar
-      if (spaceHandlerCallback && eventData.which == Env.KEYCODE_SPACEBAR) {
-        spaceHandlerCallback.call(element, eventData);
-      }
-
       // if a return handler was specified, invoke it on return
       if (returnHandlerCallback && eventData.which == Env.KEYCODE_RETURN) {
         returnHandlerCallback.call(element, eventData);
+      }
+
+      // if a space handler was specified, invoke it on spacebar
+      if (spaceHandlerCallback && eventData.which == Env.KEYCODE_SPACEBAR) {
+        spaceHandlerCallback.call(element, eventData);
+        return false; // actively swallow the space event to stop scrolling
       }
     });
   }

--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -211,16 +211,21 @@ Env.addClickKeyboardHandlers = function(
   // behavior, install a keydown handler.
   if (spaceHandlerCallback || returnHandlerCallback) {
     element.keydown(function(eventData) {
+      doSwallowKeypress = false;
+
+      // if a space handler was specified, invoke it on spacebar
+      if (spaceHandlerCallback && eventData.which == Env.KEYCODE_SPACEBAR) {
+        spaceHandlerCallback.call(element, eventData);
+        doSwallowKeypress = true; // actively swallow the space event to stop scrolling
+      }
 
       // if a return handler was specified, invoke it on return
       if (returnHandlerCallback && eventData.which == Env.KEYCODE_RETURN) {
         returnHandlerCallback.call(element, eventData);
       }
 
-      // if a space handler was specified, invoke it on spacebar
-      if (spaceHandlerCallback && eventData.which == Env.KEYCODE_SPACEBAR) {
-        spaceHandlerCallback.call(element, eventData);
-        return false; // actively swallow the space event to stop scrolling
+      if (doSwallowKeypress) {
+        return false;
       }
     });
   }

--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -211,12 +211,13 @@ Env.addClickKeyboardHandlers = function(
   // behavior, install a keydown handler.
   if (spaceHandlerCallback || returnHandlerCallback) {
     element.keydown(function(eventData) {
-      doSwallowKeypress = false;
+      var doSwallowKeypress = false;
 
       // if a space handler was specified, invoke it on spacebar
       if (spaceHandlerCallback && eventData.which == Env.KEYCODE_SPACEBAR) {
         spaceHandlerCallback.call(element, eventData);
-        doSwallowKeypress = true; // actively swallow the space event to stop scrolling
+        // actively swallow the space event to stop scrolling
+        doSwallowKeypress = true;
       }
 
       // if a return handler was specified, invoke it on return


### PR DESCRIPTION
Fixes #1683.

Tested on the game page. I'm not aware of other space handlers, but I might have missed some.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/844/