### PR TITLE
Changed W/L/T to –/–/– for rejected games on the history page

### DIFF
--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -668,8 +668,7 @@ History.buildResultsTableBody = function() {
 
 History.scoreCol = function(game) {
   var score;
-  if ((game.status == 'REJECTED') ||
-      (game.gameStart == game.lastMove)) {
+  if (game.status == 'REJECTED') {
     score = '–/–/–';
   } else {
     score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;

--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -643,22 +643,7 @@ History.buildResultsTableBody = function() {
       'text': Env.formatTimestamp(game.lastMove, 'date'),
     }));
 
-    var score = game.roundsWonA + '/' + game.roundsWonB + '/' +
-      game.roundsDrawn + ' (' + game.targetWins + ')';
-
-    var winnerColor;
-    if (game.roundsWonA >= game.targetWins) {
-      winnerColor = game.colorA;
-    } else if (game.roundsWonB >= game.targetWins) {
-      winnerColor = game.colorB;
-    } else {
-      winnerColor = '#ffffff';
-    }
-
-    gameRow.append($('<td>', {
-      'text': score,
-      'style': 'background-color: ' + winnerColor + ';',
-    }));
+    gameRow.append(History.scoreCol(game));
 
     if (game.status == 'COMPLETE') {
       gameRow.append($('<td>', {
@@ -679,6 +664,32 @@ History.buildResultsTableBody = function() {
   });
 
   return body;
+};
+
+History.scoreCol = function(game) {
+    var score;
+    if (game.status == 'REJECTED') {
+      score = '–/–/–';
+    } else {
+      score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;
+    }
+    score += ' (' + game.targetWins + ')';
+
+    var winnerColor;
+    if (game.roundsWonA >= game.targetWins) {
+      winnerColor = game.colorA;
+    } else if (game.roundsWonB >= game.targetWins) {
+      winnerColor = game.colorB;
+    } else {
+      winnerColor = '#ffffff';
+    }
+
+    var column = $('<td>', {
+      'text': score,
+      'style': 'background-color: ' + winnerColor + ';',
+    });
+
+    return column;
 };
 
 History.buildResultsTableFooter = function() {

--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -667,8 +667,11 @@ History.buildResultsTableBody = function() {
 };
 
 History.scoreCol = function(game) {
+  console.log(game);
+
   var score;
-  if (game.status == 'REJECTED') {
+  if ((game.status == 'REJECTED') ||
+      (game.gameStart == game.lastMove)) {
     score = '–/–/–';
   } else {
     score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;

--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -667,8 +667,6 @@ History.buildResultsTableBody = function() {
 };
 
 History.scoreCol = function(game) {
-  console.log(game);
-
   var score;
   if ((game.status == 'REJECTED') ||
       (game.gameStart == game.lastMove)) {

--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -667,29 +667,29 @@ History.buildResultsTableBody = function() {
 };
 
 History.scoreCol = function(game) {
-    var score;
-    if (game.status == 'REJECTED') {
-      score = '–/–/–';
-    } else {
-      score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;
-    }
-    score += ' (' + game.targetWins + ')';
+  var score;
+  if (game.status == 'REJECTED') {
+    score = '–/–/–';
+  } else {
+    score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;
+  }
+  score += ' (' + game.targetWins + ')';
 
-    var winnerColor;
-    if (game.roundsWonA >= game.targetWins) {
-      winnerColor = game.colorA;
-    } else if (game.roundsWonB >= game.targetWins) {
-      winnerColor = game.colorB;
-    } else {
-      winnerColor = '#ffffff';
-    }
+  var winnerColor;
+  if (game.roundsWonA >= game.targetWins) {
+    winnerColor = game.colorA;
+  } else if (game.roundsWonB >= game.targetWins) {
+    winnerColor = game.colorB;
+  } else {
+    winnerColor = '#ffffff';
+  }
 
-    var column = $('<td>', {
-      'text': score,
-      'style': 'background-color: ' + winnerColor + ';',
-    });
+  var column = $('<td>', {
+    'text': score,
+    'style': 'background-color: ' + winnerColor + ';',
+  });
 
-    return column;
+  return column;
 };
 
 History.buildResultsTableFooter = function() {

--- a/test/src/ui/js/test_History.js
+++ b/test/src/ui/js/test_History.js
@@ -253,6 +253,83 @@ test("test_History.buildResultsTableBody", function(assert) {
   });
 });
 
+test("test_History.scoreCol", function(assert) {
+    var game;
+    var column;
+
+    // test normal games
+    game = {
+      'status' : 'ACTIVE',
+      'roundsWonA' : 1,
+      'roundsWonB' : 2,
+      'roundsDrawn' : 4,
+      'targetWins' : 5,
+      'colorA' : '#aa0000',
+      'colorB' : '#00bb00',
+    }
+
+    column = History.scoreCol(game);
+    assert.ok(column.is('td'), 'active score column has the correct type');
+    assert.equal(
+      '1/2/4 (5)',
+      column.text(),
+      'active score column has the correct text'
+    );
+    assert.equal(
+      'rgb(255, 255, 255)',
+      column.css('background-color'),
+      'active score column has the correct color'
+    );
+
+    // test completed games
+    game = {
+      'status' : 'COMPLETED',
+      'roundsWonA' : 1,
+      'roundsWonB' : 3,
+      'roundsDrawn' : 2,
+      'targetWins' : 3,
+      'colorA' : '#ff0000',
+      'colorB' : '#00ff00',
+    }
+
+    column = History.scoreCol(game);
+    assert.ok(column.is('td'), 'completed score column has the correct type');
+    assert.equal(
+      '1/3/2 (3)',
+      column.text(),
+      'completed score column has the correct text'
+    );
+    assert.equal(
+      'rgb(0, 255, 0)',
+      column.css('background-color'),
+      'completed score column has the correct color'
+    );
+
+    // test rejected games
+    game = {
+      'status' : 'REJECTED',
+      'roundsWonA' : 0,
+      'roundsWonB' : 0,
+      'roundsDrawn' : 0,
+      'targetWins' : 4,
+      'colorA' : '#aaaaaa',
+      'colorB' : '#bbbbbb',
+    }
+
+    column = History.scoreCol(game);
+    assert.ok(column.is('td'), 'rejected score column has the correct type');
+    assert.equal(
+      '–/–/– (4)',
+      column.text(),
+      'rejected score column has the correct text'
+    );
+    assert.equal(
+      'rgb(255, 255, 255)',
+      column.css('background-color'),
+      'rejected score column has the correct color'
+    );
+});
+
 test("test_History.buildResultsTableFooter", function(assert) {
   stop();
   History.searchParameters = {

--- a/test/src/ui/js/test_History.js
+++ b/test/src/ui/js/test_History.js
@@ -257,8 +257,36 @@ test("test_History.scoreCol", function(assert) {
   var game;
   var column;
 
-  // test normal games
+  // test new games
   game = {
+    'gameStart' : 10000,
+    'lastMove' : 10000,
+    'status' : 'ACTIVE',
+    'roundsWonA' : 0,
+    'roundsWonB' : 0,
+    'roundsDrawn' : 0,
+    'targetWins' : 4,
+    'colorA' : '#aaaaaa',
+    'colorB' : '#bbbbbb',
+  };
+
+  column = History.scoreCol(game);
+  assert.ok(column.is('td'), 'new game score column has the correct type');
+  assert.equal(
+    '–/–/– (4)',
+    column.text(),
+    'new game score column has the correct text'
+  );
+  assert.equal(
+    'rgb(255, 255, 255)',
+    column.css('background-color'),
+    'new game score column has the correct color'
+  );
+
+  // test normal active games
+  game = {
+    'gameStart' : 10000,
+    'lastMove' : 15000,
     'status' : 'ACTIVE',
     'roundsWonA' : 1,
     'roundsWonB' : 2,
@@ -269,20 +297,22 @@ test("test_History.scoreCol", function(assert) {
   };
 
   column = History.scoreCol(game);
-  assert.ok(column.is('td'), 'active score column has the correct type');
+  assert.ok(column.is('td'), 'active game score column has the correct type');
   assert.equal(
     '1/2/4 (5)',
     column.text(),
-    'active score column has the correct text'
+    'active game score column has the correct text'
   );
   assert.equal(
     'rgb(255, 255, 255)',
     column.css('background-color'),
-    'active score column has the correct color'
+    'active game score column has the correct color'
   );
 
   // test completed games
   game = {
+    'gameStart' : 10000,
+    'lastMove' : 18000,
     'status' : 'COMPLETED',
     'roundsWonA' : 1,
     'roundsWonB' : 3,
@@ -293,20 +323,25 @@ test("test_History.scoreCol", function(assert) {
   };
 
   column = History.scoreCol(game);
-  assert.ok(column.is('td'), 'completed score column has the correct type');
+  assert.ok(
+    column.is('td'),
+    'completed game score column has the correct type'
+  );
   assert.equal(
     '1/3/2 (3)',
     column.text(),
-    'completed score column has the correct text'
+    'completed game score column has the correct text'
   );
   assert.equal(
     'rgb(0, 255, 0)',
     column.css('background-color'),
-    'completed score column has the correct color'
+    'completed game score column has the correct color'
   );
 
   // test rejected games
   game = {
+    'gameStart' : 10000,
+    'lastMove' : 12000,
     'status' : 'REJECTED',
     'roundsWonA' : 0,
     'roundsWonB' : 0,
@@ -317,16 +352,16 @@ test("test_History.scoreCol", function(assert) {
   };
 
   column = History.scoreCol(game);
-  assert.ok(column.is('td'), 'rejected score column has the correct type');
+  assert.ok(column.is('td'), 'rejected game score column has the correct type');
   assert.equal(
     '–/–/– (4)',
     column.text(),
-    'rejected score column has the correct text'
+    'rejected game score column has the correct text'
   );
   assert.equal(
     'rgb(255, 255, 255)',
     column.css('background-color'),
-    'rejected score column has the correct color'
+    'rejected game score column has the correct color'
   );
 });
 

--- a/test/src/ui/js/test_History.js
+++ b/test/src/ui/js/test_History.js
@@ -254,80 +254,80 @@ test("test_History.buildResultsTableBody", function(assert) {
 });
 
 test("test_History.scoreCol", function(assert) {
-    var game;
-    var column;
+  var game;
+  var column;
 
-    // test normal games
-    game = {
-      'status' : 'ACTIVE',
-      'roundsWonA' : 1,
-      'roundsWonB' : 2,
-      'roundsDrawn' : 4,
-      'targetWins' : 5,
-      'colorA' : '#aa0000',
-      'colorB' : '#00bb00',
-    }
+  // test normal games
+  game = {
+    'status' : 'ACTIVE',
+    'roundsWonA' : 1,
+    'roundsWonB' : 2,
+    'roundsDrawn' : 4,
+    'targetWins' : 5,
+    'colorA' : '#aa0000',
+    'colorB' : '#00bb00',
+  };
 
-    column = History.scoreCol(game);
-    assert.ok(column.is('td'), 'active score column has the correct type');
-    assert.equal(
-      '1/2/4 (5)',
-      column.text(),
-      'active score column has the correct text'
-    );
-    assert.equal(
-      'rgb(255, 255, 255)',
-      column.css('background-color'),
-      'active score column has the correct color'
-    );
+  column = History.scoreCol(game);
+  assert.ok(column.is('td'), 'active score column has the correct type');
+  assert.equal(
+    '1/2/4 (5)',
+    column.text(),
+    'active score column has the correct text'
+  );
+  assert.equal(
+    'rgb(255, 255, 255)',
+    column.css('background-color'),
+    'active score column has the correct color'
+  );
 
-    // test completed games
-    game = {
-      'status' : 'COMPLETED',
-      'roundsWonA' : 1,
-      'roundsWonB' : 3,
-      'roundsDrawn' : 2,
-      'targetWins' : 3,
-      'colorA' : '#ff0000',
-      'colorB' : '#00ff00',
-    }
+  // test completed games
+  game = {
+    'status' : 'COMPLETED',
+    'roundsWonA' : 1,
+    'roundsWonB' : 3,
+    'roundsDrawn' : 2,
+    'targetWins' : 3,
+    'colorA' : '#ff0000',
+    'colorB' : '#00ff00',
+  };
 
-    column = History.scoreCol(game);
-    assert.ok(column.is('td'), 'completed score column has the correct type');
-    assert.equal(
-      '1/3/2 (3)',
-      column.text(),
-      'completed score column has the correct text'
-    );
-    assert.equal(
-      'rgb(0, 255, 0)',
-      column.css('background-color'),
-      'completed score column has the correct color'
-    );
+  column = History.scoreCol(game);
+  assert.ok(column.is('td'), 'completed score column has the correct type');
+  assert.equal(
+    '1/3/2 (3)',
+    column.text(),
+    'completed score column has the correct text'
+  );
+  assert.equal(
+    'rgb(0, 255, 0)',
+    column.css('background-color'),
+    'completed score column has the correct color'
+  );
 
-    // test rejected games
-    game = {
-      'status' : 'REJECTED',
-      'roundsWonA' : 0,
-      'roundsWonB' : 0,
-      'roundsDrawn' : 0,
-      'targetWins' : 4,
-      'colorA' : '#aaaaaa',
-      'colorB' : '#bbbbbb',
-    }
+  // test rejected games
+  game = {
+    'status' : 'REJECTED',
+    'roundsWonA' : 0,
+    'roundsWonB' : 0,
+    'roundsDrawn' : 0,
+    'targetWins' : 4,
+    'colorA' : '#aaaaaa',
+    'colorB' : '#bbbbbb',
+  };
 
-    column = History.scoreCol(game);
-    assert.ok(column.is('td'), 'rejected score column has the correct type');
-    assert.equal(
-      '–/–/– (4)',
-      column.text(),
-      'rejected score column has the correct text'
-    );
-    assert.equal(
-      'rgb(255, 255, 255)',
-      column.css('background-color'),
-      'rejected score column has the correct color'
-    );
+  column = History.scoreCol(game);
+  assert.ok(column.is('td'), 'rejected score column has the correct type');
+  assert.equal(
+    '–/–/– (4)',
+    column.text(),
+    'rejected score column has the correct text'
+  );
+  assert.equal(
+    'rgb(255, 255, 255)',
+    column.css('background-color'),
+    'rejected score column has the correct color'
+  );
 });
 
 test("test_History.buildResultsTableFooter", function(assert) {

--- a/test/src/ui/js/test_History.js
+++ b/test/src/ui/js/test_History.js
@@ -257,36 +257,10 @@ test("test_History.scoreCol", function(assert) {
   var game;
   var column;
 
-  // test new games
-  game = {
-    'gameStart' : 10000,
-    'lastMove' : 10000,
-    'status' : 'ACTIVE',
-    'roundsWonA' : 0,
-    'roundsWonB' : 0,
-    'roundsDrawn' : 0,
-    'targetWins' : 4,
-    'colorA' : '#aaaaaa',
-    'colorB' : '#bbbbbb',
-  };
-
-  column = History.scoreCol(game);
-  assert.ok(column.is('td'), 'new game score column has the correct type');
-  assert.equal(
-    '–/–/– (4)',
-    column.text(),
-    'new game score column has the correct text'
-  );
-  assert.equal(
-    'rgb(255, 255, 255)',
-    column.css('background-color'),
-    'new game score column has the correct color'
-  );
+  // james: there needs to be a test for new games when this is supported
 
   // test normal active games
   game = {
-    'gameStart' : 10000,
-    'lastMove' : 15000,
     'status' : 'ACTIVE',
     'roundsWonA' : 1,
     'roundsWonB' : 2,
@@ -311,8 +285,6 @@ test("test_History.scoreCol", function(assert) {
 
   // test completed games
   game = {
-    'gameStart' : 10000,
-    'lastMove' : 18000,
     'status' : 'COMPLETED',
     'roundsWonA' : 1,
     'roundsWonB' : 3,
@@ -340,8 +312,6 @@ test("test_History.scoreCol", function(assert) {
 
   // test rejected games
   game = {
-    'gameStart' : 10000,
-    'lastMove' : 12000,
     'status' : 'REJECTED',
     'roundsWonA' : 0,
     'roundsWonB' : 0,


### PR DESCRIPTION
Addresses part of #1840.

I am aware that the logic to detect new games is not really the best way, but until we explicitly add the ability to search for New Games in the history page (and perhaps add an extra game status type), the current implementation seems to be the easiest way to achieve the goal.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1011/
