### PR TITLE
Adding links to buttons in some selection pages (such as auxiliary dice)

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2612,6 +2612,9 @@ Game.playerOpponentHeaderRow = function(label, field) {
   if (field == 'playerName') {
     playerInfo.append(Env.buildProfileLink(Api.game.player[field]));
     opponentInfo.append(Env.buildProfileLink(Api.game.opponent[field]));
+  } else if (field == 'buttonName') {
+    playerInfo.append(Env.buildButtonLink(Api.game.player[field]));
+    opponentInfo.append(Env.buildButtonLink(Api.game.opponent[field]));
   } else {
     playerInfo.append(Api.game.player[field]);
     opponentInfo.append(Api.game.opponent[field]);


### PR DESCRIPTION
Fixes bug #1245.

I verified the links to the button exist for auxiliary selection page, reserve dice selection page, and swing dice selection page.

Jenkins still running as I post this, but here's a sample Jenkins for now: 

http://jenkins.buttonweavers.com:8080/job/buttonmen-dwvanstone/1/