### PR TITLE
Add a few missing skills and interactions to responderTest's hardcoded list

### DIFF
--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -163,6 +163,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
                 'description' => 'Cannot win initiative.',
                 'interacts' => array(),
             ),
+            'Insult' => array(
+                'code' => 'I',
+                'description' => 'Cannot be attacked by skill attacks.',
+                'interacts' => array(),
+            ),
             'Konstant' => array(
                 'code' => 'k',
                 'description' => 'These dice do not reroll after an attack; they keep their current value. Konstant dice can not Power Attack, and cannot perform a Skill Attack by themselves, but they can add OR subtract their value in a multi-dice Skill Attack. If another skill causes a Konstant die to reroll (e.g., Chance, Trip, Ornery), it continues to show the same value. If another skill causes the die to change its value without rerolling (e.g., Focus, Fire), the die\'s value does change and then continues to show that new value.',
@@ -231,6 +236,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
                 'description' => 'These dice are worth negative points. If you keep a Poison Die of your own at the end of a round, subtract its full value from your score. If you capture a Poison Die from someone else, subtract half its value from your score.',
                 'interacts' => array(
                      'Null' => 'Dice with both Null and Poison skills are Null',
+                     'Value' => 'Dice with both Poison and Value skills are Poison dice that score based on the negative of their current value rather than on their number of sides',
                 ),
             ),
             'Queer' => array(
@@ -318,6 +324,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
                 'description' => 'These dice are not scored like normal dice. Instead, a Value Die is scored as if the number of sides it has is equal to the value that it is currently showing. If a Value Die is ever part of an attack, all dice that are captured become Value Dice (i.e. They are scored by the current value they are showing when they are captured, not by their size).',
                 'interacts' => array(
                      'Null' => 'Dice with both Null and Value skills are Null',
+                     'Poison' => 'Dice with both Poison and Value skills are Poison dice that score based on the negative of their current value rather than on their number of sides',
                 ),
             ),
             'Warrior' => array(
@@ -332,6 +339,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
                     'Berserk' => 'Dice with both Berserk and Weak skills will first halve in size, and then shrink',
                     'Fire' => 'Dice with both Fire and Weak skills do not shrink when firing, only when actually rolling',
                 ),
+            ),
+            'Zero' => array(
+                'code' => '',
+                'description' => 'Copies the opponent\'s button recipe.',
+                'interacts' => array(),
             ),
         );
         $retval = array();


### PR DESCRIPTION
No effect on existing tests, but these skill definitions are correct, and not having them sometimes causes false positives in regression tests i run with RandomAI.

Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/426/