### PR TITLE
Exclude common ignorable errors from apache log monitor so it is usable

### DIFF
--- a/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
+++ b/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
@@ -6,5 +6,7 @@
   | grep -v "Caught exception in BMDie::create_from_string_components: Illegal die size: C" \
   | grep -v "Caught exception in BMDie::create_from_string_components: Invalid recipe: &" \
   | grep -v "Caught exception in BMDie::create_from_string_components: Invalid recipe: ," \
-  | grep -v "File does not exist: /var/www/test-ui/js/Env.js," \
-  | grep -v "File does not exist: /var/www/ui/images/button/"
+  | grep -v "File does not exist: " \
+  | grep -v " not found or unable to stat" \
+  | grep -v " Graceful restart requested, doing restart" \
+  | grep -v " resuming normal operations"


### PR DESCRIPTION
Goal here is just to make the apache log monitor a bit more usable - i've been finding that i fall pretty far behind on the mail it sends, which means i'm not using it as a straightforward way to detect internal errors in real-time.