### PR TITLE
Optimised button query, and added more database indices

### DIFF
--- a/deploy/database/schema.stats.sql
+++ b/deploy/database/schema.stats.sql
@@ -2,14 +2,16 @@ DROP TABLE IF EXISTS dhs_player;
 CREATE TABLE dhs_player (
     dhs_player_id   SMALLINT UNSIGNED NOT NULL,
     dhs_player_name VARCHAR(40) NOT NULL,
-    bw_player_id    SMALLINT UNSIGNED
+    bw_player_id    SMALLINT UNSIGNED,
+    INDEX (bw_player_id)
 );
 
 DROP TABLE IF EXISTS dhs_button;
 CREATE TABLE dhs_button (
     dhs_button_id   SMALLINT UNSIGNED NOT NULL,
     dhs_button_name VARCHAR(40) NOT NULL,
-    bw_button_id    SMALLINT UNSIGNED
+    bw_button_id    SMALLINT UNSIGNED,
+    INDEX (bw_button_id)
 );
 
 

--- a/deploy/database/updates/01580_database_indices_03.sql
+++ b/deploy/database/updates/01580_database_indices_03.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dhs_player ADD INDEX (bw_player_id);
+ALTER TABLE dhs_button ADD INDEX (bw_button_id);

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -2314,17 +2314,19 @@ class BMInterface {
     protected function execute_button_data_query($buttonName, $setName) {
         $parameters = array();
         $query =
-            'SELECT id, name, recipe, btn_special, set_name, tourn_legal, flavor_text ' .
-            'FROM button_view v ';
+            'SELECT b.id, b.name, b.recipe, b.btn_special, b.tourn_legal, b.flavor_text, ' .
+            '       s.name AS set_name ' .
+            'FROM button AS b ' .
+            'LEFT JOIN buttonset AS s ON b.set_id = s.id ';
         if ($buttonName !== NULL) {
-            $query .= 'WHERE v.name = :button_name ';
+            $query .= 'WHERE b.name = :button_name ';
             $parameters[':button_name'] = $buttonName;
         } elseif ($setName !== NULL) {
-            $query .= 'WHERE v.set_name = :set_name ';
+            $query .= 'WHERE s.name = :set_name ';
             $parameters[':set_name'] = $setName;
         }
         $query .=
-            'ORDER BY v.set_sort_order ASC, v.name ASC;';
+            'ORDER BY s.sort_order ASC, b.name ASC;';
 
         $statement = self::$conn->prepare($query);
         $statement->execute($parameters);


### PR DESCRIPTION
Continues to address #1580.

So, this pull request doesn't lead to huge improvements in performance, but it does stop the select_full_join count from increasing on:
- viewing button information (buttons.html and buttons.html?...)
- loading the create game page (create_game.html)

I watched the select_full_join count on my MAMP stack using the following query:

    SELECT * from information_schema.global_status where variable_name='select_full_join';

Then, I looked up the slow queries, which had been logged because I had a my.cnf with the following contents:

    [mysqld]
    log-slow-queries = /Users/james/slow.log
    long_query_time = 20
    log-queries-not-using-indexes

The button query was rewritten because MySQL views don't support indexing.

Requires database update 01580_database_indices_03.sql

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/865/ (if it passes)