### PR TITLE
Allow game rejection

### DIFF
--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -14,7 +14,7 @@ CREATE TABLE player (
     dob_month           INT DEFAULT 0 NOT NULL,
     dob_day             INT DEFAULT 0 NOT NULL,
     gender              VARCHAR(100) DEFAULT '' NOT NULL,
-    autoaccept          BOOLEAN DEFAULT 1,
+    autoaccept          BOOLEAN DEFAULT 0,
     autopass            BOOLEAN DEFAULT 0,
     fire_overshooting   BOOLEAN DEFAULT 0,
     monitor_redirects_to_game   BOOLEAN DEFAULT 0 NOT NULL,

--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -14,6 +14,7 @@ CREATE TABLE player (
     dob_month           INT DEFAULT 0 NOT NULL,
     dob_day             INT DEFAULT 0 NOT NULL,
     gender              VARCHAR(100) DEFAULT '' NOT NULL,
+    autoaccept          BOOLEAN DEFAULT 1,
     autopass            BOOLEAN DEFAULT 0,
     fire_overshooting   BOOLEAN DEFAULT 0,
     monitor_redirects_to_game   BOOLEAN DEFAULT 0 NOT NULL,

--- a/deploy/database/updates/00205_reject_game_02.sql
+++ b/deploy/database/updates/00205_reject_game_02.sql
@@ -1,4 +1,4 @@
-ALTER TABLE player ADD COLUMN autoaccept BOOLEAN DEFAULT 1 AFTER gender;
+ALTER TABLE player ADD COLUMN autoaccept BOOLEAN DEFAULT 0 AFTER gender;
 
 DROP VIEW IF EXISTS player_view;
 CREATE VIEW player_view

--- a/deploy/database/updates/00205_reject_game_02.sql
+++ b/deploy/database/updates/00205_reject_game_02.sql
@@ -1,4 +1,4 @@
-# Views for player-related tables
+ALTER TABLE player ADD COLUMN autoaccept BOOLEAN DEFAULT 1 AFTER gender;
 
 DROP VIEW IF EXISTS player_view;
 CREATE VIEW player_view

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -238,6 +238,7 @@ class ApiResponder {
         $infoArray['dob_day'] = (int)$args['dob_day'];
         $infoArray['comment'] = $args['comment'];
         $infoArray['gender'] = $args['gender'];
+        $infoArray['autoaccept'] = ('true' == $args['autoaccept']);
         $infoArray['autopass'] = ('true' == $args['autopass']);
         $infoArray['fire_overshooting'] = ('true' == $args['fire_overshooting']);
         $infoArray['monitor_redirects_to_game'] = ('true' == $args['monitor_redirects_to_game']);

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -92,13 +92,14 @@ class ApiResponder {
             $previousGameId = NULL;
         }
 
-        $retval = $interface->player()->create_game(
+        $retval = $interface->create_game(
             $playerIdArray,
             $buttonNameArray,
             $maxWins,
             $description,
             $previousGameId,
-            (int)$_SESSION['user_id']
+            (int)$_SESSION['user_id'],
+            FALSE
         );
 
         if (isset($retval)) {
@@ -444,6 +445,34 @@ class ApiResponder {
 
         if (isset($retval)) {
             $interface->player()->update_last_action_time($_SESSION['user_id'], $args['game']);
+        }
+
+        return $retval;
+    }
+
+    protected function get_interface_response_acceptGame($interface, $args) {
+        $retval = $interface->save_join_game_decision(
+            $_SESSION['user_id'],
+            $args['gameId'],
+            'accept'
+        );
+
+        if (isset($retval)) {
+            $interface->player()->update_last_action_time($_SESSION['user_id'], $args['gameId']);
+        }
+
+        return $retval;
+    }
+
+    protected function get_interface_response_rejectGame($interface, $args) {
+        $retval = $interface->save_join_game_decision(
+            $_SESSION['user_id'],
+            $args['gameId'],
+            'reject'
+        );
+
+        if (isset($retval)) {
+            $interface->player()->update_last_action_time($_SESSION['user_id'], $args['gameId']);
         }
 
         return $retval;

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -140,6 +140,10 @@ class ApiResponder {
         return $interface->get_all_open_games($_SESSION['user_id']);
     }
 
+    protected function get_interface_response_loadNewGames($interface) {
+        return $interface->get_all_new_games($_SESSION['user_id']);
+    }
+
     protected function get_interface_response_loadActiveGames($interface) {
         // Once we return to the list of active games, we no longer need to remember
         // which ones we were skipping.

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -451,25 +451,11 @@ class ApiResponder {
         return $retval;
     }
 
-    protected function get_interface_response_acceptGame($interface, $args) {
+    protected function get_interface_response_reactToNewGame($interface, $args) {
         $retval = $interface->save_join_game_decision(
             $_SESSION['user_id'],
             $args['gameId'],
-            'accept'
-        );
-
-        if (isset($retval)) {
-            $interface->player()->update_last_action_time($_SESSION['user_id'], $args['gameId']);
-        }
-
-        return $retval;
-    }
-
-    protected function get_interface_response_rejectGame($interface, $args) {
-        $retval = $interface->save_join_game_decision(
-            $_SESSION['user_id'],
-            $args['gameId'],
-            'reject'
+            $args['action']
         );
 
         if (isset($retval)) {

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -23,6 +23,7 @@ class ApiSpec {
     private $automatableApiCalls = array(
         'loadNextPendingGame',
         'loadNextNewPost',
+        'loadNewGames',
         'loadActiveGames',
         'loadCompletedGames',
         'loadPlayerInfo',
@@ -343,6 +344,10 @@ class ApiSpec {
             'permitted' => array(
                 'logEntryLimit' => 'number',
             ),
+        ),
+        'loadNewGames' => array(
+            'mandatory' => array(),
+            'permitted' => array(),
         ),
         'loadNextPendingGame' => array(
             'mandatory' => array(),

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -158,15 +158,10 @@ class ApiSpec {
                 'previousGameId' => 'number',
             ),
         ),
-        'acceptGame' => array(
+        'reactToNewGame' => array(
             'mandatory' => array(
                 'gameId' => 'number',
-            ),
-            'permitted' => array(),
-        ),
-        'rejectGame' => array(
-            'mandatory' => array(
-                'gameId' => 'number',
+                'action' => 'string',
             ),
             'permitted' => array(),
         ),

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -522,6 +522,7 @@ class ApiSpec {
                     'arg_type' => 'string',
                     'maxlength' => 100,
                 ),
+                'autoaccept' => 'boolean',
                 'autopass' => 'boolean',
                 'fire_overshooting' => 'boolean',
                 'monitor_redirects_to_game' => 'boolean',

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -158,6 +158,18 @@ class ApiSpec {
                 'previousGameId' => 'number',
             ),
         ),
+        'acceptGame' => array(
+            'mandatory' => array(
+                'gameId' => 'number',
+            ),
+            'permitted' => array(),
+        ),
+        'rejectGame' => array(
+            'mandatory' => array(
+                'gameId' => 'number',
+            ),
+            'permitted' => array(),
+        ),
         'dismissGame' => array(
             'mandatory' => array(
                 'gameId' => 'number',

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -272,6 +272,34 @@ class DummyApiResponder {
         return $game;
     }
 
+    protected function get_interface_response_loadNewGames() {
+        $data = array(
+            'gameIdArray' => array(),
+            'opponentIdArray' => array(),
+            'opponentNameArray' => array(),
+            'myButtonNameArray' => array(),
+            'opponentButtonNameArray' => array(),
+            'nWinsArray' => array(),
+            'nLossesArray' => array(),
+            'nDrawsArray' => array(),
+            'nTargetWinsArray' => array(),
+            'isAwaitingActionArray' => array(),
+            'gameStateArray' => array(),
+            'statusArray' => array(),
+            'inactivityArray' => array(),
+            'inactivityRawArray' => array(),
+            'playerColorArray' => array(),
+            'opponentColorArray' => array(),
+        );
+
+//        for ($gameIdx = 1; $gameIdx <= 25; $gameIdx++) {
+//            $funcname = 'add_active_game_data_'.$gameIdx;
+//            $this->$funcname($data);
+//        }
+
+        return array($data, "All game details retrieved successfully.");
+    }
+
     protected function get_interface_response_loadActiveGames() {
         // Use the same fake games here which were described in loadGameData
         $data = array(

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -292,11 +292,6 @@ class DummyApiResponder {
             'opponentColorArray' => array(),
         );
 
-//        for ($gameIdx = 1; $gameIdx <= 25; $gameIdx++) {
-//            $funcname = 'add_new_game_data_'.$gameIdx;
-//            $this->$funcname($data);
-//        }
-
         return array($data, "All game details retrieved successfully.");
     }
 
@@ -1233,12 +1228,14 @@ class DummyApiResponder {
         return array(NULL, "function not implemented");
     }
 
-    protected function get_interface_response_acceptGame() {
-        return array(TRUE, 'Successfully accepted game');
-    }
-
-    protected function get_interface_response_rejectGame() {
-        return array(TRUE, 'Successfully rejected game');
+    protected function get_interface_response_reactToNewGame($args) {
+        if ('accept' == $args['action']) {
+            return array(TRUE, 'Successfully accepted game');
+        } elseif ('reject' == $args['action']) {
+            return array(TRUE, 'Successfully rejected game');
+        } else {
+            return FALSE;
+        }
     }
 
     protected function get_interface_response_dismissGame() {

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -1233,6 +1233,14 @@ class DummyApiResponder {
         return array(NULL, "function not implemented");
     }
 
+    protected function get_interface_response_acceptGame() {
+        return array(TRUE, 'Successfully accepted game');
+    }
+
+    protected function get_interface_response_rejectGame() {
+        return array(TRUE, 'Successfully rejected game');
+    }
+
     protected function get_interface_response_dismissGame() {
         return array(TRUE, 'Dismissing game succeeded');
     }

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -1229,10 +1229,8 @@ class DummyApiResponder {
     }
 
     protected function get_interface_response_reactToNewGame($args) {
-        if ('accept' == $args['action']) {
-            return array(TRUE, 'Successfully accepted game');
-        } elseif ('reject' == $args['action']) {
-            return array(TRUE, 'Successfully rejected game');
+        if (array_key_exists('action', $args)) {
+            return array(TRUE, 'Successfully ' . $args['action'] . 'ed game');
         } else {
             return FALSE;
         }

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -1112,6 +1112,7 @@ class DummyApiResponder {
                                 'dob_day' => 0,
                                 'gender' => '',
                                 'image_size' => NULL,
+                                'autoaccept' => TRUE,
                                 'autopass' => TRUE,
                                 'fire_overshooting' => FALSE,
                                 'uses_gravatar' => FALSE,

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -293,7 +293,7 @@ class DummyApiResponder {
         );
 
 //        for ($gameIdx = 1; $gameIdx <= 25; $gameIdx++) {
-//            $funcname = 'add_active_game_data_'.$gameIdx;
+//            $funcname = 'add_new_game_data_'.$gameIdx;
 //            $this->$funcname($data);
 //        }
 

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1909,6 +1909,12 @@ class BMGame {
     protected function update_game_state_end_game() {
     }
 
+    protected function do_next_step_rejected() {
+    }
+
+    protected function update_game_state_rejected() {
+    }
+
     // The variable $gameStateBreakpoint is used for debugging purposes only.
     // If used, the game will stop as soon as the game state becomes
 

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1942,7 +1942,7 @@ class BMGame {
 
             $this->do_next_step();
 
-            if (BMGameState::END_GAME === $this->gameState) {
+            if ($this->gameState >= BMGameState::END_GAME) {
                 return;
             }
 

--- a/src/engine/BMGameState.php
+++ b/src/engine/BMGameState.php
@@ -41,6 +41,9 @@ class BMGameState {
     // end game
     const END_GAME = 60;
 
+    // special states
+    const REJECTED = 251;
+
     /**
      * All possible game state strings
      *
@@ -65,7 +68,8 @@ class BMGameState {
                      'CHOOSE_TURBO_SWING',
                      'END_TURN',
                      'END_ROUND',
-                     'END_GAME');
+                     'END_GAME',
+                     'REJECTED');
     }
 
     /**

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -3116,6 +3116,7 @@ class BMInterface {
                                       ':id'         => $gameId));
 
             $game = $this->load_game($gameId);
+            $game->hasPlayerAcceptedGameArray[$emptyPlayerIdx] = TRUE;
             $this->save_game($game);
 
             return TRUE;

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1044,8 +1044,9 @@ class BMInterface {
             $this->choose_button($game, $buttonId, $buttonIdx);
         }
 
-        // ensure that the chat has also been cached
+        // ensure that the chat and game acceptance have also been cached
         $this->save_chat_log($game);
+        $this->save_player_game_decisions($game);
 
         $game = $this->load_game($game->gameId);
         $game->proceed_to_next_user_action();

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -454,6 +454,8 @@ class BMInterface {
         } else {
             $this->set_message("Rejected game $gameId");
         }
+
+        return TRUE;
     }
 
     public function load_api_game_data($playerId, $gameId, $logEntryLimit) {

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -2831,7 +2831,7 @@ class BMInterface {
         array &$sqlParameters
     ) {
         $restrictions = 'WHERE game_id = :game_id ';
-        if ($isChat && $game->gameState != BMGameState::END_GAME && !is_null($game->previousGameId)) {
+        if ($isChat && $game->gameState < BMGameState::END_GAME && !is_null($game->previousGameId)) {
             $restrictions .= 'OR game_id = :previous_game_id ';
             $sqlParameters[':previous_game_id'] = $game->previousGameId;
         }

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1983,43 +1983,55 @@ class BMInterface {
         }
     }
 
-    // Get all player games (either active or inactive) from the database
-    // No error checking - caller must do it
-    protected function get_all_games($playerId, $getActiveGames) {
+    // Get all player games of a certain type (new, active, or inactive) from
+    // the database.
+    protected function get_all_games($playerId, $type) {
+        try {
+            $this->set_message('All game details retrieved successfully.');
 
-        // the following SQL logic assumes that there are only two players per game
-        $query = 'SELECT v1.game_id,'.
-                 'v1.player_id AS opponent_id,'.
-                 'v1.player_name AS opponent_name,'.
-                 'v2.button_name AS my_button_name,'.
-                 'v1.button_name AS opponent_button_name,'.
-                 'v2.n_rounds_won AS n_wins,'.
-                 'v2.n_rounds_drawn AS n_draws,'.
-                 'v1.n_rounds_won AS n_losses,'.
-                 'v1.n_target_wins,'.
-                 'v2.is_awaiting_action,'.
-                 'g.game_state,'.
-                 's.name AS status, '.
-                 'UNIX_TIMESTAMP(g.last_action_time) AS last_action_timestamp '.
-                 'FROM game_player_view AS v1 '.
-                 'LEFT JOIN game_player_view AS v2 '.
-                 'ON v1.game_id = v2.game_id '.
-                 'LEFT JOIN game AS g '.
-                 'ON g.id = v1.game_id '.
-                 'LEFT JOIN game_status AS s '.
-                 'ON g.status_id = s.id '.
-                 'WHERE v2.player_id = :player_id '.
-                 'AND v1.player_id != v2.player_id ';
-        if ($getActiveGames) {
-            $query .= 'AND s.name = "ACTIVE" ';
-        } else {
-            $query .= 'AND s.name = "COMPLETE" AND v2.was_game_dismissed = 0 ';
+            // the following SQL logic assumes that there are only two players per game
+            $query = 'SELECT v1.game_id,'.
+                     'v1.player_id AS opponent_id,'.
+                     'v1.player_name AS opponent_name,'.
+                     'v2.button_name AS my_button_name,'.
+                     'v1.button_name AS opponent_button_name,'.
+                     'v2.n_rounds_won AS n_wins,'.
+                     'v2.n_rounds_drawn AS n_draws,'.
+                     'v1.n_rounds_won AS n_losses,'.
+                     'v1.n_target_wins,'.
+                     'v2.is_awaiting_action,'.
+                     'g.game_state,'.
+                     's.name AS status, '.
+                     'UNIX_TIMESTAMP(g.last_action_time) AS last_action_timestamp '.
+                     'FROM game_player_view AS v1 '.
+                     'LEFT JOIN game_player_view AS v2 '.
+                     'ON v1.game_id = v2.game_id '.
+                     'LEFT JOIN game AS g '.
+                     'ON g.id = v1.game_id '.
+                     'LEFT JOIN game_status AS s '.
+                     'ON g.status_id = s.id '.
+                     'WHERE v2.player_id = :player_id '.
+                     'AND v1.player_id != v2.player_id ';
+            if ('ACTIVE' == $type) {
+                $query .= 'AND s.name = "ACTIVE" AND g.game_state > 13 ';
+            } elseif ('NEW' == $type) {
+                $query .= 'AND s.name = "ACTIVE" AND g.game_state <= 13 ';
+            } elseif ('COMPLETE' == $type) {
+                $query .= 'AND s.name = "COMPLETE" AND v2.was_game_dismissed = 0 ';
+            }
+            $query .= 'ORDER BY g.last_action_time ASC;';
+            $statement = self::$conn->prepare($query);
+            $statement->execute(array(':player_id' => $playerId));
+
+            return self::read_game_list_from_db_results($playerId, $statement);
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::get_all_games: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Game detail get failed.');
+            return NULL;
         }
-        $query .= 'ORDER BY g.last_action_time ASC;';
-        $statement = self::$conn->prepare($query);
-        $statement->execute(array(':player_id' => $playerId));
-
-        return self::read_game_list_from_db_results($playerId, $statement);
     }
 
     protected function read_game_list_from_db_results($playerId, $results) {
@@ -2094,32 +2106,16 @@ class BMInterface {
                      'opponentColorArray'      => $opponentColorArray);
     }
 
+    public function get_all_new_games($playerId) {
+        return $this->get_all_games($playerId, 'NEW');
+    }
+
     public function get_all_active_games($playerId) {
-        try {
-            $this->set_message('All game details retrieved successfully.');
-            return $this->get_all_games($playerId, TRUE);
-        } catch (Exception $e) {
-            error_log(
-                'Caught exception in BMInterface::get_all_active_games: ' .
-                $e->getMessage()
-            );
-            $this->set_message('Game detail get failed.');
-            return NULL;
-        }
+        return $this->get_all_games($playerId, 'ACTIVE');
     }
 
     public function get_all_completed_games($playerId) {
-        try {
-            $this->set_message('All game details retrieved successfully.');
-            return $this->get_all_games($playerId, FALSE);
-        } catch (Exception $e) {
-            error_log(
-                'Caught exception in BMInterface::get_all_active_games: ' .
-                $e->getMessage()
-            );
-            $this->set_message('Game detail get failed.');
-            return NULL;
-        }
+        return $this->get_all_games($playerId, 'COMPLETE');
     }
 
     public function get_all_open_games($currentPlayerId) {

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -429,6 +429,10 @@ class BMInterface {
         $decisionFlag = ('accept' == $decision);
         $game->hasPlayerAcceptedGameArray[$playerIdx] = $decisionFlag;
 
+        if (!$decisionFlag) {
+            $game->gameState = BMGameState::REJECTED;
+        }
+
         $this->save_game($game);
 
         if ($decisionFlag) {
@@ -1114,6 +1118,8 @@ class BMInterface {
     protected function get_game_status($game) {
         if (BMGameState::END_GAME == $game->gameState) {
             $status = 'COMPLETE';
+        } elseif (BMGameState::REJECTED == $game->gameState) {
+            $status = 'REJECTED';
         } elseif (in_array(NULL, $game->playerIdArray) ||
                   in_array(NULL, $game->buttonArray)) {
             $status = 'OPEN';

--- a/src/engine/BMInterfacePlayer.php
+++ b/src/engine/BMInterfacePlayer.php
@@ -71,6 +71,7 @@ class BMInterfacePlayer extends BMInterface {
             'dob_day' => (int)$infoArray['dob_day'],
             'gender' => $infoArray['gender'],
             'image_size' => $image_size,
+            'autoaccept' => (bool)$infoArray['autoaccept'],
             'autopass' => (bool)$infoArray['autopass'],
             'fire_overshooting' => (bool)$infoArray['fire_overshooting'],
             'uses_gravatar' => (bool)$infoArray['uses_gravatar'],

--- a/src/ui/js/Api.js
+++ b/src/ui/js/Api.js
@@ -276,6 +276,39 @@ var Api = (function () {
   };
 
   ////////////////////////////////////////////////////////////////////////
+  // Load and parse the current player's list of new games
+
+  my.getNewGamesData = function(callbackfunc) {
+    my.apiParsePost(
+      {'type': 'loadNewGames', },
+      'new_games',
+      my.parseNewGamesData,
+      callbackfunc,
+      callbackfunc
+    );
+  };
+
+  my.parseNewGamesData = function(data) {
+    my.new_games.games = [];
+    my.new_games.nGames = data.gameIdArray.length;
+    var i = 0;
+    while (i < my.new_games.nGames) {
+      var gameInfo = {
+        'gameId': data.gameIdArray[i],
+        'opponentId': data.opponentIdArray[i],
+        'opponentName': data.opponentNameArray[i],
+        'playerButtonName': data.myButtonNameArray[i],
+        'opponentButtonName': data.opponentButtonNameArray[i],
+        'isAwaitingAction': data.isAwaitingActionArray[i],
+        'maxWins': data.nTargetWinsArray[i],
+      };
+      my.new_games.games.push(gameInfo);
+      i += 1;
+    }
+    return true;
+  };
+
+  ////////////////////////////////////////////////////////////////////////
   // Load and parse the current player's list of active games
 
   my.getActiveGamesData = function(callbackfunc) {
@@ -327,7 +360,7 @@ var Api = (function () {
   };
 
   ////////////////////////////////////////////////////////////////////////
-  // Load and parse the current player's list of active games
+  // Load and parse the current player's list of completed games
 
   my.getCompletedGamesData = function(callbackfunc) {
     my.apiParsePost(

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -26,6 +26,8 @@ Game.GAME_STATE_END_TURN = 'END_TURN';
 Game.GAME_STATE_END_ROUND = 'END_ROUND';
 Game.GAME_STATE_END_GAME = 'END_GAME';
 
+Game.GAME_STATE_REJECTED = 'REJECTED';
+
 // Convenience HTML used in the mat layout to break text
 Game.SPACE_BULLET = ' &nbsp;&bull;&nbsp; ';
 
@@ -119,6 +121,11 @@ Game.showStatePage = function() {
     if (Api.game.gameState == Game.GAME_STATE_CHOOSE_JOIN_GAME) {
       Game.page =
         $('<p>', {'text': 'This game hasn\'t started yet.', });
+      Game.form = null;
+      includeFooter = false;
+    } else if (Api.game.gameState == Game.GAME_STATE_REJECTED) {
+      Game.page =
+        $('<p>', {'text': 'This game has been rejected.', });
       Game.form = null;
       includeFooter = false;
     } else if (Api.game.gameState == Game.GAME_STATE_SPECIFY_DICE) {

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -116,7 +116,12 @@ Game.showStatePage = function() {
 
   // Figure out what to do next based on the game state
   if (Api.game.load_status == 'ok') {
-    if (Api.game.gameState == Game.GAME_STATE_SPECIFY_DICE) {
+    if (Api.game.gameState == Game.GAME_STATE_CHOOSE_JOIN_GAME) {
+      Game.page =
+        $('<p>', {'text': 'This game hasn\'t started yet.', });
+      Game.form = null;
+      includeFooter = false;
+    } else if (Api.game.gameState == Game.GAME_STATE_SPECIFY_DICE) {
       if (Api.game.isParticipant) {
         if (Api.game.player.waitingOnAction) {
           Game.actionSpecifyDiceActive();

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -436,21 +436,28 @@ Overview.pageAddGameTableNew = function() {
 
     decideTd = $('<td>');
     gameRow.append(decideTd);
-    acceptLink = $('<a>', {
-      'text': 'Accept',
-      'href': '#',
-      'data-gameId': gameInfo.gameId,
-    });
-    acceptLink.click(Overview.formAcceptGame);
+
+    if (Api.new_games.games[0].isAwaitingAction) {
+      acceptLink = $('<a>', {
+        'text': 'Accept',
+        'href': '#',
+        'data-gameId': gameInfo.gameId,
+      });
+      acceptLink.click(Overview.formAcceptGame);
+
+      decideTd.append('[')
+              .append(acceptLink)
+              .append('] / ');
+    }
+
     rejectLink = $('<a>', {
       'text': 'Reject',
       'href': '#',
       'data-gameId': gameInfo.gameId,
     });
     rejectLink.click(Overview.formRejectGame);
+
     decideTd.append('[')
-            .append(acceptLink)
-            .append('] / [')
             .append(rejectLink)
             .append(']');
 

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -441,13 +441,13 @@ Overview.pageAddGameTableNew = function() {
       'href': '#',
       'data-gameId': gameInfo.gameId,
     });
-    acceptLink.click();
+    acceptLink.click(Overview.formAcceptGame);
     rejectLink = $('<a>', {
       'text': '[Reject]',
       'href': '#',
       'data-gameId': gameInfo.gameId,
     });
-    rejectLink.click();
+    rejectLink.click(Overview.formRejectGame);
     decideTd.append(acceptLink).append(' / ').append(rejectLink);
 
     i += 1;
@@ -556,6 +556,28 @@ Overview.pageAddIntroText = function() {
   }));
   infopar.append(', and is used with permission.');
   Overview.page.append(infopar);
+};
+
+Overview.formAcceptGame = function(e) {
+  e.preventDefault();
+  var args = { 'type': 'acceptGame', 'gameId': $(this).attr('data-gameId'), };
+  var messages = {
+    'ok': { 'type': 'fixed', 'text': 'Successfully accepted game', },
+    'notok': { 'type': 'server' },
+  };
+  Api.apiFormPost(args, messages, $(this), Overview.showLoggedInPage,
+    Overview.showLoggedInPage);
+};
+
+Overview.formRejectGame = function(e) {
+  e.preventDefault();
+  var args = { 'type': 'rejectGame', 'gameId': $(this).attr('data-gameId'), };
+  var messages = {
+    'ok': { 'type': 'fixed', 'text': 'Successfully rejected game', },
+    'notok': { 'type': 'server' },
+  };
+  Api.apiFormPost(args, messages, $(this), Overview.showLoggedInPage,
+    Overview.showLoggedInPage);
 };
 
 Overview.formDismissGame = function(e) {

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -20,10 +20,10 @@ Overview.STALENESS_SECS = Overview.STALENESS_DAYS * 24 * 60 * 60;
 // * Overview.showLoggedInPage() is the landing function.  Always call this
 //   first when logged out. This calls Overview.pageAddIntroText()
 // * Overview.getOverview() asks the API for information about the
-//   player's overview status (currently, the lists of active and completed
-//   games, and potentially the user's preferences).
-//   It sets Api.active_games, Api.completed_games and potentially
-//   Api.user_prefs.  If successful, it calls Overview.showPage().
+//   player's overview status (currently, the lists of new, active, and
+//   completed games, and potentially the user's preferences).
+//   It sets Api.new_games, Api.active_games, Api.completed_games and
+//   potentially Api.user_prefs.  If successful, it calls Overview.showPage().
 // * Overview.showPage() assembles the page contents as a variable.
 //
 // N.B. There is no form submission on this page (aside from the [Dismiss]
@@ -83,6 +83,7 @@ Overview.showPreferredOverview = function() {
 
 Overview.getOverview = function(callback) {
   Env.callAsyncInParallel([
+    Api.getNewGamesData,
     Api.getActiveGamesData,
     Api.getCompletedGamesData,
   ], callback);
@@ -113,7 +114,9 @@ Overview.showPage = function() {
     setTimeout(Overview.executeMonitor, Overview.MONITOR_TIMEOUT * 1000);
   }
 
-  if ((Api.active_games.nGames === 0) && (Api.completed_games.nGames === 0)) {
+  if ((Api.new_games.nGames === 0) &&
+      (Api.active_games.nGames === 0) &&
+      (Api.completed_games.nGames === 0)) {
     Env.message = {
       'type': 'none',
       'text': 'You have no games',
@@ -163,6 +166,7 @@ Overview.completeMonitor = function() {
 
 // Add tables for types of existing games
 Overview.pageAddGameTables = function() {
+  Overview.pageAddGameTable('new', 'New games', false);
   Overview.pageAddGameTable('finished', 'Completed games', false);
   Overview.pageAddGameTable('awaitingPlayer', 'Active games', false);
   Overview.pageAddGameTable('awaitingOpponent', 'Active games', true);
@@ -205,6 +209,11 @@ Overview.pageAddGameTable = function(
     sectionHeader,
     reverseSortOrder
   ) {
+  if (gameType == 'new') {
+    Overview.pageAddGameTableNew();
+    return;
+  }
+
   if (typeof reverseSortOrder === 'undefined') {
     reverseSortOrder = false;
   }
@@ -366,6 +375,83 @@ Overview.pageAddGameTable = function(
     footRow.append(footCol);
     tableFoot.append(footRow);
     tableBody.closest('table').append(tableFoot);
+  }
+};
+
+Overview.pageAddGameTableNew = function() {
+  var gamesource = Api.new_games.games;
+  var tableClass = 'newGames';
+
+  if (gamesource.length === 0) {
+    return;
+  }
+
+  var tableBody = Overview.page.find('table.' + tableClass + ' tbody');
+  var tableDiv = $('<div>');
+  tableDiv.append($('<h2>', {'text': 'New games', }));
+  var table = $('<table>', { 'class': 'gameList ' + tableClass, });
+  tableDiv.append(table);
+  Overview.page.append(tableDiv);
+
+  var tableHead = $('<thead>');
+  var headerRow = $('<tr>');
+  headerRow.append($('<th>', {'text': 'Game #', }));
+  headerRow.append($('<th>', {'text': 'Your Button', }));
+  headerRow.append($('<th>', {'text': 'Opponent\'s Button', }));
+  headerRow.append($('<th>', {'text': 'Opponent', }));
+  headerRow.append($('<th>', {'text': 'Max wins', }));
+  headerRow.append($('<th>', {'text': 'Action', 'colspan': '2', }));
+
+  tableHead.append(headerRow);
+  table.append(tableHead);
+
+  tableBody = $('<tbody>');
+  table.append(tableBody);
+
+  var i = 0;
+  var gameInfo;
+  var gameRow;
+  var decideTd;
+  var acceptLink;
+  var rejectLink;
+  while (i < gamesource.length) {
+    gameInfo = gamesource[i];
+
+    gameRow = $('<tr>');
+    gameRow.append($('<td>', {
+      'text': 'Game ' + gameInfo.gameId,
+    }));
+    gameRow.append($('<td>').append(
+      Env.buildButtonLink(gameInfo.playerButtonName)
+    ));
+    gameRow.append($('<td>').append(
+      Env.buildButtonLink(gameInfo.opponentButtonName)
+    ));
+    gameRow.append($('<td>').append(
+      Env.buildProfileLink(gameInfo.opponentName)
+    ));
+    gameRow.append($('<td>', {
+      'text': gameInfo.maxWins,
+    }));
+
+    decideTd = $('<td>');
+    gameRow.append(decideTd);
+    acceptLink = $('<a>', {
+      'text': '[Accept]',
+      'href': '#',
+      'data-gameId': gameInfo.gameId,
+    });
+    acceptLink.click();
+    rejectLink = $('<a>', {
+      'text': '[Reject]',
+      'href': '#',
+      'data-gameId': gameInfo.gameId,
+    });
+    rejectLink.click();
+    decideTd.append(acceptLink).append(' / ').append(rejectLink);
+
+    i += 1;
+    tableBody.append(gameRow);
   }
 };
 

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -571,7 +571,11 @@ Overview.pageAddIntroText = function() {
 
 Overview.formAcceptGame = function(e) {
   e.preventDefault();
-  var args = { 'type': 'acceptGame', 'gameId': $(this).attr('data-gameId'), };
+  var args = {
+    'type': 'reactToNewGame',
+    'gameId': $(this).attr('data-gameId'),
+    'action': 'accept',
+  };
   var messages = {
     'ok': { 'type': 'fixed', 'text': 'Successfully accepted game', },
     'notok': { 'type': 'server' },
@@ -582,7 +586,11 @@ Overview.formAcceptGame = function(e) {
 
 Overview.formRejectGame = function(e) {
   e.preventDefault();
-  var args = { 'type': 'rejectGame', 'gameId': $(this).attr('data-gameId'), };
+  var args = {
+    'type': 'reactToNewGame',
+    'gameId': $(this).attr('data-gameId'),
+    'action': 'reject',
+  };
   var messages = {
     'ok': { 'type': 'fixed', 'text': 'Successfully rejected game', },
     'notok': { 'type': 'server' },

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -437,18 +437,22 @@ Overview.pageAddGameTableNew = function() {
     decideTd = $('<td>');
     gameRow.append(decideTd);
     acceptLink = $('<a>', {
-      'text': '[Accept]',
+      'text': 'Accept',
       'href': '#',
       'data-gameId': gameInfo.gameId,
     });
     acceptLink.click(Overview.formAcceptGame);
     rejectLink = $('<a>', {
-      'text': '[Reject]',
+      'text': 'Reject',
       'href': '#',
       'data-gameId': gameInfo.gameId,
     });
     rejectLink.click(Overview.formRejectGame);
-    decideTd.append(acceptLink).append(' / ').append(rejectLink);
+    decideTd.append('[')
+            .append(acceptLink)
+            .append('] / [')
+            .append(rejectLink)
+            .append(']');
 
     i += 1;
     tableBody.append(gameRow);

--- a/src/ui/js/UserPrefs.js
+++ b/src/ui/js/UserPrefs.js
@@ -173,6 +173,11 @@ UserPrefs.actionSetPrefs = function() {
   var autoBlurb = 'These preferences configure things that the site can do ' +
     'automatically for you.';
   var autoPrefs = {
+    'autoaccept': {
+      'text': 'Automatically accept challenges from other players',
+      'type': 'checkbox',
+      'checked': Api.user_prefs.autoaccept,
+    },
     'autopass': {
       'text': 'Automatically pass when you have no valid attack',
       'type': 'checkbox',
@@ -370,6 +375,7 @@ UserPrefs.formSetPrefs = function() {
   var image_size = $('#userprefs_image_size').val();
   var homepage = $('#userprefs_homepage').val();
   var comment = $('#userprefs_comment').val();
+  var autoaccept = $('#userprefs_autoaccept').prop('checked');
   var autopass = $('#userprefs_autopass').prop('checked');
   var fire_overshooting = $('#userprefs_fire_overshooting').prop('checked');
   var monitor_redirects_to_game =
@@ -476,6 +482,7 @@ UserPrefs.formSetPrefs = function() {
       'uses_gravatar': uses_gravatar,
       'homepage': homepage,
       'comment': comment,
+      'autoaccept': autoaccept,
       'autopass': autopass,
       'fire_overshooting': fire_overshooting,
       'monitor_redirects_to_game': monitor_redirects_to_game,

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -2213,8 +2213,6 @@ class responderTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @group fulltest_deps
-     *
      * This is the same game setup as in
      * BMInterfaceTest::test_option_reset_bug(), but tested from
      * the API point of view, and we play long enough to set option dice in two consecutive rounds.

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1564,6 +1564,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'gender' => '',
             'comment' => '',
             'homepage' => '',
+            'autoaccept' => 'true',
             'autopass' => 'true',
             'fire_overshooting' => 'false',
             'uses_gravatar' => 'false',

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1124,9 +1124,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
         // Since user IDs are sequential, this is a good time to test the behavior of
         // to verify the behavior of loadProfileInfo() on an invalid player name.
         // However, mock_test_user_login() ensures that users 1-5 are created, so skip those
-        // (If you create real user responder006, increment badUserNum's minimum)
+        // (If you create real user responder007, increment badUserNum's minimum)
         $_SESSION = $this->mock_test_user_login();
-        $badUserNum = max(6, $trynum);
+        $badUserNum = max(7, $trynum);
         $args = array(
            'type' => 'loadProfileInfo',
            'playerName' =>  'responder' . sprintf('%03d', $badUserNum),

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1252,6 +1252,19 @@ class responderTest extends PHPUnit_Framework_TestCase {
             "Real and dummy game lists should have matching structures");
     }
 
+    public function test_request_loadNewGames() {
+        $this->verify_login_required('loadNewGames');
+
+        $_SESSION = $this->mock_test_user_login();
+        $this->verify_invalid_arg_rejected('loadNewGames');
+
+        $args = array('type' => 'loadNewGames');
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+
+        $this->assertEquals('ok', $dummyval['status'], 'Dummy load of new games should succeed');
+    }
+
     public function test_request_loadActiveGames() {
         $this->verify_login_required('loadActiveGames');
 

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1552,6 +1552,37 @@ class responderTest extends PHPUnit_Framework_TestCase {
     public function test_request_savePlayerInfo() {
         $this->verify_login_required('savePlayerInfo');
 
+        $args = array(
+            'type' => 'savePlayerInfo',
+            'name_irl' => 'Test User',
+            'is_email_public' => 'False',
+            'dob_month' => '2',
+            'dob_day' => '29',
+            'gender' => '',
+            'comment' => '',
+            'homepage' => '',
+            'autoaccept' => 'true',
+            'autopass' => 'false',
+            'fire_overshooting' => 'false',
+            'uses_gravatar' => 'false',
+            'player_color' => '#dd99dd',
+            'opponent_color' => '#ddffdd',
+            'neutral_color_a' => '#cccccc',
+            'neutral_color_b' => '#dddddd',
+            'monitor_redirects_to_game' => 'false',
+            'monitor_redirects_to_forum' => 'false',
+            'automatically_monitor' => 'false',
+        );
+        $_SESSION = $this->mock_test_user_login('responder001');
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
+
+        $_SESSION = $this->mock_test_user_login('responder002');
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
+
         $_SESSION = $this->mock_test_user_login('responder003');
         $this->verify_invalid_arg_rejected('savePlayerInfo');
 
@@ -2182,6 +2213,8 @@ class responderTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @group fulltest_deps
+     *
      * This is the same game setup as in
      * BMInterfaceTest::test_option_reset_bug(), but tested from
      * the API point of view, and we play long enough to set option dice in two consecutive rounds.

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -651,7 +651,14 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         $args = array('type' => 'createUser', 'password' => 't');
 
-        $userarray = array('responder001', 'responder002', 'responder003', 'responder004', 'responder005');
+        $userarray = array(
+            'responder001',
+            'responder002',
+            'responder003',
+            'responder004',
+            'responder005',
+            'responder006'
+        );
 
         // Hack: we don't know in advance whether each user creation
         // will succeed or fail.  Therefore, repeat each one so we
@@ -781,6 +788,29 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $retval = $this->verify_api_success($args);
         // FIXME: once #1274 is resolved, actually test the message here
         // $this->assertEquals('foobar', $retval['message']);
+        $this->assertEquals(TRUE, $retval['data']);
+        return $retval['data'];
+    }
+
+    /**
+     * verify_api_reactToNewGame() - helper routine which calls the API
+     * reactToNewGame method using provided fake die rolls, and makes
+     * standard assertions about its return value
+     */
+    protected function verify_api_reactToNewGame($postJoinDieRolls, $gameId, $action) {
+        global $BM_RAND_VALS;
+        $BM_RAND_VALS = $postJoinDieRolls;
+        $args = array(
+            'type' => 'reactToNewGame',
+            'gameId' => $gameId,
+            'action' => $action,
+        );
+        $retval = $this->verify_api_success($args);
+        if ('accept' == $action) {
+            $this->assertEquals('Joined game ' . $gameId, $retval['message']);
+        } elseif ('reject' == $action) {
+            $this->assertEquals('Rejected game ' . $gameId, $retval['message']);
+        }
         $this->assertEquals(TRUE, $retval['data']);
         return $retval['data'];
     }
@@ -1116,8 +1146,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
      * @group fulltest_deps
      *
      * As a side effect, this test actually enables preferences which some other tests need:
-     * * turn on autopass for responder003, responder004, and responder005
+     * * turn on autopass for responder003-006
      * * turn on fire_overshooting for responder005
+     * * turn off autoaccept for responder006
      */
     public function test_request_savePlayerInfo() {
         $this->verify_login_required('savePlayerInfo');
@@ -1192,6 +1223,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         $args['fire_overshooting'] = 'true';
         $_SESSION = $this->mock_test_user_login('responder005');
+        $retval = $this->verify_api_success($args);
+
+        $args['fire_overshooting'] = 'false';
+        $args['autoaccept'] = 'false';
+        $_SESSION = $this->mock_test_user_login('responder006');
         $retval = $this->verify_api_success($args);
     }
 
@@ -1352,6 +1388,67 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $dummyval = $this->dummy->process_request($args);
 
         $this->assertEquals('ok', $dummyval['status'], 'Dummy load of new games should succeed');
+    }
+
+    public function test_request_reactToNewGameAccept() {
+        $this->verify_login_required('reactToNewGame');
+
+        $_SESSION = $this->mock_test_user_login('responder003');
+        $this->verify_invalid_arg_rejected('reactToNewGame');
+        $this->verify_mandatory_args_required(
+            'reactToNewGame',
+            array('gameId' => 21, 'action' => 'accept')
+        );
+
+        $_SESSION = $this->mock_test_user_login('responder004');
+        $gameId = $this->verify_api_createGame(
+            array(),
+            'responder004', 'responder006', 'Avis', 'Avis', '3'
+        );
+
+        $_SESSION = $this->mock_test_user_login('responder006');
+        $retdata = $this->verify_api_reactToNewGame(
+            array(1, 1, 1, 1, 2, 2, 2, 2),
+            $gameId,
+            'accept'
+        );
+
+        $args = array(
+            'type' => 'reactToNewGame',
+            'gameId' => $gameId,
+            'action' => 'accept',
+        );
+        $dummyval = $this->dummy->process_request($args);
+        $dummydata = $dummyval['data'];
+
+        $this->assertEquals($retdata, $dummydata,
+            "Real and dummy game joining return values should both be true");
+    }
+
+    public function test_request_reactToNewGameReject() {
+        $_SESSION = $this->mock_test_user_login('responder004');
+        $gameId = $this->verify_api_createGame(
+            array(),
+            'responder004', 'responder006', 'Avis', 'Avis', '3'
+        );
+
+        $_SESSION = $this->mock_test_user_login('responder006');
+        $retdata = $this->verify_api_reactToNewGame(
+            array(),
+            $gameId,
+            'reject'
+        );
+
+        $args = array(
+            'type' => 'reactToNewGame',
+            'gameId' => $gameId,
+            'action' => 'reject',
+        );
+        $dummyval = $this->dummy->process_request($args);
+        $dummydata = $dummyval['data'];
+
+        $this->assertEquals($retdata, $dummydata,
+            "Real and dummy game joining return values should both be true");
     }
 
     /**

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1112,6 +1112,92 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
     }
 
+    /**
+     * @group fulltest_deps
+     *
+     * As a side effect, this test actually enables preferences which some other tests need:
+     * * turn on autopass for responder003, responder004, and responder005
+     * * turn on fire_overshooting for responder005
+     */
+    public function test_request_savePlayerInfo() {
+        $this->verify_login_required('savePlayerInfo');
+
+        $args = array(
+            'type' => 'savePlayerInfo',
+            'name_irl' => 'Test User',
+            'is_email_public' => 'False',
+            'dob_month' => '2',
+            'dob_day' => '29',
+            'gender' => '',
+            'comment' => '',
+            'homepage' => '',
+            'autoaccept' => 'true',
+            'autopass' => 'false',
+            'fire_overshooting' => 'false',
+            'uses_gravatar' => 'false',
+            'player_color' => '#dd99dd',
+            'opponent_color' => '#ddffdd',
+            'neutral_color_a' => '#cccccc',
+            'neutral_color_b' => '#dddddd',
+            'monitor_redirects_to_game' => 'false',
+            'monitor_redirects_to_forum' => 'false',
+            'automatically_monitor' => 'false',
+        );
+        $_SESSION = $this->mock_test_user_login('responder001');
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
+
+        $_SESSION = $this->mock_test_user_login('responder002');
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
+
+        $_SESSION = $this->mock_test_user_login('responder003');
+        $this->verify_invalid_arg_rejected('savePlayerInfo');
+
+        $args = array(
+            'type' => 'savePlayerInfo',
+            'name_irl' => 'Test User',
+            'is_email_public' => 'False',
+            'dob_month' => '2',
+            'dob_day' => '29',
+            'gender' => '',
+            'comment' => '',
+            'homepage' => '',
+            'autoaccept' => 'true',
+            'autopass' => 'true',
+            'fire_overshooting' => 'false',
+            'uses_gravatar' => 'false',
+            'player_color' => '#dd99dd',
+            'opponent_color' => '#ddffdd',
+            'neutral_color_a' => '#cccccc',
+            'neutral_color_b' => '#dddddd',
+            'monitor_redirects_to_game' => 'false',
+            'monitor_redirects_to_forum' => 'false',
+            'automatically_monitor' => 'false',
+        );
+        $retval = $this->verify_api_success($args);
+        $dummyval = $this->dummy->process_request($args);
+        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
+
+        $retdata = $retval['data'];
+        $dummydata = $dummyval['data'];
+        $this->assertTrue(
+            $this->object_structures_match($dummydata, $retdata),
+            "Real and dummy player data update return values should have matching structures");
+
+        $_SESSION = $this->mock_test_user_login('responder004');
+        $retval = $this->verify_api_success($args);
+
+        $args['fire_overshooting'] = 'true';
+        $_SESSION = $this->mock_test_user_login('responder005');
+        $retval = $this->verify_api_success($args);
+    }
+
+    /**
+     * @depends test_request_savePlayerInfo
+     */
     public function test_request_createGame() {
         $this->verify_login_required('createGame');
 
@@ -1158,6 +1244,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
             "Real and dummy game creation return values should have matching structures");
     }
 
+    /**
+     * @depends test_request_savePlayerInfo
+     */
     public function test_request_searchGameHistory() {
         $this->verify_login_required('searchGameHistory');
 
@@ -1265,6 +1354,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('ok', $dummyval['status'], 'Dummy load of new games should succeed');
     }
 
+    /**
+     * @depends test_request_savePlayerInfo
+     */
     public function test_request_loadActiveGames() {
         $this->verify_login_required('loadActiveGames');
 
@@ -1458,6 +1550,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
         }
     }
 
+    /**
+     * @depends test_request_savePlayerInfo
+     */
     public function test_request_loadGameData() {
         $this->verify_login_required('loadGameData');
 
@@ -1540,89 +1635,6 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue(
             $this->object_structures_match($dummydata, $retdata, True),
             "Real and dummy player data should have matching structures");
-    }
-
-    /**
-     * @group fulltest_deps
-     *
-     * As a side effect, this test actually enables preferences which some other tests need:
-     * * turn on autopass for responder003, responder004, and responder005
-     * * turn on fire_overshooting for responder005
-     */
-    public function test_request_savePlayerInfo() {
-        $this->verify_login_required('savePlayerInfo');
-
-        $args = array(
-            'type' => 'savePlayerInfo',
-            'name_irl' => 'Test User',
-            'is_email_public' => 'False',
-            'dob_month' => '2',
-            'dob_day' => '29',
-            'gender' => '',
-            'comment' => '',
-            'homepage' => '',
-            'autoaccept' => 'true',
-            'autopass' => 'false',
-            'fire_overshooting' => 'false',
-            'uses_gravatar' => 'false',
-            'player_color' => '#dd99dd',
-            'opponent_color' => '#ddffdd',
-            'neutral_color_a' => '#cccccc',
-            'neutral_color_b' => '#dddddd',
-            'monitor_redirects_to_game' => 'false',
-            'monitor_redirects_to_forum' => 'false',
-            'automatically_monitor' => 'false',
-        );
-        $_SESSION = $this->mock_test_user_login('responder001');
-        $retval = $this->verify_api_success($args);
-        $dummyval = $this->dummy->process_request($args);
-        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
-
-        $_SESSION = $this->mock_test_user_login('responder002');
-        $retval = $this->verify_api_success($args);
-        $dummyval = $this->dummy->process_request($args);
-        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
-
-        $_SESSION = $this->mock_test_user_login('responder003');
-        $this->verify_invalid_arg_rejected('savePlayerInfo');
-
-        $args = array(
-            'type' => 'savePlayerInfo',
-            'name_irl' => 'Test User',
-            'is_email_public' => 'False',
-            'dob_month' => '2',
-            'dob_day' => '29',
-            'gender' => '',
-            'comment' => '',
-            'homepage' => '',
-            'autoaccept' => 'true',
-            'autopass' => 'true',
-            'fire_overshooting' => 'false',
-            'uses_gravatar' => 'false',
-            'player_color' => '#dd99dd',
-            'opponent_color' => '#ddffdd',
-            'neutral_color_a' => '#cccccc',
-            'neutral_color_b' => '#dddddd',
-            'monitor_redirects_to_game' => 'false',
-            'monitor_redirects_to_forum' => 'false',
-            'automatically_monitor' => 'false',
-        );
-        $retval = $this->verify_api_success($args);
-        $dummyval = $this->dummy->process_request($args);
-        $this->assertEquals('ok', $dummyval['status'], "dummy responder should succeed");
-
-        $retdata = $retval['data'];
-        $dummydata = $dummyval['data'];
-        $this->assertTrue(
-            $this->object_structures_match($dummydata, $retdata),
-            "Real and dummy player data update return values should have matching structures");
-
-        $_SESSION = $this->mock_test_user_login('responder004');
-        $retval = $this->verify_api_success($args);
-
-        $args['fire_overshooting'] = 'true';
-        $_SESSION = $this->mock_test_user_login('responder005');
-        $retval = $this->verify_api_success($args);
     }
 
     public function test_request_loadProfileInfo() {

--- a/test/src/engine/BMGameStateTest.php
+++ b/test/src/engine/BMGameStateTest.php
@@ -38,6 +38,8 @@ class BMGameStateTest extends PHPUnit_Framework_TestCase {
                           BMGameState::END_ROUND);
         $this->assertTrue(BMGameState::END_ROUND <
                           BMGameState::END_GAME);
+        $this->assertTrue(BMGameState::END_GAME <
+                          BMGameState::REJECTED);
     }
 
     /**

--- a/test/src/engine/BMInterface000Test.php
+++ b/test/src/engine/BMInterface000Test.php
@@ -41,11 +41,38 @@ class BMInterface000Test extends BMInterfaceTestAbstract {
 
         $this->assertTrue($created_real,
             "Creation of $username user should be reported as success");
+
+        $infoArray = array(
+            'name_irl' => '',
+            'is_email_public' => FALSE,
+            'dob_month' => 0,
+            'dob_day' => 0,
+            'gender' => '',
+            'comment' => '',
+            'monitor_redirects_to_game' => 0,
+            'monitor_redirects_to_forum' => 0,
+            'automatically_monitor' => 0,
+            'autoaccept' => 1,
+            'autopass' => 0,
+            'fire_overshooting' => 0
+        );
+        $addlInfo = array('dob_month' => 0, 'dob_day' => 0, 'homepage' => '');
+
+        $this->interfacePlayer->set_player_info(
+            $createResult['playerId'],
+            $infoArray,
+            $addlInfo
+        );
         self::$userId1WithoutAutopass = (int)$createResult['playerId'];
 
         $username = 'interface' . sprintf('%03d', $trynum);
         $email = $username . '@example.com';
         $createResult = $this->newuserObject->create_user($username, 't', $email);
+        $this->interfacePlayer->set_player_info(
+            $createResult['playerId'],
+            $infoArray,
+            $addlInfo
+        );
         self::$userId2WithoutAutopass = (int)$createResult['playerId'];
 
         $trynum++;

--- a/test/src/engine/BMInterface000Test.php
+++ b/test/src/engine/BMInterface000Test.php
@@ -63,6 +63,7 @@ class BMInterface000Test extends BMInterfaceTestAbstract {
             'monitor_redirects_to_game' => 0,
             'monitor_redirects_to_forum' => 0,
             'automatically_monitor' => 0,
+            'autoaccept' => 1,
             'autopass' => 1,
             'fire_overshooting' => 0
         );
@@ -85,5 +86,33 @@ class BMInterface000Test extends BMInterfaceTestAbstract {
             $addlInfo
         );
         self::$userId4WithAutopass = (int)$createResult['playerId'];
+
+        $trynum++;
+        $username = 'interface' . sprintf('%03d', $trynum);
+        $email = $username . '@example.com';
+        $createResult = $this->newuserObject->create_user($username, 't', $email);
+
+        $infoArray = array(
+            'name_irl' => '',
+            'is_email_public' => FALSE,
+            'dob_month' => 0,
+            'dob_day' => 0,
+            'gender' => '',
+            'comment' => '',
+            'monitor_redirects_to_game' => 0,
+            'monitor_redirects_to_forum' => 0,
+            'automatically_monitor' => 0,
+            'autoaccept' => 0,
+            'autopass' => 1,
+            'fire_overshooting' => 0
+        );
+        $addlInfo = array('dob_month' => 0, 'dob_day' => 0, 'homepage' => '');
+
+        $this->interfacePlayer->set_player_info(
+            $createResult['playerId'],
+            $infoArray,
+            $addlInfo
+        );
+        self::$userId5WithoutAutoaccept = (int)$createResult['playerId'];
     }
 }

--- a/test/src/engine/BMInterfaceTest.php
+++ b/test/src/engine/BMInterfaceTest.php
@@ -599,9 +599,45 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertTrue(is_array($game->hasPlayerAcceptedGameArray));
         $this->assertCount(2, $game->hasPlayerAcceptedGameArray);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
+        $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
+
+        $retval = $this->object->create_game(
+            array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
+            array('Bauer', 'Stark'),
+            4,
+            '',
+            NULL,
+            NULL,
+            FALSE
+        );
+
+        $gameId = $retval['gameId'];
+        $game = self::load_game($gameId);
+        $this->assertTrue(isset($game->hasPlayerAcceptedGameArray));
+        $this->assertTrue(is_array($game->hasPlayerAcceptedGameArray));
+        $this->assertCount(2, $game->hasPlayerAcceptedGameArray);
+        $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
+        $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
+        
+        $retval = $this->object->create_game(
+            array(self::$userId5WithoutAutoaccept, self::$userId2WithoutAutopass),
+            array('Bauer', 'Stark'),
+            4,
+            '',
+            NULL,
+            NULL,
+            FALSE
+        );
+
+        $gameId = $retval['gameId'];
+        $game = self::load_game($gameId);
+        $this->assertTrue(isset($game->hasPlayerAcceptedGameArray));
+        $this->assertTrue(is_array($game->hasPlayerAcceptedGameArray));
+        $this->assertCount(2, $game->hasPlayerAcceptedGameArray);
+        $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
         $this->assertFalse($game->hasPlayerAcceptedGameArray[1]);
 
-        $this->object->save_join_game_decision(self::$userId2WithoutAutopass, $gameId, 'accept');
+        $this->object->save_join_game_decision(self::$userId5WithoutAutoaccept, $gameId, 'accept');
         $game = self::load_game($gameId);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);

--- a/test/src/engine/BMInterfaceTest.php
+++ b/test/src/engine/BMInterfaceTest.php
@@ -602,7 +602,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
 
         $retval = $this->object->create_game(
-            array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
+            array(self::$userId5WithoutAutoaccept, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             4,
             '',
@@ -618,9 +618,9 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertCount(2, $game->hasPlayerAcceptedGameArray);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
-        
+
         $retval = $this->object->create_game(
-            array(self::$userId5WithoutAutoaccept, self::$userId2WithoutAutopass),
+            array(self::$userId1WithoutAutopass, self::$userId5WithoutAutoaccept),
             array('Bauer', 'Stark'),
             4,
             '',

--- a/test/src/engine/BMInterfaceTestAbstract.php
+++ b/test/src/engine/BMInterfaceTestAbstract.php
@@ -10,6 +10,7 @@ class BMInterfaceTestAbstract extends PHPUnit_Framework_TestCase {
     protected static $userId2WithoutAutopass;
     protected static $userId3WithAutopass;
     protected static $userId4WithAutopass;
+    protected static $userId5WithoutAutoaccept;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/test/src/ui/js/test_Api.js
+++ b/test/src/ui/js/test_Api.js
@@ -14,6 +14,7 @@ module("Api", {
     delete Api.button;
     delete Api.buttonSet;
     delete Api.player;
+    delete Api.new_games;
     delete Api.active_games;
     delete Api.completed_games;
     delete Api.user_prefs;

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -270,11 +270,35 @@ test("test_Overview.pageAddIntroText", function(assert) {
 });
 
 test("test_Overview.formAcceptGame", function(assert) {
-  // james: currently not tested
+  stop();
+  expect(3);
+  // Temporarily back up Overview.showLoggedInPage and replace it with
+  // a mocked version for testing
+  var showLoggedInPage = Overview.showLoggedInPage;
+  Overview.showLoggedInPage = function() {
+    Overview.showLoggedInPage = showLoggedInPage;
+    assert.equal(Env.message.text, 'Successfully accepted game',
+      'Accept game should succeed');
+    start();
+  };
+  var link = $('<a>', { 'data-gameId': 5 });
+  Overview.formAcceptGame.call(link, $.Event());
 })
 
 test("test_Overview.formRejectGame", function(assert) {
-  // james: currently not tested
+  stop();
+  expect(3);
+  // Temporarily back up Overview.showLoggedInPage and replace it with
+  // a mocked version for testing
+  var showLoggedInPage = Overview.showLoggedInPage;
+  Overview.showLoggedInPage = function() {
+    Overview.showLoggedInPage = showLoggedInPage;
+    assert.equal(Env.message.text, 'Successfully rejected game',
+      'Reject game should succeed');
+    start();
+  };
+  var link = $('<a>', { 'data-gameId': 5 });
+  Overview.formRejectGame.call(link, $.Event());
 })
 
 test("test_Overview.formDismissGame", function(assert) {

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -30,6 +30,7 @@ module("Overview", {
     // Delete all elements we expect this module to create
 
     // JavaScript variables
+    delete Api.new_games;
     delete Api.active_games;
     delete Api.completed_games;
     delete Api.gameNavigation;

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -269,7 +269,7 @@ test("test_Overview.pageAddIntroText", function(assert) {
     'Page intro text contains the Button Men copyright');
 });
 
-test("test_Overview.formAcceptGame", function(assert) {
+test("test_Overview.formReactToNewGame", function(assert) {
   stop();
   expect(3);
   // Temporarily back up Overview.showLoggedInPage and replace it with
@@ -281,11 +281,11 @@ test("test_Overview.formAcceptGame", function(assert) {
       'Accept game should succeed');
     start();
   };
-  var link = $('<a>', { 'data-gameId': 5 });
+  var link = $('<a>', { 'data-gameId': 5, 'action': 'accept' });
   Overview.formAcceptGame.call(link, $.Event());
 })
 
-test("test_Overview.formRejectGame", function(assert) {
+test("test_Overview.formReactToNewGameReject", function(assert) {
   stop();
   expect(3);
   // Temporarily back up Overview.showLoggedInPage and replace it with

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -183,6 +183,16 @@ test("test_Overview.pageAddGameTables", function(assert) {
   });
 });
 
+test("test_Overview.pageAddGameTableNew", function(assert) {
+  stop();
+  Overview.getOverview(function() {
+    Overview.page = $('<div>');
+    Overview.pageAddGameTableNew();
+    assert.ok(true, "No special testing of pageAddGameTableNew() as a whole is done");
+    start();
+  });
+});
+
 // The default overview data contains games awaiting both the player and the opponent
 test("test_Overview.pageAddNewgameLink", function(assert) {
   stop();
@@ -258,6 +268,14 @@ test("test_Overview.pageAddIntroText", function(assert) {
     'Button Men is copyright 1999, 2015 James Ernest and Cheapass Games'),
     'Page intro text contains the Button Men copyright');
 });
+
+test("test_Overview.formAcceptGame", function(assert) {
+  // james: currently not tested
+})
+
+test("test_Overview.formRejectGame", function(assert) {
+  // james: currently not tested
+})
 
 test("test_Overview.formDismissGame", function(assert) {
   stop();

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -269,7 +269,7 @@ test("test_Overview.pageAddIntroText", function(assert) {
     'Page intro text contains the Button Men copyright');
 });
 
-test("test_Overview.formReactToNewGame", function(assert) {
+test("test_Overview.formAcceptGame", function(assert) {
   stop();
   expect(3);
   // Temporarily back up Overview.showLoggedInPage and replace it with
@@ -285,7 +285,7 @@ test("test_Overview.formReactToNewGame", function(assert) {
   Overview.formAcceptGame.call(link, $.Event());
 })
 
-test("test_Overview.formReactToNewGameReject", function(assert) {
+test("test_Overview.formRejectGame", function(assert) {
   stop();
   expect(3);
   // Temporarily back up Overview.showLoggedInPage and replace it with


### PR DESCRIPTION
Fixes #205.

This pull request does the following:
- add a new section to the Overview page called "New games", showing games that have not yet been accepted
- adds a user preference to auto-accept games, default on

Currently, the game page is minimal for a not-yet-accepted game or for a rejected game.

Requires database update 00205_reject_game_02.sql

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/898/