### PR TITLE
"New game" shortcuts that preserve chat now dismiss the previous game

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -88,6 +88,7 @@ class ApiResponder {
         }
         if (isset($args['previousGameId'])) {
             $previousGameId = $args['previousGameId'];
+            $interface->dismiss_game($_SESSION['user_id'], $args['previousGameId']);
         } else {
             $previousGameId = NULL;
         }

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1740,7 +1740,7 @@ Game.pageAddNewGameLinkFooter = function() {
     Game.page.append($('<div>', {
       'text':
         'Challenge ' + Api.game.opponent.playerName +
-        ' to another game, preserving chat:',
+        ' to another game, preserving chat, and dismiss this game:',
     }));
 
     linkDiv = $('<div>');


### PR DESCRIPTION
Fixes #1657.

Tested with 1-round Haruspex vs Haruspex matches.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/917/ (if it passes)