### PR TITLE
Run bzip2 on backups while storing them

### DIFF
--- a/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
@@ -4,7 +4,7 @@ BACKUPDIR=/srv/backup
 DBNAME=buttonmen
 TODAY=`date +"%Y%m%d"`
 
-BACKUPFILE="${BACKUPDIR}/${DBNAME}.${TODAY}.sql.bz2"
+BACKUPFILE="${BACKUPDIR}/${DBNAME}.${TODAY}.sql"
 
 # Fail if BACKUPDIR isn't there
 if [ ! -d "$BACKUPDIR" ]; then
@@ -12,9 +12,18 @@ if [ ! -d "$BACKUPDIR" ]; then
   exit 1
 fi
 
-mysqldump -u root $DBNAME | bzip2 > $BACKUPFILE
+mysqldump -u root $DBNAME > $BACKUPFILE
 if [ ! -s "$BACKUPFILE" ]; then
   echo "after backup, backup file is missing or zero size"
+  exit 1
+fi
+
+# Now compress the backup to save disk space
+# This has to be done as a separate step to save site performance
+# while backup/compression are happening
+bzip2 -f $BACKUPFILE
+if [ "$?" != "0" ]; then
+  echo "Bzip2 of successful backup failed"
   exit 1
 fi
 

--- a/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
@@ -4,7 +4,7 @@ BACKUPDIR=/srv/backup
 DBNAME=buttonmen
 TODAY=`date +"%Y%m%d"`
 
-BACKUPFILE="${BACKUPDIR}/${DBNAME}.${TODAY}.sql"
+BACKUPFILE="${BACKUPDIR}/${DBNAME}.${TODAY}.sql.bz2"
 
 # Fail if BACKUPDIR isn't there
 if [ ! -d "$BACKUPDIR" ]; then
@@ -12,7 +12,7 @@ if [ ! -d "$BACKUPDIR" ]; then
   exit 1
 fi
 
-mysqldump -u root $DBNAME > $BACKUPFILE
+mysqldump -u root $DBNAME | bzip2 > $BACKUPFILE
 if [ ! -s "$BACKUPFILE" ]; then
   echo "after backup, backup file is missing or zero size"
   exit 1


### PR DESCRIPTION
* Partially addresses problem that the backup disks on prod and (to a lesser extent) dev keep running out of space
* No jenkins because there are no changes to code that jenkins is aware of
* Tested manually on virtualbox with the dev database loaded:
```bash
sandbox,[~],13:32(0)$ ls -lart /srv/backup/
total 8
drwxr-xr-x 3 root root 4096 Nov 30 13:15 ../
drwxr-x--- 2 root adm  4096 Nov 30 13:32 ./
sandbox,[~],13:32(0)$ time sudo /usr/local/bin/backup_buttonmen_database

real    0m19.952s
user    0m18.453s
sys     0m1.084s
sandbox,[~],13:33(0)$ ls -lart /srv/backup/
total 2068
drwxr-xr-x 3 root root    4096 Nov 30 13:15 ../
drwxr-x--- 2 root adm     4096 Nov 30 13:32 ./
-rw-r--r-- 1 root root 2106650 Nov 30 13:33 buttonmen.20151130.sql.bz2
sandbox,[~],13:33(0)$ bzcat /srv/backup/buttonmen.20151130.sql.bz2 | mysql -u root buttonmen
sandbox,[~],13:33(0)$ sudo /usr/local/bin/backup_buttonmen_database 
sandbox,[~],13:37(0)$ ls -lart /srv/backup/
total 2068
drwxr-xr-x 3 root root    4096 Nov 30 13:15 ../
drwxr-x--- 2 root adm     4096 Nov 30 13:32 ./
-rw-r--r-- 1 root root 2106789 Nov 30 13:37 buttonmen.20151130.sql.bz2
sandbox,[~],13:37(0)$ 
```

That shows:
* the new backup scheme works
* the new backup scheme can be run a second time in a day and will overwrite the first backup (the current behavior)
* the resulting database can be loaded (then i went to the UI and verified that it looked fine)
* the approximate wall-clock time of running the new backups on a dev-sized database
