### PR TITLE
Move turndown_focus action_log secondary information to dedicated tables

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -101,6 +101,15 @@ CREATE TABLE game_action_log_type_add_auxiliary (
     INDEX (action_log_id)
 );
 
+CREATE TABLE game_action_log_type_turndown_focus_die (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    recipe             VARCHAR(20) NOT NULL,
+    orig_value         SMALLINT,
+    turndown_value     SMALLINT,
+    INDEX (action_log_id)
+);
+
 CREATE TABLE game_chat_log (
     id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     game_id            MEDIUMINT UNSIGNED NOT NULL,

--- a/deploy/database/updates/01991_action_log_turndown_focus.sql
+++ b/deploy/database/updates/01991_action_log_turndown_focus.sql
@@ -1,0 +1,8 @@
+CREATE TABLE game_action_log_type_turndown_focus_die (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    recipe             VARCHAR(20) NOT NULL,
+    orig_value         SMALLINT,
+    turndown_value     SMALLINT,
+    INDEX (action_log_id)
+);

--- a/deploy/database/updates/scripts/01991_migrate_turndown_focus_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_turndown_focus_action_logs
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+#####
+# Utility to migrate turndown_focus action log entries to new format
+
+import json
+import MySQLdb
+
+def migrate_to_type_log_turndown_focus(row, crs):
+  row_id = row[0]
+  msgdata = json.loads(row[1])
+  pre_turndown = msgdata['preTurndown']
+  post_turndown = msgdata['postTurndown']
+  assert(len(pre_turndown) == len(post_turndown))
+
+  for i in range(len(pre_turndown)):
+    recipe = pre_turndown[i]['recipe']
+    orig_value = pre_turndown[i]['value']
+    turndown_value = post_turndown[i]['value']
+    insert_sql = 'INSERT INTO game_action_log_type_turndown_focus_die ' + \
+      '(action_log_id, recipe, orig_value, turndown_value) VALUES ' + \
+      '(%s, "%s", %s, %s);' % (row[0], recipe, orig_value, turndown_value)
+    result = crs.execute(insert_sql)
+    if not result == 1:
+      raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  update_sql = 'UPDATE game_action_log SET message=NULL WHERE id=%d' % (row_id)
+  result = crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Moved row %s message %s to game_action_log_type_turndown_focus_die" % (row[0], row[1])
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="turndown_focus" ' + \
+  'AND message IS NOT NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_turndown_focus(row, crs)
+conn.commit()

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -2301,13 +2301,9 @@ class BMGame {
 
         // change specified die values
         $oldDieValueArray = array();
-        $preTurndownData = array();
-        $postTurndownData = array();
         foreach ($args['focusValueArray'] as $dieIdx => $newDieValue) {
-            $preTurndownData[] = $player->activeDieArray[$dieIdx]->get_action_log_data();
             $oldDieValueArray[$dieIdx] = $player->activeDieArray[$dieIdx]->value;
             $player->activeDieArray[$dieIdx]->value = $newDieValue;
-            $postTurndownData[] = $player->activeDieArray[$dieIdx]->get_action_log_data();
         }
         $newInitiativeArray = BMGame::does_player_have_initiative_array(
             $this->getBMPlayerProps('activeDieArray')
@@ -2315,12 +2311,18 @@ class BMGame {
 
         // if the change is successful, disable focus dice that changed
         // value
+        $turndownDiceLogInfo = array();
         if ($newInitiativeArray[$playerIdx] &&
             1 == array_sum($newInitiativeArray)) {
             foreach ($oldDieValueArray as $dieIdx => $oldDieValue) {
                 if ($oldDieValue >
                     $player->activeDieArray[$dieIdx]->value) {
                     $player->activeDieArray[$dieIdx]->add_flag('Dizzy');
+                    $turndownDiceLogInfo[] = array(
+                        'recipe'        => $player->activeDieArray[$dieIdx]->get_recipe(TRUE),
+                        'origValue'     => $oldDieValue,
+                        'turndownValue' => $player->activeDieArray[$dieIdx]->value,
+                    );
                 }
             }
         } else {
@@ -2337,8 +2339,7 @@ class BMGame {
             'turndown_focus',
             $player->playerId,
             array(
-                'preTurndown' => $preTurndownData,
-                'postTurndown' => $postTurndownData,
+                'turndownDice' => $turndownDiceLogInfo,
             )
         );
 

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -813,9 +813,9 @@ class BMGameAction {
     protected function friendly_message_turndown_focus() {
         $message = $this->outputPlayerIdNames[$this->actingPlayerId] . ' gained initiative by turning down focus dice';
         $focusStrs = array();
-        foreach ($this->params['preTurndown'] as $idx => $die) {
-            $focusStrs[] = $die['recipe'] . ' from ' . $die['value'] . ' to ' .
-                           $this->params['postTurndown'][$idx]['value'];
+        foreach ($this->params['turndownDice'] as $die) {
+            $focusStrs[] = $die['recipe'] . ' from ' . $die['origValue'] . ' to ' .
+                           $die['turndownValue'];
         }
         $message .= ': ' . implode(", ", $focusStrs);
         return $message;

--- a/src/engine/BMInterfaceGameAction.php
+++ b/src/engine/BMInterfaceGameAction.php
@@ -286,6 +286,72 @@ class BMInterfaceGameAction extends BMInterface {
     }
 
     /**
+     * Load the parameters for a single game action log message of type turndown_focus
+     *
+     * @param int $action_log_id
+     * @return array
+     */
+    protected function load_params_from_type_log_turndown_focus($action_log_id) {
+        try {
+            // turndown_focus has one set of secondary parameters for each die which was turned down
+            $query = 'SELECT recipe,orig_value,turndown_value FROM game_action_log_type_turndown_focus_die ' .
+                     'WHERE action_log_id=:action_log_id';
+            $statement = self::$conn->prepare($query);
+            $statement->execute(array(':action_log_id' => $action_log_id));
+            $turndownDice = array();
+            while ($row = $statement->fetch()) {
+                $turndownDice[] = array(
+                    'recipe'        => (string)$row['recipe'],
+                    'origValue'     => (int)$row['orig_value'],
+                    'turndownValue' => (int)$row['turndown_value'],
+                );
+            }
+            return array(
+                'turndownDice' => $turndownDice,
+            );
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::load_params_from_type_log_turndown_focus: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Internal error while reading log entries');
+            return NULL;
+        }
+    }
+
+    /**
+     * Save the parameters for a single game action log message of type turndown_focus
+     *
+     * @param int $action_log_id
+     * @param array $params
+     * @return void
+     */
+    protected function save_params_to_type_log_turndown_focus($action_log_id, $params) {
+        try {
+            // turndown_focus has one set of secondary parameters for each die which was turned down
+            $query = 'INSERT INTO game_action_log_type_turndown_focus_die ' .
+                     '(action_log_id, recipe, orig_value, turndown_value) ' .
+                     'VALUES ' .
+                     '(:action_log_id, :recipe, :orig_value, :turndown_value)';
+            foreach ($params['turndownDice'] as $die) {
+                $statement = self::$conn->prepare($query);
+                $statement->execute(array(
+                    ':action_log_id'  => $action_log_id,
+                    ':recipe'         => $die['recipe'],
+                    ':orig_value'     => $die['origValue'],
+                    ':turndown_value' => $die['turndownValue']));
+            }
+        } catch (Exception $e) {
+            error_log(
+                'Caught exception in BMInterface::save_params_to_type_log_turndown_focus: ' .
+                $e->getMessage()
+            );
+            $this->set_message('Internal error while saving log entries');
+            return NULL;
+        }
+    }
+
+    /**
      * Helper function which asks the database for the ID of the last inserted row
      *
      * @return int

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -684,9 +684,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      */
     public function test_friendly_message_turndown_focus() {
         $this->object = new BMGameAction(BMGameState::REACT_TO_INITIATIVE, 'turndown_focus', 1, array(
-            'preTurndown' => array(array('recipe' => 'f(20)', 'min' => 1, 'max' => 20, 'value' => 4, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => 'f(20):4')),
-            'postTurndown' => array(array('recipe' => 'f(20)', 'min' => 1, 'max' => 20, 'value' => 2, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => 'f(20):2')),
-            'gainedInitiative' => FALSE,
+            'turndownDice' => array(array('recipe' => 'f(20)', 'origValue' => 4, 'turndownValue' => 2)),
         ));
         $this->assertEquals(
             "gameaction01 gained initiative by turning down focus dice: f(20) from 4 to 2",


### PR DESCRIPTION
* Partially addresses #1991 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/449/ (if it passes)

Note that this is the first example of a case in which there might be more than one secondary table entry per primary log entry.  IMO it's pretty clean, but obviously i'll be doing a bunch more of this when i get to stuff like specify_dice and attack.  Worth noting is that i named the secondary table `...turndown_focus_die` rather than `...turndown_focus` as a marker that it's a per-turndown-focus-entry-die table rather than a per-turndown-focus-entry table (and when i get to specify_dice and attack there may be more than one secondary table, each storing a different type of secondary data).

Also worth noting is that the savings here are pretty big per-entry (though of course there are a small number of entries) --- the new secondary data is 6% of the size of the old secondary data.  Turns out that storing a bunch of die information we don't need in JSON with big string prefixes is expensive.