### PR TITLE
Improve "Skills in this game" section

### DIFF
--- a/src/ui/game.html
+++ b/src/ui/game.html
@@ -22,7 +22,7 @@
     <script>
         $(document).ready(function() {
           $.getScript('js/Loader.js', function() {
-            Loader.loadScripts([ 'js/Game.js' ], function() {
+            Loader.loadScripts([ 'js/extern/jquery-ui.min.js', 'js/Game.js' ], function() {
                 Login.showLoginHeader(Game);
             });
           });

--- a/src/ui/game.html
+++ b/src/ui/game.html
@@ -8,6 +8,7 @@
 
     <meta charset="utf-8" />
     <title>Button Men Online</title>
+    <link rel="stylesheet" href="js/extern/jquery-ui.css" />
     <link rel="stylesheet" href="gui.css" />
     <meta http-equiv="Cache-control" content="no-cache">
 

--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -892,3 +892,10 @@ div.forum div.splitRight {
 #buttons_page table.skills p.interaction {
     font-style: italic;
 }
+
+div.ui-tooltip {
+    background-color: #ffffcc;
+    border: 1px solid grey;
+    margin: 10px;
+    padding: 10px;
+}

--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -894,5 +894,6 @@ div.forum div.splitRight {
 }
 
 div.ui-tooltip {
-    max-width: 400px;
+    font-size: 1em;
+    max-width: 80%;
 }

--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -894,8 +894,5 @@ div.forum div.splitRight {
 }
 
 div.ui-tooltip {
-    background-color: #ffffcc;
-    border: 1px solid grey;
-    margin: 10px;
-    padding: 10px;
+    max-width: 400px;
 }

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1690,6 +1690,7 @@ Game.pageAddSkillListFooter = function() {
   $.each(Api.game.gameSkillsInfo, function(skill, info) {
     skillDesc = skill;
     if (info.code) {
+      skill += ' (' + info.code + ')';
       skillDesc += ' (' + info.code + ')';
     }
     skillDesc += ': ' + info.description;

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1726,8 +1726,11 @@ Game.pageAddSkillListFooter = function() {
         items: 'span'
       })
       .on('click', function() {
+        // james: without closing other tooltips, it's possible that
+        // the same tooltip might occur twice on a browser page due
+        // to the combination of hover and click
+        $('.ui-tooltip').hide();
         $(this).tooltip('open');
-        return false;
       });
 
     gameSkillDiv.append(indivSkillSpan);

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1707,10 +1707,10 @@ Game.pageAddSkillListFooter = function() {
       isFirstInteraction = true;
       $.each(info.interacts, function(otherSkill, interactDesc) {
         if (isFirstInteraction) {
-          skillDesc += '\n\nInteraction with other skills in this game:';
+          skillDesc += '<br/><br/>Interaction with other skills in this game:';
           isFirstInteraction = false;
         }
-        skillDesc += '\n * ' + otherSkill + ': ' + interactDesc;
+        skillDesc += '<br/> * ' + otherSkill + ': ' + interactDesc;
       });
 
       if (isFirstDieSkill) {
@@ -1762,7 +1762,8 @@ Game.skillSpan = function(skill, skillDesc) {
   skillSpan
     .tooltip({
       content: skillDesc,
-      items: 'span'
+      items: 'span',
+      position: { my: 'bottom', at: 'top-5', collision: 'flipfit'},
     })
     .on('click', function() {
       // james: without closing other tooltips, it's possible that

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1680,72 +1680,100 @@ Game.pageAddGameNavigationFooter = function() {
 
 // Display a footer-style message with the list of skills in this game
 Game.pageAddSkillListFooter = function() {
-  var gameSkillDiv = $('<div>', {
+  var hasButtonSpecial = false;
+  var hasDieSkill = false;
+  var isFirstButtonSpecial = true;
+  var isFirstDieSkill = true;
+  var isFirstInteraction;
+  var skillDesc;
+
+  var buttonSpecialDiv = $('<div>', {
+    'text': 'Button specials in this game: ',
+  });
+  var dieSkillDiv = $('<div>', {
     'text': 'Skills in this game: ',
   });
 
-  var firstSkill = true;
-  var firstInteract;
-  var skillDesc;
-  var indivSkillSpan;
   $.each(Api.game.gameSkillsInfo, function(skill, info) {
     skillDesc = skill;
+
     if (info.code) {
+      // add a die skill ...
       skill += ' (' + info.code + ')';
       skillDesc += ' (' + info.code + ')';
-    }
-    skillDesc += ': ' + info.description;
+      skillDesc += ': ' + info.description;
 
-    firstInteract = true;
-    $.each(info.interacts, function(otherSkill, interactDesc) {
-      if (firstInteract) {
-        skillDesc += '\n\nInteraction with other skills in this game:';
-      }
-      skillDesc += '\n * ' + otherSkill + ': ' + interactDesc;
-    });
-
-    if (!(firstSkill)) {
-      gameSkillDiv.append('&nbsp;&nbsp;');
-    }
-
-    indivSkillSpan = $('<span>');
-
-    indivSkillSpan.append(
-      $('<span>', {
-        'text': skill,
-        'class': 'skill_desc',
-      })
-    );
-    indivSkillSpan.append($('<span>', {
-      'text': 'i',
-      'class': 'info_icon',
-    }));
-    indivSkillSpan
-      .tooltip({
-        content: skillDesc,
-        items: 'span'
-      })
-      .on('click', function() {
-        // james: without closing other tooltips, it's possible that
-        // the same tooltip might occur twice on a browser page due
-        // to the combination of hover and click
-        $('.ui-tooltip').hide();
-        $(this).tooltip('open');
+      // ... with interactions
+      isFirstInteraction = true;
+      $.each(info.interacts, function(otherSkill, interactDesc) {
+        if (isFirstInteraction) {
+          skillDesc += '\n\nInteraction with other skills in this game:';
+          isFirstInteraction = false;
+        }
+        skillDesc += '\n * ' + otherSkill + ': ' + interactDesc;
       });
 
-    gameSkillDiv.append(indivSkillSpan);
+      if (isFirstDieSkill) {
+        hasDieSkill = true;
+        isFirstDieSkill = false;
+      } else {
+        dieSkillDiv.append('&nbsp;&nbsp;');
+      }
+      dieSkillDiv.append(Game.skillSpan(skill, skillDesc));
+    } else {
+      // add a button special
+      skillDesc += ': ' + info.description;
 
-    firstSkill = false;
+      if (isFirstButtonSpecial) {
+        hasButtonSpecial = true;
+        isFirstButtonSpecial = false;
+      } else {
+        buttonSpecialDiv.append('&nbsp;&nbsp;');
+      }
+      buttonSpecialDiv.append(Game.skillSpan(skill, skillDesc));
+    }
   });
 
-  if (firstSkill) {
-    gameSkillDiv.append('none');
+  if (!hasDieSkill) {
+    dieSkillDiv.append('none');
   }
 
   Game.page.append($('<br>'));
-  Game.page.append(gameSkillDiv);
+  if (hasButtonSpecial) {
+    Game.page.append(buttonSpecialDiv).append($('<br>'));
+  }
+  Game.page.append(dieSkillDiv);
   return true;
 };
+
+Game.skillSpan = function(skill, skillDesc) {
+  var skillSpan = $('<span>');
+
+  skillSpan.append(
+    $('<span>', {
+      'text': skill,
+      'class': 'skill_desc',
+    })
+  );
+  skillSpan.append($('<span>', {
+    'text': 'i',
+    'class': 'info_icon',
+  }));
+  skillSpan
+    .tooltip({
+      content: skillDesc,
+      items: 'span'
+    })
+    .on('click', function() {
+      // james: without closing other tooltips, it's possible that
+      // the same tooltip might occur twice on a browser page due
+      // to the combination of hover and click
+      $('.ui-tooltip').hide();
+      $(this).tooltip('open');
+    });
+
+  return skillSpan;
+}
 
 // Display links to create new games similar to this one
 Game.pageAddNewGameLinkFooter = function() {

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1687,6 +1687,7 @@ Game.pageAddSkillListFooter = function() {
   var firstSkill = true;
   var firstInteract;
   var skillDesc;
+  var indivSkillSpan;
   $.each(Api.game.gameSkillsInfo, function(skill, info) {
     skillDesc = skill;
     if (info.code) {
@@ -1706,16 +1707,31 @@ Game.pageAddSkillListFooter = function() {
     if (!(firstSkill)) {
       gameSkillDiv.append('&nbsp;&nbsp;');
     }
-    gameSkillDiv.append($('<span>', {
-      'text': skill,
-      'title': skillDesc,
-      'class': 'skill_desc',
-    }));
-    gameSkillDiv.append($('<span>', {
+
+    indivSkillSpan = $('<span>');
+
+    indivSkillSpan.append(
+      $('<span>', {
+        'text': skill,
+        'class': 'skill_desc',
+      })
+    );
+    indivSkillSpan.append($('<span>', {
       'text': 'i',
-      'title': skillDesc,
       'class': 'info_icon',
     }));
+    indivSkillSpan
+      .tooltip({
+        content: skillDesc,
+        items: 'span'
+      })
+      .on('click', function() {
+        $(this).tooltip('open');
+        return false;
+      });
+
+    gameSkillDiv.append(indivSkillSpan);
+
     firstSkill = false;
   });
 

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1774,7 +1774,7 @@ Game.skillSpan = function(skill, skillDesc) {
     });
 
   return skillSpan;
-}
+};
 
 // Display links to create new games similar to this one
 Game.pageAddNewGameLinkFooter = function() {

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1161,7 +1161,8 @@ test("test_Game.skillSpan", function(assert) {
   );
 });
 
-test("test_Game.pageAddLogFooter_actionlog", function(assert) {
+// this test checks the footer for action log entries
+test("test_Game.pageAddLogFooter", function(assert) {
   stop();
   BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
   Game.getCurrentGame(function() {

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1136,16 +1136,29 @@ test("test_Game.pageAddSkillListFooter", function(assert) {
   });
 });
 
-test("test_Game.pageAddLogFooter", function(assert) {
+test("test_Game.pageAddSkillListFooter", function(assert) {
   stop();
-  BMTestUtils.GameType = 'frasquito_wiseman_specifydice';
+  BMTestUtils.GameType = 'blackomega_thefool_reacttoinitiative';
   Game.getCurrentGame(function() {
     Game.page = $('<div>');
-    Game.pageAddLogFooter();
+    Game.pageAddSkillListFooter();
     var htmlout = Game.page.html();
-    assert.deepEqual(htmlout, "", "Action log footer for a new game should be empty");
+    assert.ok(htmlout.match('<br>'), "Skill list footer should insert line break");
+    assert.ok(htmlout.match('<div>Skills in this game: '),
+      "Die skills footer text is present");
+    assert.ok(htmlout.match('Focus'),
+      "Die skills footer text lists the Focus skill");
     start();
   });
+});
+
+test("test_Game.skillSpan", function(assert) {
+  var skillSpan = Game.skillSpan('DummySkill', 'description');
+  assert.ok(skillSpan.is('span'));
+  assert.equal(skillSpan.html(),
+    '<span class="skill_desc">DummySkill</span>' +
+    '<span class="info_icon">i</span>'
+  );
 });
 
 test("test_Game.pageAddLogFooter_actionlog", function(assert) {


### PR DESCRIPTION
Fixes #1697.

This implements four improvements:
- button specials are separated from die skills
- die skill codes are shown explicitly in the list of skills
- hint text now appears both on click and on hover
- hint text is now larger than before

Tested with Giant vs Echo, Prudence vs Giant, Bauer vs Avis.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/916/