### PR TITLE
Update page title in forum topic

### DIFF
--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -148,7 +148,9 @@ Forum.showBoard = function() {
     return;
   }
 
-  $('title').html('Button Men Online &mdash; Forum: ' + Api.forum_board.boardName);
+  var pageTitle='Button Men Online &mdash; Forum: ';
+  pageTitle += Api.forum_board.boardName;
+  $('title').html(pageTitle);
 
   var table = $('<table>', {
     'class': 'threads'

--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -93,6 +93,8 @@ Forum.showOverview = function() {
     return;
   }
 
+  $('title').html('Button Men Online &mdash; Forum');
+
   var table = $('<table>', { 'class': 'boards' });
   Forum.page.append(table);
 

--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -148,6 +148,8 @@ Forum.showBoard = function() {
     return;
   }
 
+  $('title').html('Button Men Online &mdash; Forum: ' + Api.forum_board.boardName);
+
   var table = $('<table>', {
     'class': 'threads'
   });
@@ -262,6 +264,12 @@ Forum.showThread = function() {
   if (!Api.verifyApiData('forum_thread', Forum.arrangePage)) {
     return;
   }
+
+  // Don't display special characters (such as "&auml;") in page title
+  var tempDiv = $('<div>', { 'text': Api.forum_thread.threadTitle});
+  var pageTitle = tempDiv.html();
+
+  $('title').html('Button Men Online &mdash; ' + pageTitle);
 
   var table = $('<table>', { 'class': 'posts' });
   Forum.page.append(table);


### PR DESCRIPTION
Fixes #1684 by putting the forum topic in the page title.

For consistency, I also added forum board title to the page title when on a specific board.

Tested on Chrome, Firefox, & Safari on my Mac. Did not test on any mobile devices. Note that most of the time the forum topic is not visible because the page title is truncated on tabs. 

http://jenkins.buttonweavers.com:8080/job/buttonmen-dwvanstone/10/