### PR TITLE
Set an explicit API message when joining an open game

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -3129,6 +3129,7 @@ class BMInterface {
             $game = $this->load_game($gameId);
             $game->hasPlayerAcceptedGameArray[$emptyPlayerIdx] = TRUE;
             $this->save_game($game);
+            $this->set_message('Successfully joined game ' . $gameId);
 
             return TRUE;
         } catch (Exception $e) {

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -786,8 +786,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
             'gameId' => $gameId,
         );
         $retval = $this->verify_api_success($args);
-        // FIXME: once #1274 is resolved, actually test the message here
-        // $this->assertEquals('foobar', $retval['message']);
+        $this->assertEquals('Successfully joined game ' . $gameId, $retval['message']);
         $this->assertEquals(TRUE, $retval['data']);
         return $retval['data'];
     }


### PR DESCRIPTION
Fixes #1274.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/919/