### PR TITLE
Change the database format for end_draw to put the index in the secondary table

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -69,7 +69,6 @@ CREATE TABLE game_action_log (
     action_time        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     game_state         TINYINT UNSIGNED DEFAULT 10,
     action_type        VARCHAR(20),
-    type_log_id        INTEGER UNSIGNED DEFAULT NULL,
     acting_player      SMALLINT UNSIGNED NOT NULL,
     message            TEXT,
     INDEX (game_id)
@@ -77,8 +76,10 @@ CREATE TABLE game_action_log (
 
 CREATE TABLE game_action_log_type_end_draw (
     id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
     round_number       TINYINT UNSIGNED NOT NULL,
-    round_score        VARCHAR(10) NOT NULL
+    round_score        VARCHAR(10) NOT NULL,
+    INDEX (action_log_id)
 );
 
 CREATE TABLE game_chat_log (

--- a/deploy/database/updates/01991_action_log.sql
+++ b/deploy/database/updates/01991_action_log.sql
@@ -1,7 +1,7 @@
-ALTER TABLE game_action_log ADD type_log_id INTEGER UNSIGNED DEFAULT NULL AFTER action_type;
-
 CREATE TABLE game_action_log_type_end_draw (
     id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
     round_number       TINYINT UNSIGNED NOT NULL,
-    round_score        VARCHAR(10) NOT NULL
+    round_score        VARCHAR(10) NOT NULL,
+    INDEX (action_log_id)
 );

--- a/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_end_draw_action_logs
@@ -8,10 +8,6 @@ import MySQLdb
 
 END_DRAW_OLD_STRING_RE = re.compile('^Round (\d+) ended in a draw \((-?\d+(?:\.\d+)?) vs\. (-?\d+(?:\.\d+)?)\)$')
 
-def get_last_insert_id(crs):
-  crs.execute('SELECT LAST_INSERT_ID()')
-  return crs.fetchone()[0]
-
 def migrate_to_type_log_end_draw(row, crs):
   row_id = row[0]
   try:
@@ -27,24 +23,25 @@ def migrate_to_type_log_end_draw(row, crs):
     round_number = mobj.group(1)
     assert(mobj.group(2) == mobj.group(3))
     round_score = mobj.group(2)
+
   insert_sql = 'INSERT INTO game_action_log_type_end_draw ' + \
-    '(id, round_number, round_score) VALUES ' + \
-    '(0, %s, %s);' % (round_number, round_score)
+    '(action_log_id, round_number, round_score) VALUES ' + \
+    '(%s, %s, %s);' % (row[0], round_number, round_score)
   result = crs.execute(insert_sql)
   if not result == 1:
     raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
-  type_log_id = get_last_insert_id(crs)
-  update_sql = 'UPDATE game_action_log SET type_log_id=%s,message=NULL WHERE id=%d' % (type_log_id, row_id)
+
+  update_sql = 'UPDATE game_action_log SET message=NULL WHERE id=%d' % (row_id)
   result = crs.execute(update_sql)
   if not result == 1:
     raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
-  print "Moved %s to game_action_log_type_end_draw id %s" % (row[1], type_log_id)
+  print "Moved row %s message %s to game_action_log_type_end_draw" % (row[0], row[1])
 
 conn = MySQLdb.connect(user='root', db='buttonmen')
 crs = conn.cursor()
 results = crs.execute(
   'SELECT id,message FROM game_action_log WHERE action_type="end_draw" ' + \
-  'AND type_log_id IS NULL')
+  'AND message IS NOT NULL')
 if results > 0:
   for row in crs.fetchall():
     migrate_to_type_log_end_draw(row, crs)


### PR DESCRIPTION
* Related to #1991 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/439/

I apologise for all the bother --- i think it makes much more sense to do things this way, and the fact that it simplifies the database update (no modify to game_action_log needed), saves space while we're in transition, and makes it easier to handle the case where no auxiliary table is needed (just have a secondary function with the usual name which returns empty params, rather than hardcoding an exception), makes me confident that this change is the right thing.