### PR TITLE
Fixed bug with displaying opponent info on the game mat

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2527,7 +2527,7 @@ Game.buttonImageDisplay = function(player) {
     'text': Api.game[player].button.recipe,
   });
 
-  if (player == 'opponent' && isPreOrPostGame) {
+  if (player == 'opponent' && !isPreOrPostGame) {
     buttonTd.append(playerName);
     buttonTd.append(buttonInfo);
     buttonTd.append(buttonRecipe);


### PR DESCRIPTION
This pull request fixes the problem of the opponent's info not being visible on the game mat.

I am aware that there should be an appropriate unit test locking our expected behaviour into place, but I'd like to put this fix in first.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/997/