### PR TITLE
Disabled Connecticut so that mood option doesn't get misinterpreted

### DIFF
--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -798,7 +798,7 @@ INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
 # Replaced $p(20) with Up(20) and $q(12) with Uq(12)
 (590, 'California',      '@(10) @(20) Up(20) Uq(12) (Y)? (Z)',             0, 0, (SELECT id FROM buttonset WHERE name="50 States")),
 (591, 'Colorado',        '(4) (6) z(14) (U)? (U)?',                        0, 0, (SELECT id FROM buttonset WHERE name="50 States")),
-(592, 'Connecticut',     'H(4) v(11) h(20) (4/20)? (R)',                   0, 0, (SELECT id FROM buttonset WHERE name="50 States")),
+(592, 'Connecticut',     'H(4) v(11) h(20) (4/20)? (R)',                   1, 0, (SELECT id FROM buttonset WHERE name="50 States")),
 (593, 'Delaware',        '(1) (4) h(6) f(8) (T)',                          0, 0, (SELECT id FROM buttonset WHERE name="50 States")),
 (594, 'Florida',       'g(6) F(10) p(12) (U) r(4) r(6) hr(12) @whr(20)',   0, 0, (SELECT id FROM buttonset WHERE name="50 States")),
 (595, 'Georgia(US)',     'oz(10) (4/20) B(X) B(X) q(X)',                   0, 0, (SELECT id FROM buttonset WHERE name="50 States")),

--- a/deploy/database/updates/01927_mood_option_01.sql
+++ b/deploy/database/updates/01927_mood_option_01.sql
@@ -1,0 +1,3 @@
+UPDATE button
+SET btn_special=1
+WHERE name='Connecticut';


### PR DESCRIPTION
Addresses part of #1927.

Requires database update 01927_mood_option_01.sql.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1054/