### PR TITLE
Fixed pending game count when games have been cancelled

### DIFF
--- a/deploy/database/updates/01771_pending_game_01_dev.sql
+++ b/deploy/database/updates/01771_pending_game_01_dev.sql
@@ -1,3 +1,3 @@
-UPDATE game_player_map AS m
+UPDATE game_player_map
 SET is_awaiting_action = 0
 WHERE game_id IN (SELECT id FROM game WHERE game_state = 251);

--- a/deploy/database/updates/01771_pending_game_01_dev.sql
+++ b/deploy/database/updates/01771_pending_game_01_dev.sql
@@ -1,0 +1,3 @@
+UPDATE game_player_map AS m
+SET is_awaiting_action = 0
+WHERE game_id IN (SELECT id FROM game WHERE game_state = 251);

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1910,6 +1910,7 @@ class BMGame {
     }
 
     protected function do_next_step_rejected() {
+        $this->waitingOnActionArray = array_fill(0, $this->nPlayers, FALSE);
     }
 
     protected function update_game_state_rejected() {
@@ -2523,14 +2524,13 @@ class BMGame {
         $this->activeDieArrayArray = NULL;
         $this->attack = NULL;
 
-        $nPlayers = count($this->playerIdArray);
         $this->nRecentPasses = 0;
         $this->turnNumberInRound = 0;
-        $this->capturedDieArrayArray = array_fill(0, $nPlayers, array());
-        $this->outOfPlayDieArrayArray = array_fill(0, $nPlayers, array());
-        $this->waitingOnActionArray = array_fill(0, $nPlayers, FALSE);
-        $this->swingRequestArrayArray = array_fill(0, $nPlayers, array());
-        $this->optRequestArrayArray = array_fill(0, $nPlayers, array());
+        $this->capturedDieArrayArray = array_fill(0, $this->nPlayers, array());
+        $this->outOfPlayDieArrayArray = array_fill(0, $this->nPlayers, array());
+        $this->waitingOnActionArray = array_fill(0, $this->nPlayers, FALSE);
+        $this->swingRequestArrayArray = array_fill(0, $this->nPlayers, array());
+        $this->optRequestArrayArray = array_fill(0, $this->nPlayers, array());
         unset($this->forceRoundResult);
     }
 

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -540,7 +540,9 @@ class BMInterface {
                 'FROM game_player_map AS gpm '.
                    'LEFT JOIN game AS g ON g.id = gpm.game_id '.
                 'WHERE gpm.player_id = :player_id '.
-                   'AND gpm.is_awaiting_action = 1 ';
+                   'AND gpm.is_awaiting_action = 1 '.
+                   'AND g.status_id = '.
+                       '(SELECT id FROM game_status WHERE name = \'ACTIVE\') ';
 
             $statement = self::$conn->prepare($query);
             $statement->execute($parameters);


### PR DESCRIPTION
Fixes #1771. Fixes #1788.

The dev database requires update 01771_pending_game_01_dev.sql

Once we add an appropriate responder test to this, I'll run Jenkins.