### PR TITLE
TimeAndSpace now doesn't trigger if the die doesn't reroll

### DIFF
--- a/src/engine/BMSkillTimeAndSpace.php
+++ b/src/engine/BMSkillTimeAndSpace.php
@@ -42,6 +42,10 @@ class BMSkillTimeAndSpace extends BMSkill {
             return;
         }
 
+        if (!$die->doesReroll) {
+            return;
+        }
+
         if ($die->value & 1) {
             $game->nextPlayerIdx = $game->activePlayerIdx;
         }


### PR DESCRIPTION
Fixes #1729.

Tested with artificially altered die recipes in the database, using odd-valued b^ and k^ dice.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/913/