### PR TITLE
Migrate end_winner action_log entry parameters to a separate database

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -81,6 +81,14 @@ CREATE TABLE game_action_log_type_end_draw (
     round_score        VARCHAR(10) NOT NULL
 );
 
+CREATE TABLE game_action_log_type_end_winner (
+    id                  INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    round_number        TINYINT UNSIGNED NOT NULL,
+    winning_round_score VARCHAR(10) NOT NULL,
+    losing_round_score  VARCHAR(10) NOT NULL,
+    surrendered         BOOLEAN DEFAULT FALSE
+);
+
 CREATE TABLE game_chat_log (
     id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     game_id            MEDIUMINT UNSIGNED NOT NULL,

--- a/deploy/database/updates/01991_action_log_end_winner.sql
+++ b/deploy/database/updates/01991_action_log_end_winner.sql
@@ -1,0 +1,7 @@
+CREATE TABLE game_action_log_type_end_winner (
+    id                  INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    round_number        TINYINT UNSIGNED NOT NULL,
+    winning_round_score VARCHAR(10) NOT NULL,
+    losing_round_score  VARCHAR(10) NOT NULL,
+    surrendered         BOOLEAN DEFAULT FALSE
+);

--- a/deploy/database/updates/scripts/01991_migrate_end_winner_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_end_winner_action_logs
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#####
+# Utility to migrate end_winner action log entries to new format
+
+import json
+import re
+import MySQLdb
+
+END_WINNER_OLD_STRING_RE = re.compile('^won round (\d+) \((-?[0-9\.]+) vs (-?[0-9\.]+)\)$')
+
+def get_last_insert_id(crs):
+  crs.execute('SELECT LAST_INSERT_ID()')
+  return crs.fetchone()[0]
+
+def migrate_to_type_log_end_winner(row, crs):
+  row_id = row[0]
+  try:
+    msgdata = json.loads(row[1])
+    round_number = msgdata['roundNumber']
+    assert(len(msgdata['roundScoreArray']) == 2)
+    winning_round_score = max([float(x) for x in msgdata['roundScoreArray']])
+    losing_round_score = min([float(x) for x in msgdata['roundScoreArray']])
+    round_score = msgdata['roundScoreArray'][0]
+    surrendered = bool('resultForced' in msgdata and msgdata['resultForced'])
+  except ValueError:
+    mobj = END_WINNER_OLD_STRING_RE.match(row[1])
+    if not mobj:
+      raise ValueError, "Could not match string: %s" % row[1]
+    round_number = mobj.group(1)
+    winning_round_score = max(float(mobj.group(2)), float(mobj.group(3)))
+    losing_round_score = min(float(mobj.group(2)), float(mobj.group(3)))
+    surrendered = False
+    
+  insert_sql = 'INSERT INTO game_action_log_type_end_winner ' + \
+    '(round_number, winning_round_score, losing_round_score, surrendered) VALUES ' + \
+    '(%s, %s, %s, %s);' % (round_number, winning_round_score, losing_round_score, surrendered)
+  result = crs.execute(insert_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+  type_log_id = get_last_insert_id(crs)
+  update_sql = 'UPDATE game_action_log SET type_log_id=%s,message=NULL WHERE id=%d' % (type_log_id, row_id)
+  result == crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Moved %s to game_action_log_type_end_winner id %s" % (row[1], type_log_id)
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="end_winner" ' + \
+  'AND type_log_id IS NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_end_winner(row, crs)
+conn.commit()

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1907,10 +1907,10 @@ class BMGame {
         } else {
             if (isset($this->forceRoundResult)) {
                 $winnerIdx = array_search(TRUE, $this->forceRoundResult);
-                $forceRoundResult = $this->forceRoundResult;
+                $surrendered = TRUE;
             } else {
                 $winnerIdx = array_search(max($roundScoreArray), $roundScoreArray);
-                $forceRoundResult = FALSE;
+                $surrendered = FALSE;
             }
 
             foreach ($this->playerArray as $playerIdx => $player) {
@@ -1930,8 +1930,9 @@ class BMGame {
                 $this->playerArray[$winnerIdx]->playerId,
                 array(
                     'roundNumber' => $this->get_prevRoundNumber(),
-                    'roundScoreArray' => $roundScoreArray,
-                    'resultForced' => $forceRoundResult,
+                    'winningRoundScore' => max($roundScoreArray),
+                    'losingRoundScore' => min($roundScoreArray),
+                    'surrendered' => $surrendered,
                 )
             );
         }

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -125,11 +125,11 @@ class BMGameAction {
     protected function friendly_message_end_winner() {
         $message = 'End of round: ' . $this->outputPlayerIdNames[$this->actingPlayerId] .
                    ' won round ' . $this->params['roundNumber'];
-        if (array_key_exists('resultForced', $this->params) && ($this->params['resultForced'])) {
+        if ($this->params['surrendered']) {
             $message .= ' because opponent surrendered';
         } else {
-            $message .= ' (' .  max($this->params['roundScoreArray']) . ' vs. ' .
-                        min($this->params['roundScoreArray']) . ')';
+            $message .= ' (' .  $this->params['winningRoundScore'] . ' vs. ' .
+                        $this->params['losingRoundScore'] . ')';
         }
         return $message;
     }

--- a/src/engine/BMInterfaceGameAction.php
+++ b/src/engine/BMInterfaceGameAction.php
@@ -149,6 +149,64 @@ class BMInterfaceGameAction extends BMInterface {
     }
 
     /**
+     * Load the parameters for a single game action log message of type end_winner
+     *
+     * @param int $row_id
+     * @return array
+     */
+    protected function load_params_from_type_log_end_winner($row_id) {
+        try {
+            $query = 'SELECT round_number,winning_round_score,losing_round_score,surrendered ' .
+                     ' FROM game_action_log_type_end_winner ' .
+                     'WHERE id=:row_id';
+            $statement = self::$conn->prepare($query);
+            $statement->execute(array(':row_id' => $row_id));
+            $row = $statement->fetch();
+            return array(
+                'roundNumber' => (int)$row['round_number'],
+                'winningRoundScore' => (float)$row['winning_round_score'],
+                'losingRoundScore' => (float)$row['losing_round_score'],
+                'surrendered' => (bool)$row['surrendered'],
+            );
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::load_params_from_type_log_end_winner: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Internal error while reading log entries');
+            return NULL;
+        }
+    }
+
+    /**
+     * Save the parameters for a single game action log message of type end_winner
+     *
+     * @param array $params
+     * @return void
+     */
+    protected function save_params_to_type_log_end_winner($params) {
+        try {
+            $query = 'INSERT INTO game_action_log_type_end_winner ' .
+                     '(round_number, winning_round_score, losing_round_score, surrendered) ' .
+                     'VALUES ' .
+                     '(:round_number, :winning_round_score, :losing_round_score, :surrendered)';
+            $statement = self::$conn->prepare($query);
+            $statement->execute(array(
+                ':round_number' => $params['roundNumber'],
+                ':winning_round_score' => $params['winningRoundScore'],
+                ':losing_round_score' => $params['losingRoundScore'],
+                ':surrendered' => $params['surrendered']));
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::save_params_to_type_log_end_winner: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Internal error while reading log entries');
+            return NULL;
+        }
+    }
+
+    /**
      * Helper function which asks the database for the ID of the last inserted row
      *
      * @return int

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -68,13 +68,13 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_end_winner()
      */
     public function test_friendly_message_end_winner() {
-        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_winner', 2, array('roundNumber' => 1, 'roundScoreArray' => array(24, 43), 'resultForced' => NULL));
+        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_winner', 2, array('roundNumber' => 1, 'winningRoundScore' => 43, 'losingRoundScore' => 24, 'surrendered' => FALSE));
         $this->assertEquals(
             "End of round: gameaction02 won round 1 (43 vs. 24)",
             $this->object->friendly_message($this->playerIdNames, 0, 0)
         );
 
-        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_winner', 2, array('roundNumber' => 2, 'roundScoreArray' => array(25, 23), 'resultForced' => array(FALSE, TRUE)));
+        $this->object = new BMGameAction(BMGameState::END_ROUND, 'end_winner', 2, array('roundNumber' => 2, 'roundScoreArray' => array(25, 23), 'surrendered' => TRUE));
         $this->assertEquals(
             "End of round: gameaction02 won round 2 because opponent surrendered",
             $this->object->friendly_message($this->playerIdNames, 0, 0)

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -7593,7 +7593,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $attackLogEntry = end($arrayVal);
         $this->assertEquals('end_winner', $attackLogEntry->actionType);
         $this->assertEquals(1, $attackLogEntry->params['roundNumber']);
-        $this->assertEquals(array(TRUE, FALSE), $attackLogEntry->params['resultForced']);
+        $this->assertEquals(TRUE, $attackLogEntry->params['surrendered']);
     }
 
     /**


### PR DESCRIPTION
* Partially addresses #1991 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/435/

Worth noting:
* I realised while testing this that there are old end_winner and end_draw entries in the dev database which are still in string form rather than JSON array form.  There aren't any in the prod database.  So i modified the script for end_winner to be able to handle either.  I'll go back and do the same for the end_draw script as a separate small pull, since that blocks pushing the end_draw change onto dev
* I chose to rename "resultForced" to "surrendered" within the action log sphere, because the code treats it as meaning surrendered (whenever it's set, the message printed is "surrendered")
* I chose to change the 'true' value of resultForced/surrendered from an array to a boolean.  The false value is a boolean, and, while this nominally loses information about which player surrendered: (1) we weren't using that information in any way, and (2) the way the game is implemented right now is that the player who surrendered is the one who didn't win the round.  So in practice we lose no information, and it's easier/more compact to deal with a boolean FALSE/TRUE than a boolean FALSE/array().
