### PR TITLE
Remove extraneous parameter from init_decline action log messages

### DIFF
--- a/deploy/database/updates/scripts/01991_migrate_init_decline_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_init_decline_action_logs
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+#####
+# Utility to migrate init_decline action log entries to new format
+#
+# N.B. init_decline does not actually have any parameters, so
+# there is no secondary table; we just clear the now-extraneous message
+# from the existing table
+
+import json
+import MySQLdb
+
+def migrate_to_type_log_init_decline(row, crs):
+  row_id = row[0]
+  update_sql = 'UPDATE game_action_log SET message=NULL WHERE id=%d' % (row_id)
+  result = crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Deleted row %s message %s from game_action_log" % (row[0], row[1])
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="init_decline" ' + \
+  'AND message IS NOT NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_init_decline(row, crs)
+conn.commit()

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -2237,7 +2237,7 @@ class BMGame {
         $this->log_action(
             'init_decline',
             $player->playerId,
-            array('initDecline' => TRUE)
+            array()
         );
 
         if (!$this->isWaitingOnAnyAction()) {

--- a/src/engine/BMInterfaceGameAction.php
+++ b/src/engine/BMInterfaceGameAction.php
@@ -415,6 +415,26 @@ class BMInterfaceGameAction extends BMInterface {
     }
 
     /**
+     * Load the parameters for a single game action log message of type init_decline
+     *
+     * @return array
+     */
+    protected function load_params_from_type_log_init_decline() {
+        // init_decline has no secondary parameters
+        return array();
+    }
+
+    /**
+     * Save the parameters for a single game action log message of type init_decline
+     *
+     * @return void
+     */
+    protected function save_params_to_type_log_init_decline() {
+        // init_decline has no secondary parameters
+        return;
+    }
+
+    /**
      * Helper function which asks the database for the ID of the last inserted row
      *
      * @return int

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -694,7 +694,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
      * @covers BMGameAction::friendly_message_init_decline()
      */
     public function test_friendly_message_init_decline() {
-        $this->object = new BMGameAction(BMGameState::REACT_TO_INITIATIVE, 'init_decline', 2, array('initDecline' => TRUE));
+        $this->object = new BMGameAction(BMGameState::REACT_TO_INITIATIVE, 'init_decline', 2, array());
         $this->assertEquals(
             "gameaction02 chose not to try to gain initiative using chance or focus dice",
             $this->object->friendly_message($this->playerIdNames, 0, 0)


### PR DESCRIPTION
* Partially addresses #1991 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/454/ (if it passes)

This one should be pretty boring - unless i mucked up the merge and it fails tests, i doubt there's anything to see here.