### PR TITLE
Use apache to log whether API calls are successful within the BM engine

### DIFF
--- a/deploy/vagrant/modules/apache/templates/site_default.erb
+++ b/deploy/vagrant/modules/apache/templates/site_default.erb
@@ -94,7 +94,7 @@
     # alert, emerg.
     LogLevel warn
 
-    CustomLog ${APACHE_LOG_DIR}/access.log "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" BMUser=%{BMUserID}n BMAPI=%{BMAPIMethod}n"
+    CustomLog ${APACHE_LOG_DIR}/access.log "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" BMUser=%{BMUserID}n BMAPI=%{BMAPIMethod}n BMStatus=%{BMAPIStatus}n"
 
     Alias /doc/ "/usr/share/doc/"
     <Directory "/usr/share/doc/">

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -626,6 +626,7 @@ class ApiResponder {
                 'message' => $check['message'],
             );
         }
+        apache_note('BMAPIStatus', $output['status']);
 
         if ($this->isTest) {
             return $output;


### PR DESCRIPTION
This will help us understand and detect the call failure problem being reported by players on the prod site (#1989), and detect problems in the future in which API calls are failing unexpectedly.

Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/431/ - if it passes

Additional testing done:
* Browsing to `http://localhost:8080/ui/game.html?game=1` (game 1 exists) yielded:
```
10.0.2.2 - - [13/May/2016:11:11:04 +0000] "POST /api/responder HTTP/1.1" 200 55 "http://localhost:8080/ui/game.html?game=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=- BMAPI=loadPlayerName BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:04 +0000] "POST /api/responder HTTP/1.1" 200 103 "http://localhost:8080/ui/game.html?game=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=loadNextNewPost BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:04 +0000] "POST /api/responder HTTP/1.1" 200 76 "http://localhost:8080/ui/game.html?game=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=countPendingGames BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:04 +0000] "POST /api/responder HTTP/1.1" 200 6760 "http://localhost:8080/ui/game.html?game=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=loadGameData BMStatus=ok
```
* Browsing to `http://localhost:8080/ui/game.html?game=2` (game 2 does not exist) yielded:
```
10.0.2.2 - - [13/May/2016:11:11:13 +0000] "POST /api/responder HTTP/1.1" 200 55 "http://localhost:8080/ui/game.html?game=2" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=- BMAPI=loadPlayerName BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:14 +0000] "POST /api/responder HTTP/1.1" 200 103 "http://localhost:8080/ui/game.html?game=2" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=loadNextNewPost BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:14 +0000] "POST /api/responder HTTP/1.1" 200 76 "http://localhost:8080/ui/game.html?game=2" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=countPendingGames BMStatus=ok
10.0.2.2 - - [13/May/2016:11:11:14 +0000] "POST /api/responder HTTP/1.1" 200 66 "http://localhost:8080/ui/game.html?game=2" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:46.0) Gecko/20100101 Firefox/46.0" BMUser=1 BMAPI=loadGameData BMStatus=failed
```
