### PR TITLE
Stopped mood skill triggering after a trip attack

### DIFF
--- a/src/engine/BMSkillMood.php
+++ b/src/engine/BMSkillMood.php
@@ -62,6 +62,10 @@ class BMSkillMood extends BMSkill {
             return FALSE;
         }
 
+        if ($die->has_flag('JustPerformedTripAttack')) {
+            return FALSE;
+        }
+
         if (array_key_exists('isSubdie', $args) && $args['isSubdie']) {
             return FALSE;
         }


### PR DESCRIPTION
Fixes #1723.

Game 1857 on the dev site will need to be fixed manually once this pull request is accepted. The fix is simply to set the appropriate die value to a valid value, and then change the game status from BROKEN to ACTIVE.

Tested Jenniegirl vs Jenniegirl.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/912/