### PR TITLE
Reformatted count of pending games in title.

### DIFF
--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -93,10 +93,8 @@ Overview.showPage = function() {
   var nGamesAwaitingAction = Api.new_games.nGamesAwaitingAction +
     Api.active_games.nGamesAwaitingAction;
   var gameCountText='';
-  if (nGamesAwaitingAction > 1) {
-    gameCountText = '(' + nGamesAwaitingAction + ' games waiting) &mdash; ';
-  } else if (nGamesAwaitingAction == 1) {
-    gameCountText = '(1 game waiting) &mdash; ';
+  if (nGamesAwaitingAction > 0) {
+    gameCountText = '(' + nGamesAwaitingAction+ ') ';
   }
   $('title').html(gameCountText + 'Button Men Online');
 


### PR DESCRIPTION
Fixes #1850.

http://jenkins.buttonweavers.com:8080/job/buttonmen-dwvanstone/28/

I went with using the title "(N) Button Men Online" since that matches GitHub. 

An alternative would be to do what Google Mail does: "Overview (N) - Button Men Online." But I prefer having the title be as short as possible for this case.