### PR TITLE
Migrate action_log entries of type end_draw to new database structure

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -69,9 +69,16 @@ CREATE TABLE game_action_log (
     action_time        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     game_state         TINYINT UNSIGNED DEFAULT 10,
     action_type        VARCHAR(20),
+    type_log_id        INTEGER UNSIGNED DEFAULT NULL,
     acting_player      SMALLINT UNSIGNED NOT NULL,
     message            TEXT,
     INDEX (game_id)
+);
+
+CREATE TABLE game_action_log_type_end_draw (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    round_number       TINYINT UNSIGNED NOT NULL,
+    round_score        VARCHAR(10) NOT NULL
 );
 
 CREATE TABLE game_chat_log (

--- a/deploy/database/updates/01991_action_log.sql
+++ b/deploy/database/updates/01991_action_log.sql
@@ -1,0 +1,7 @@
+ALTER TABLE game_action_log ADD type_log_id INTEGER UNSIGNED DEFAULT NULL AFTER action_type;
+
+CREATE TABLE game_action_log_type_end_draw (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    round_number       TINYINT UNSIGNED NOT NULL,
+    round_score        VARCHAR(10) NOT NULL
+);

--- a/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+#####
+# Utility to migrate end_draw action log entries to new format
+
+import json
+import MySQLdb
+
+def get_last_insert_id(crs):
+  crs.execute('SELECT LAST_INSERT_ID()')
+  return crs.fetchone()[0]
+
+def migrate_to_type_log_end_draw(row, crs):
+  row_id = row[0]
+  msgdata = json.loads(row[1])
+  round_number = msgdata['roundNumber']
+  assert(len(msgdata['roundScoreArray']) == 2)
+  assert(msgdata['roundScoreArray'][0] == msgdata['roundScoreArray'][1])
+  round_score = msgdata['roundScoreArray'][0]
+  insert_sql = 'INSERT INTO game_action_log_type_end_draw ' + \
+    '(id, round_number, round_score) VALUES ' + \
+    '(0, %s, %s);' % (round_number, round_score)
+  result = crs.execute(insert_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+  type_log_id = get_last_insert_id(crs)
+  update_sql = 'UPDATE game_action_log SET type_log_id=%s,message=NULL WHERE id=%d' % (type_log_id, row_id)
+  result == crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Moved %s to game_action_log_type_end_draw id %s" % (row[1], type_log_id)
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="end_draw" ' + \
+  'AND type_log_id IS NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_end_draw(row, crs)
+conn.commit()

--- a/deploy/database/updates/scripts/README
+++ b/deploy/database/updates/scripts/README
@@ -1,0 +1,3 @@
+This directory contains non-SQL scripts which can be used to migrate
+database contents as part of updates.  The naming scheme should be
+similar to the updates directory.

--- a/deploy/vagrant/modules/mysql/manifests/init.pp
+++ b/deploy/vagrant/modules/mysql/manifests/init.pp
@@ -1,9 +1,12 @@
 # Configuration for a buttonmen mysql server
 class mysql::server {
 
-  # Install mysql-server and php5-mysql packages
   package {
+    # Install mysql-server and php5-mysql packages
     "mysql-server": ensure => installed;
     "php5-mysql": ensure => installed;
+
+    # Install python-mysqldb for use by helper scripts
+    "python-mysqldb": ensure => installed;
   }
 }

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1901,7 +1901,7 @@ class BMGame {
                 0,
                 array(
                     'roundNumber' => $this->get_prevRoundNumber(),
-                    'roundScoreArray' => $roundScoreArray,
+                    'roundScore'  => $roundScoreArray[0],
                 )
             );
         } else {

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -112,8 +112,8 @@ class BMGameAction {
     protected function friendly_message_end_draw() {
         $message = 'Round ' . $this->params['roundNumber'] .
                    ' ended in a draw (' .
-                   $this->params['roundScoreArray'][0] . ' vs. ' .
-                   $this->params['roundScoreArray'][1] . ')';
+                   $this->params['roundScore'] . ' vs. ' .
+                   $this->params['roundScore'] . ')';
         return $message;
     }
 

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -89,6 +89,12 @@ class BMInterface {
         return $interface;
     }
 
+    public function game_action() {
+        $interface = $this->cast('BMInterfaceGameAction');
+        $interface->parent = $this;
+        return $interface;
+    }
+
     public function history() {
         $interface = $this->cast('BMInterfaceHistory');
         $interface->parent = $this;
@@ -144,7 +150,7 @@ class BMInterface {
                 $data['playerDataArray'][$gamePlayerIdx]['isOnVacation'] = $isOnVacation;
             }
 
-            $actionLogArray = $this->load_game_action_log($game, $logEntryLimit);
+            $actionLogArray = $this->game_action()->load_game_action_log($game, $logEntryLimit);
             if (empty($actionLogArray)) {
                 $data['gameActionLog'] = NULL;
                 $data['gameActionLogCount'] = 0;
@@ -706,7 +712,7 @@ class BMInterface {
             $this->save_captured_dice($game);
             $this->save_out_of_play_dice($game);
             $this->delete_dice_marked_as_deleted($game);
-            $this->save_action_log($game);
+            $this->game_action()->save_action_log($game);
             $this->save_chat_log($game);
         } catch (Exception $e) {
             error_log(
@@ -1124,16 +1130,6 @@ class BMInterface {
                  'AND game_id = :game_id;';
         $statement = self::$conn->prepare($query);
         $statement->execute(array(':game_id' => $game->gameId));
-    }
-
-    protected function save_action_log($game) {
-        // If any game action entries were generated, load them
-        // into the message so the calling player can see them,
-        // then save them to the historical log
-        if (count($game->actionLog) > 0) {
-            $this->load_message_from_game_actions($game);
-            $this->log_game_actions($game);
-        }
     }
 
     protected function save_chat_log($game) {
@@ -1882,80 +1878,6 @@ class BMInterface {
         }
     }
 
-    // Enter recent game actions into the action log
-    // Note: it might be possible for this to be a protected function
-    protected function log_game_actions(BMGame $game) {
-        $query = 'INSERT INTO game_action_log ' .
-                 '(game_id, game_state, action_type, acting_player, message) ' .
-                 'VALUES ' .
-                 '(:game_id, :game_state, :action_type, :acting_player, :message)';
-        foreach ($game->actionLog as $gameAction) {
-            $statement = self::$conn->prepare($query);
-            $statement->execute(
-                array(':game_id'     => $game->gameId,
-                      ':game_state' => $gameAction->gameState,
-                      ':action_type' => $gameAction->actionType,
-                      ':acting_player' => $gameAction->actingPlayerId,
-                      ':message'    => json_encode($gameAction->params))
-            );
-        }
-        $game->empty_action_log();
-    }
-
-    protected function load_game_action_log(BMGame $game, $logEntryLimit) {
-        try {
-            $sqlParameters = array(':game_id' => $game->gameId);
-            $query = 'SELECT UNIX_TIMESTAMP(action_time) AS action_timestamp, ' .
-                     'game_state,action_type,acting_player,message ' .
-                     'FROM game_action_log ';
-            $query .= $this->build_game_log_query_restrictions($game, FALSE, FALSE, $sqlParameters);
-
-            $statement = self::$conn->prepare($query);
-            $statement->execute($sqlParameters);
-            $logEntries = array();
-            $playerIdNames = $this->get_player_name_mapping($game);
-            while ($row = $statement->fetch()) {
-                $params = json_decode($row['message'], TRUE);
-                if (!($params)) {
-                    $params = $row['message'];
-                }
-                $gameAction = new BMGameAction(
-                    $row['game_state'],
-                    $row['action_type'],
-                    $row['acting_player'],
-                    $params
-                );
-
-                // Only add the message to the log if one is returned: friendly_message() may
-                // intentionally return no message if providing one would leak information
-                $message = $gameAction->friendly_message($playerIdNames, $game->roundNumber, $game->gameState);
-                if ($message) {
-                    $logEntries[] = array(
-                        'timestamp' => (int)$row['action_timestamp'],
-                        'player' => $this->get_player_name_from_id($gameAction->actingPlayerId),
-                        'message' => $message,
-                    );
-                }
-            }
-
-            $nEntries = count($logEntries);
-
-            if (!is_null($logEntryLimit) &&
-                ($nEntries > $logEntryLimit)) {
-                $logEntries = array_slice($logEntries, 0, $logEntryLimit);
-            }
-
-            return array('logEntries' => $logEntries, 'nEntries' => $nEntries);
-        } catch (Exception $e) {
-            error_log(
-                'Caught exception in BMInterface::load_game_action_log: ' .
-                $e->getMessage()
-            );
-            $this->set_message('Internal error while reading log entries');
-            return NULL;
-        }
-    }
-
     protected function load_game_chat_log(BMGame $game, $logEntryLimit) {
         try {
             $sqlParameters = array(':game_id' => $game->gameId);
@@ -2014,31 +1936,6 @@ class BMInterface {
         }
 
         return $restrictions;
-    }
-
-    // Create a status message based on recent game actions
-    protected function load_message_from_game_actions(BMGame $game) {
-        $message = '';
-        $playerIdNames = $this->get_player_name_mapping($game);
-        foreach ($game->actionLog as $gameAction) {
-            $messagePart = $gameAction->friendly_message(
-                $playerIdNames,
-                $game->roundNumber,
-                $game->gameState
-            );
-
-            if (!empty($messagePart)) {
-                if ('.' == substr($messagePart, -1)) {
-                    $message .= $messagePart . ' ';
-                } else {
-                    $message .= $messagePart . '. ';
-                }
-            }
-        }
-
-        if (!empty($message)) {
-            $this->set_message($message);
-        }
     }
 
     protected function get_config($conf_key) {

--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -962,7 +962,7 @@ class BMInterfaceGame extends BMInterface {
             }
             $chatArray = $this->load_game_chat_log($game, 1);
             $lastChatEntryList = $chatArray['chatEntries'];
-            $logArray = $this->load_game_action_log($game, 1);
+            $logArray = $this->game_action()->load_game_action_log($game, 1);
             $lastActionEntryList = $logArray['logEntries'];
 
             if ($editTimestamp) {

--- a/src/engine/BMInterfaceGameAction.php
+++ b/src/engine/BMInterfaceGameAction.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * BMInterfaceGameAction: interface between GUI and BMGameAction for action-log-related requests
+ *
+ * @author chaos
+ */
+
+/**
+ * This class deals with communication between the UI, the game code, and the database
+ * pertaining to action-log-related information
+ */
+
+class BMInterfaceGameAction extends BMInterface {
+
+    /**
+     * Load recent game action log entries from the database
+     *
+     * @param BMGame $game
+     * @param int|NULL $logEntryLimit
+     * @return array
+     */
+    public function load_game_action_log(BMGame $game, $logEntryLimit) {
+        try {
+            $sqlParameters = array(':game_id' => $game->gameId);
+            $query = 'SELECT UNIX_TIMESTAMP(action_time) AS action_timestamp, ' .
+                     'game_state,action_type,acting_player,message ' .
+                     'FROM game_action_log ';
+            $query .= $this->build_game_log_query_restrictions($game, FALSE, FALSE, $sqlParameters);
+
+            $statement = self::$conn->prepare($query);
+            $statement->execute($sqlParameters);
+            $logEntries = array();
+            $playerIdNames = $this->get_player_name_mapping($game);
+            while ($row = $statement->fetch()) {
+                $params = json_decode($row['message'], TRUE);
+                if (!($params)) {
+                    $params = $row['message'];
+                }
+                $gameAction = new BMGameAction(
+                    $row['game_state'],
+                    $row['action_type'],
+                    $row['acting_player'],
+                    $params
+                );
+
+                // Only add the message to the log if one is returned: friendly_message() may
+                // intentionally return no message if providing one would leak information
+                $message = $gameAction->friendly_message($playerIdNames, $game->roundNumber, $game->gameState);
+                if ($message) {
+                    $logEntries[] = array(
+                        'timestamp' => (int)$row['action_timestamp'],
+                        'player' => $this->get_player_name_from_id($gameAction->actingPlayerId),
+                        'message' => $message,
+                    );
+                }
+            }
+
+            $nEntries = count($logEntries);
+
+            if (!is_null($logEntryLimit) &&
+                ($nEntries > $logEntryLimit)) {
+                $logEntries = array_slice($logEntries, 0, $logEntryLimit);
+            }
+
+            return array('logEntries' => $logEntries, 'nEntries' => $nEntries);
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::load_game_action_log: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Internal error while reading log entries');
+            return NULL;
+        }
+    }
+
+    /**
+     * Save action log entries generated during the action in progress 
+     *
+     * Any game action entries which were generated should both be loaded into
+     * the message so the calling player can see them, and saved into the database
+     *
+     * @param BMGame $game
+     * @return void
+     */
+    public function save_action_log($game) {
+        if (count($game->actionLog) > 0) {
+            $this->load_message_from_game_actions($game);
+            $this->log_game_actions($game);
+        }
+    }
+
+    /**
+     * Save new game action log entries into the database
+     *
+     * @param BMGame $game
+     * @return void
+     */
+    protected function log_game_actions(BMGame $game) {
+        $query = 'INSERT INTO game_action_log ' .
+                 '(game_id, game_state, action_type, acting_player, message) ' .
+                 'VALUES ' .
+                 '(:game_id, :game_state, :action_type, :acting_player, :message)';
+        foreach ($game->actionLog as $gameAction) {
+            $statement = self::$conn->prepare($query);
+            $statement->execute(
+                array(':game_id'     => $game->gameId,
+                      ':game_state' => $gameAction->gameState,
+                      ':action_type' => $gameAction->actionType,
+                      ':acting_player' => $gameAction->actingPlayerId,
+                      ':message'    => json_encode($gameAction->params))
+            );
+        }
+        $game->empty_action_log();
+    }
+
+    /**
+     * Create a status message based on new game action log entries
+     *
+     * @param BMGame $game
+     * @return void
+     */
+    protected function load_message_from_game_actions(BMGame $game) {
+        $message = '';
+        $playerIdNames = $this->get_player_name_mapping($game);
+        foreach ($game->actionLog as $gameAction) {
+            $messagePart = $gameAction->friendly_message(
+                $playerIdNames,
+                $game->roundNumber,
+                $game->gameState
+            );
+
+            if (!empty($messagePart)) {
+                if ('.' == substr($messagePart, -1)) {
+                    $message .= $messagePart . ' ';
+                } else {
+                    $message .= $messagePart . '. ';
+                }
+            }
+        }
+
+        if (!empty($message)) {
+            $this->set_message($message);
+        }
+    }
+}

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -57,7 +57,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_end_draw()
      */
     public function test_friendly_message_end_draw() {
-        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_draw', 0, array('roundNumber' => 2, 'roundScoreArray' => array(23, 23)));
+        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_draw', 0, array('roundNumber' => 2, 'roundScore' => 23));
         $this->assertEquals(
             "Round 2 ended in a draw (23 vs. 23)",
             $this->object->friendly_message($this->playerIdNames, 0, 0)

--- a/test/src/engine/BMInterfaceGameActionTest.php
+++ b/test/src/engine/BMInterfaceGameActionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once 'BMInterfaceTestAbstract.php';
+
+class BMInterfaceGameActionTest extends BMInterfaceTestAbstract {
+
+    protected function init() {
+        $this->object = new BMInterfaceGameAction(TRUE);
+    }
+
+    public function test_dummy() {
+        // currently, there are no interface-level tests of game action functionality
+    }
+}


### PR DESCRIPTION
* This is the proposed framework for #1991
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/434/

In this pull:
* Create BMInterfaceGameActionLog.php and move the handful of existing action_log database functions there
* Add generic logic to action_log load and save methods to use dedicated tables where they exist
* Migrate the `end_draw` action log entry's load/store methods to use such a dedicated table, `game_action_log_type_end_draw`
* Provide an idempotent utility to be run as part of the deployment which migrates all existing `end_draw` entries
