### PR TITLE
Remove extraneous parameter for decline_auxiliary

### DIFF
--- a/deploy/database/updates/scripts/01991_migrate_decline_auxiliary_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_decline_auxiliary_action_logs
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+#####
+# Utility to migrate decline_auxiliary action log entries to new format
+
+# N.B. decline_auxiliary does not actually have any parameters, so
+# there is no secondary table; we just clear the now-extraneous message
+# from the existing table
+
+import json
+import MySQLdb
+
+def get_last_insert_id(crs):
+  crs.execute('SELECT LAST_INSERT_ID()')
+  return crs.fetchone()[0]
+
+def migrate_to_type_log_decline_auxiliary(row, crs):
+  row_id = row[0]
+  update_sql = 'UPDATE game_action_log SET message=NULL WHERE id=%d' % (row_id)
+  result = crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Deleted message %s from decline_auxiliary action" % (row[1])
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="decline_auxiliary" ' + \
+  'AND message IS NOT NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_decline_auxiliary(row, crs)
+conn.commit()

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -57,9 +57,6 @@ class BMGameAction {
         $actingPlayerId,
         $params
     ) {
-        if (!$params) {
-            throw new Exception("BMGameAction error: params can't be empty");
-        }
         $this->gameState = $gameState;
         $this->actionType = $actionType;
         $this->actingPlayerId = $actingPlayerId;

--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1092,7 +1092,7 @@ class BMInterfaceGame extends BMInterface {
                     $game->log_action(
                         'decline_auxiliary',
                         $player->playerId,
-                        array('declineAuxiliary' => TRUE)
+                        array()
                     );
                     $this->set_message('Declined auxiliary dice');
                     break;

--- a/src/engine/BMInterfaceGameAction.php
+++ b/src/engine/BMInterfaceGameAction.php
@@ -36,6 +36,9 @@ class BMInterfaceGameAction extends BMInterface {
                 if ($row['type_log_id'] != NULL) {
                     $typefunc = 'load_params_from_type_log_' . $row['action_type'];
                     $params = $this->$typefunc($row['type_log_id']);
+                } elseif (in_array($row['action_type'], array('decline_auxiliary'))) {
+                    // This action_type does not store any parameters
+                    $params = array();
                 } else {
                     $params = json_decode($row['message'], TRUE);
                     if (!($params)) {
@@ -182,6 +185,10 @@ class BMInterfaceGameAction extends BMInterface {
             if (method_exists($this, $typefunc)) {
                 $this->$typefunc($gameAction->params);
                 $actionArgs[':type_log_id'] = $this->last_insert_id();
+                $actionArgs[':message'] = NULL;
+            } elseif (in_array($gameAction->actionType, array('decline_auxiliary'))) {
+                // This action_type does not store any parameters
+                $actionArgs[':type_log_id'] = NULL;
                 $actionArgs[':message'] = NULL;
             } else {
                 $actionArgs[':type_log_id'] = NULL;

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -749,7 +749,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_decline_auxiliary()
      */
     public function test_friendly_message_decline_auxiliary() {
-        $this->object = new BMGameAction(BMGameState::CHOOSE_AUXILIARY_DICE, 'decline_auxiliary', 2, array('declineAuxiliary' => TRUE));
+        $this->object = new BMGameAction(BMGameState::CHOOSE_AUXILIARY_DICE, 'decline_auxiliary', 2, array());
         $this->assertEquals(
             "gameaction02 chose not to use auxiliary dice in this game: neither player will get an auxiliary die",
                 $this->object->friendly_message($this->playerIdNames, 0, 0)


### PR DESCRIPTION
This is the example pattern for action_types which don't actually need to store any parameters.  The only reason decline_auxiliary had one was because of the check in BMGameAction.  That check isn't needed, i'm pretty sure it was just inserted to protect against trouble during the long-ago string-to-JSON conversion.

Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/437/