### PR TITLE
Fix end_draw to work with grandfathered string entries from very early on the dev site

### DIFF
--- a/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
@@ -6,7 +6,7 @@ import json
 import re
 import MySQLdb
 
-END_DRAW_OLD_STRING_RE = re.compile('^Round (\d+) ended in a draw \((-?[0-9\.]+) vs\. (-?[0-9\.]+)\)$')
+END_DRAW_OLD_STRING_RE = re.compile('^Round (\d+) ended in a draw \((-?\d+(?:\.\d+)?) vs\. (-?\d+(?:\.\d+)?)\)$')
 
 def get_last_insert_id(crs):
   crs.execute('SELECT LAST_INSERT_ID()')
@@ -35,7 +35,7 @@ def migrate_to_type_log_end_draw(row, crs):
     raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
   type_log_id = get_last_insert_id(crs)
   update_sql = 'UPDATE game_action_log SET type_log_id=%s,message=NULL WHERE id=%d' % (type_log_id, row_id)
-  result == crs.execute(update_sql)
+  result = crs.execute(update_sql)
   if not result == 1:
     raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
   print "Moved %s to game_action_log_type_end_draw id %s" % (row[1], type_log_id)

--- a/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
@@ -3,7 +3,10 @@
 # Utility to migrate end_draw action log entries to new format
 
 import json
+import re
 import MySQLdb
+
+END_DRAW_OLD_STRING_RE = re.compile('^Round (\d+) ended in a draw \((-?[0-9\.]+) vs\. (-?[0-9\.]+)\)$')
 
 def get_last_insert_id(crs):
   crs.execute('SELECT LAST_INSERT_ID()')
@@ -11,11 +14,19 @@ def get_last_insert_id(crs):
 
 def migrate_to_type_log_end_draw(row, crs):
   row_id = row[0]
-  msgdata = json.loads(row[1])
-  round_number = msgdata['roundNumber']
-  assert(len(msgdata['roundScoreArray']) == 2)
-  assert(msgdata['roundScoreArray'][0] == msgdata['roundScoreArray'][1])
-  round_score = msgdata['roundScoreArray'][0]
+  try:
+    msgdata = json.loads(row[1])
+    round_number = msgdata['roundNumber']
+    assert(len(msgdata['roundScoreArray']) == 2)
+    assert(msgdata['roundScoreArray'][0] == msgdata['roundScoreArray'][1])
+    round_score = msgdata['roundScoreArray'][0]
+  except ValueError:
+    mobj = END_DRAW_OLD_STRING_RE.match(row[1])
+    if not mobj:
+      raise ValueError, "Could not match string: %s" % row[1]
+    round_number = mobj.group(1)
+    assert(mobj.group(2) == mobj.group(3))
+    round_score = mobj.group(2)
   insert_sql = 'INSERT INTO game_action_log_type_end_draw ' + \
     '(id, round_number, round_score) VALUES ' + \
     '(0, %s, %s);' % (round_number, round_score)


### PR DESCRIPTION
* Related to #1991 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/436/ (should pass, i haven't changed anything Jenkins tracks)

Tested by loading databases from each of the dev and prod sites, and seeing that they both could still be migrated, and that early dev games containing draws still looked right.