### PR TITLE
Added game page for rejected/cancelled games

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -340,7 +340,8 @@ class BMInterface {
 
             $previousPlayerIds = array();
             while ($row = $statement->fetch()) {
-                if ($row['status'] != 'COMPLETE') {
+                if (($row['status'] != 'COMPLETE') &&
+                    ($row['status'] != 'REJECTED')) {
                     $this->set_message(
                         'Game create failed because the previous game has not been completed yet.'
                     );

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -129,10 +129,7 @@ Game.showStatePage = function() {
         Game.actionChooseJoinGameNonplayer();
       }
     } else if (Api.game.gameState == Game.GAME_STATE_REJECTED) {
-      Game.page =
-        $('<p>', {'text': 'This game has been rejected.', });
-      Game.form = null;
-      includeFooter = false;
+      Game.actionShowRejectedGame();
     } else if (Api.game.gameState == Game.GAME_STATE_SPECIFY_DICE) {
       if (Api.game.isParticipant) {
         if (Api.game.player.waitingOnAction) {
@@ -345,6 +342,27 @@ Game.actionChooseJoinGameNonplayer = function() {
   var dietable = Game.dieRecipeTable(false);
   Game.page.append(dietable);
   Game.page.append($('<br>'));
+};
+
+Game.actionShowRejectedGame = function() {
+
+  // nothing to do on button click
+  Game.form = null;
+
+  Game.page = $('<div>');
+  Game.pageAddGameHeader('This game has been rejected');
+
+  var dieEndgameTable = $('<table>');
+  var dieEndgameTr = $('<tr>');
+
+  var playerButtonTd = Game.buttonImageDisplay('player');
+  var opponentButtonTd = Game.buttonImageDisplay('opponent');
+
+  dieEndgameTr.append(playerButtonTd);
+  dieEndgameTr.append(opponentButtonTd);
+  dieEndgameTable.append(dieEndgameTr);
+  Game.page.append(dieEndgameTable);
+  Game.logEntryLimit = undefined;
 };
 
 // It is time to choose swing dice, and the current player has dice to choose
@@ -1889,7 +1907,8 @@ Game.pageAddSkillListFooter = function() {
 
 // Display links to create new games similar to this one
 Game.pageAddNewGameLinkFooter = function() {
-  if (Api.game.gameState != Game.GAME_STATE_END_GAME) {
+  if ((Api.game.gameState != Game.GAME_STATE_END_GAME) &&
+      (Api.game.gameState != Game.GAME_STATE_REJECTED)) {
     return;
   }
 

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1735,7 +1735,8 @@ Game.pageAddGameHeader = function(action_desc) {
   Game.page.append($('<br>'));
 
   if (Api.game.isParticipant && !Api.game.player.hasDismissedGame &&
-      Api.game.gameState == Game.GAME_STATE_END_GAME) {
+      (Api.game.gameState == Game.GAME_STATE_END_GAME ||
+       Api.game.gameState == Game.GAME_STATE_REJECTED)) {
     var dismissDiv = $('<div>');
     Game.page.append(dismissDiv);
     var dismissLink = $('<a>', {

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -350,7 +350,7 @@ Game.actionShowRejectedGame = function() {
   Game.form = null;
 
   Game.page = $('<div>');
-  Game.pageAddGameHeader('This game has been rejected');
+  Game.pageAddGameHeader('This game has been rejected or cancelled');
 
   var dieEndgameTable = $('<table>');
   var dieEndgameTr = $('<tr>');

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2484,8 +2484,11 @@ Game.pageAddDieBattleTable = function(clickable) {
 // all lowercase, spaces and punctuation removed
 Game.buttonImageDisplay = function(player) {
   var tdClass = 'button_' + player;
-  if (Api.game.gameState == Game.GAME_STATE_END_GAME ||
-      Api.game.gameState == Game.GAME_STATE_CHOOSE_JOIN_GAME) {
+  var isPreOrPostGame = Api.game.gameState == Game.GAME_STATE_END_GAME ||
+                        Api.game.gameState == Game.GAME_STATE_REJECTED ||
+                        Api.game.gameState == Game.GAME_STATE_CHOOSE_JOIN_GAME;
+
+  if (isPreOrPostGame) {
     tdClass += ' button_prepostgame';
   }
   var buttonTd = $('<td>', {
@@ -2507,9 +2510,7 @@ Game.buttonImageDisplay = function(player) {
     'text': Api.game[player].button.recipe,
   });
 
-  if (player == 'opponent' &&
-      Api.game.gameState != Game.GAME_STATE_END_GAME &&
-      Api.game.gameState != Game.GAME_STATE_CHOOSE_JOIN_GAME) {
+  if (player == 'opponent' && isPreOrPostGame) {
     buttonTd.append(playerName);
     buttonTd.append(buttonInfo);
     buttonTd.append(buttonRecipe);
@@ -2526,9 +2527,7 @@ Game.buttonImageDisplay = function(player) {
       'width': '150px',
     }));
   }
-  if (player == 'player' ||
-      Api.game.gameState == Game.GAME_STATE_END_GAME ||
-      Api.game.gameState == Game.GAME_STATE_CHOOSE_JOIN_GAME) {
+  if (player == 'player' || isPreOrPostGame) {
     buttonTd.append(buttonRecipe);
     buttonTd.append(buttonInfo);
     buttonTd.append(playerName);

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -413,6 +413,10 @@ test("test_Game.actionChooseJoinGameNonplayer", function(assert) {
 //  james: incomplete for the moment
 });
 
+test("test_Game.actionShowRejectedGame", function(assert) {
+//  james: incomplete for the moment
+});
+
 test("test_Game.actionSpecifyDiceActive", function(assert) {
   stop();
   BMTestUtils.GameType = 'jellybean_dirgo_specifydice';


### PR DESCRIPTION
Continues to address part of #1731. Fixes #1778. Fixes #1779. Fixes #1766.

Known issues: Currently, the game page says unspecifically that the game was "rejected or cancelled". This will eventually be sorted out properly when #1816 is addressed.

The opponent's button table has been reversed, similar to the change in #1822.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/985/