### PR TITLE
Fix regression which entirely broke user verification page

### DIFF
--- a/src/ui/js/Verify.js
+++ b/src/ui/js/Verify.js
@@ -50,10 +50,13 @@ Verify.getVerifyParams = function(callbackfunc) {
 };
 
 Verify.showStatePage = function() {
+  Verify.page = $('<div>');
 
   // If there is a message from a current or previous invocation of this
   // page, display it now
   Env.showStatusMessage();
+
+  Login.arrangePage(Verify.page);
 };
 
 Verify.setVerifyUserSuccessMessage = function(message) {


### PR DESCRIPTION
What it says on the tin.  If you try to verify a user right now on dev or prod, you'll get a blank page.

Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/422/ (if it passes)