### PR TITLE
add unit tests for UI gamePlayerDice() method

### DIFF
--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -8413,6 +8413,9 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
     }
 
+    /**
+     * @depends test_request_savePlayerInfo
+     */
     public function test_interface_game_019() {
 
         // responder003 is the POV player, so if you need to fake
@@ -8831,6 +8834,14 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $expData['gameActionLogCount'] = 17;
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+
+        // Now load the game as responder004 and check its state
+        $_SESSION = $this->mock_test_user_login('responder004');
+        $expData['currentPlayerIdx'] = 1;
+        $expData['playerDataArray'][0]['playerColor'] = '#ddffdd';
+        $expData['playerDataArray'][1]['playerColor'] = '#dd99dd';
+        $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+        $_SESSION = $this->mock_test_user_login('responder003');
     }
 
     /**

--- a/test/src/ui/js/BMTestUtils.js
+++ b/test/src/ui/js/BMTestUtils.js
@@ -112,6 +112,7 @@ BMTestUtils.testGameId = function(gameDesc) {
   if (gameDesc == 'pikathulhu_phoenix_reacttoinitiative_active') { return '1902'; }
   if (gameDesc == 'pikathulhu_phoenix_reacttoinitiative_nonplayer') { return '1903'; }
   if (gameDesc == 'pikathulhu_phoenix_reacttoinitiative_inactive') { return '1914'; }
+  if (gameDesc == 'pikathulhu_phoenix_startturn_dizzy_secondplayer') { return '1917'; }
 
   if (gameDesc == 'blackomega_thefool_reacttoinitiative') { return '2302'; }
   if (gameDesc == 'blackomega_thefool_captured_value_die') { return '2306'; }

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1492,205 +1492,395 @@ test("test_Game.gamePlayerDice", function(assert) {
   BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
   Game.getCurrentGame(function() {
     var diceJQuery = Game.gamePlayerDice('opponent', true);
-    var expectedDiceProps = [
-      "DIV", { "class": "dice_opponent" }, [
+    var diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
 
-        // dieIdx 0: q(T=2)
-        [ "DIV", {
-            "class": "hide_focus die_container die_alive unselected_opponent",
-            "id": "playerIdx_1_dieIdx_0",
-            "tabindex": "0",
-            "title": "Queer T Swing Die (with 2 sides)"
-          }, [
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
-              [ "DIV", { "class": "die_img" }, [
-                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "1" ] ] ]
-              ] ]
-            ],
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(T=2)" ] ] ]
-            ]
-          ]
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3);
+    assert.deepEqual(diceProps[0], "DIV");
+    assert.deepEqual(diceProps[1], { "class": "dice_opponent", });
+    assert.equal(diceProps[2].length, 4);
+
+    // dieIdx 0: q(T=2)
+    var expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_opponent",
+        "id": "playerIdx_1_dieIdx_0",
+        "tabindex": "0",
+        "title": "Queer T Swing Die (with 2 sides)"
+      }, [
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "1" ] ] ]
+          ] ]
         ],
-
-        // dieIdx 1: q(T=2)
-        [ "DIV", {
-            "class": "hide_focus die_container die_alive unselected_opponent",
-            "id": "playerIdx_1_dieIdx_1",
-            "tabindex": "0",
-            "title": "Queer W Swing Die (with 4 sides)"
-          }, [
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
-              [ "DIV", { "class": "die_img" }, [
-                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "4" ] ] ]
-              ] ]
-            ],
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(W=4)" ] ] ]
-            ]
-          ]
-        ],
-
-        // dieIdx 2: q(X=4)
-        [ "DIV", {
-            "class": "hide_focus die_container die_alive unselected_opponent",
-            "id": "playerIdx_1_dieIdx_2",
-            "tabindex": "0",
-            "title": "Queer X Swing Die (with 4 sides)"
-          }, [
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
-              [ "DIV", { "class": "die_img" }, [
-                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "3" ] ] ]
-              ] ]
-            ],
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(X=4)" ] ] ]
-            ]
-          ]
-        ],
-
-        // dieIdx 3: z(S=20)
-        [ "DIV", {
-            "class": "hide_focus die_container die_alive unselected_opponent",
-            "id": "playerIdx_1_dieIdx_3",
-            "tabindex": "0",
-            "title": "Speed S Swing Die (with 20 sides)"
-          }, [
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
-              [ "DIV", { "class": "die_img" }, [
-                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "12" ] ] ]
-              ] ]
-            ],
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_opponent" }, [ "z(S=20)" ] ] ]
-            ]
-          ]
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(T=2)" ] ] ]
         ]
       ]
     ];
-    assert.deepEqual(BMTestUtils.DOMNodePropArray(diceJQuery[0]), expectedDiceProps);
+    assert.deepEqual(diceProps[2][0], expectedDieProps);
+
+    // dieIdx 3: z(S=20)
+    expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_opponent",
+        "id": "playerIdx_1_dieIdx_3",
+        "tabindex": "0",
+        "title": "Speed S Swing Die (with 20 sides)"
+      }, [
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "12" ] ] ]
+          ] ]
+        ],
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "z(S=20)" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][3], expectedDieProps);
     start();
   });
 });
 
 // This test shows a mat of the player's dice when it is the opponent's turn
 // so all the dice are greyed.
-// The recipe appears before the dice.
+// Each die's recipe appears before the die.
 test("test_Game.gamePlayerDice_disabled", function(assert) {
   stop();
   BMTestUtils.GameType = 'washu_hooloovoo_startturn_inactive';
   Game.getCurrentGame(function() {
     var diceJQuery = Game.gamePlayerDice('player', false);
-    var expectedDiceProps = [
-      "DIV", { "class": "dice_player" }, [
+    var diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
 
-        // dieIdx 0: (4)
-        [ "DIV", {
-            "class": "die_container die_alive",
-            "id": "playerIdx_0_dieIdx_0",
-            "title": "4-sided die"
-          }, [
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_player" }, [ "(4)" ] ] ]
-            ],
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
-              [ "DIV", { "class": "die_img die_greyed" }, [
-                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "3" ] ]
-              ] ]
-            ] ]
-          ]
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3);
+    assert.deepEqual(diceProps[0], "DIV");
+    assert.deepEqual(diceProps[1], { "class": "dice_player", });
+    assert.equal(diceProps[2].length, 4);
+
+    // dieIdx 1: (6)
+    var expectedDieProps = [ "DIV", {
+        "class": "die_container die_alive",
+        "id": "playerIdx_0_dieIdx_1",
+        "title": "6-sided die"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(6)" ] ] ]
         ],
-
-        // dieIdx 1: (6)
-        [ "DIV", {
-            "class": "die_container die_alive",
-            "id": "playerIdx_0_dieIdx_1",
-            "title": "6-sided die"
-          }, [
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_player" }, [ "(6)" ] ] ]
-            ],
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
-              [ "DIV", { "class": "die_img die_greyed" }, [
-                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "1" ] ]
-              ] ]
-            ] ]
-          ]
-        ],
-
-        // dieIdx 2: (12)
-        [ "DIV", {
-            "class": "die_container die_alive",
-            "id": "playerIdx_0_dieIdx_2",
-            "title": "12-sided die"
-          }, [
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_player" }, [ "(12)" ] ]
-            ] ],
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
-              [ "DIV", { "class": "die_img die_greyed" }, [
-                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "5" ] ]
-              ] ]
-            ] ]
-          ]
-        ],
-
-        // dieIdx 3: (X=5)
-        [ "DIV", {
-            "class": "die_container die_alive",
-            "id": "playerIdx_0_dieIdx_3",
-            "title": "X Swing Die (with 5 sides)"
-          }, [
-            [ "DIV", {}, [
-              [ "SPAN", { "class": "die_recipe_player" }, [ "(X=5)" ] ]
-            ] ],
-            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
-              [ "DIV", { "class": "die_img die_greyed" }, [
-                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "3" ] ]
-              ] ]
-            ] ]
-          ]
-        ]
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img die_greyed" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "1" ] ]
+          ] ]
+        ] ]
       ]
     ];
-    assert.deepEqual(BMTestUtils.DOMNodePropArray(diceJQuery[0]), expectedDiceProps);
+    assert.deepEqual(diceProps[2][1], expectedDieProps, "The player's greyed die should have the correct properties");
     start();
   });
 });
 
+// This test shows a mat of the player's dice when it is the player's turn,
+// so most dice should be active, and one of the player's dice was just captured
+// and should be displayed as a dead die.
 test("test_Game.gamePlayerDice_captured", function(assert) {
   stop();
   BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
   Game.getCurrentGame(function() {
-    Game.page = $('<div>');
-    Game.page.append(Game.gamePlayerDice('player', true));
-    assert.ok(Game.page.find('.die_dead').length > 0,
-      "dice should include one that's been captured");
+    var diceJQuery = Game.gamePlayerDice('player', true);
+    var diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
+
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3);
+    assert.deepEqual(diceProps[0], "DIV");
+    assert.deepEqual(diceProps[1], { "class": "dice_player", });
+    assert.equal(diceProps[2].length, 4);
+
+    // dieIdx 0: (6)
+    var expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_player",
+        "id": "playerIdx_0_dieIdx_0",
+        "tabindex": "0",
+        "title": "6-sided die"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(6)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "5" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][0], expectedDieProps);
+
+    // dead die: (4)
+    expectedDieProps = [ "DIV", {
+        "class": "die_container die_dead",
+        "title": "This die was just captured in the last attack and is no longer in play."
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(4)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "\u00A0" + "2" + "\u00A0" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][2], expectedDieProps);
+
+    // dead die: (20)
+    expectedDieProps = [ "DIV", {
+        "class": "die_container die_dead",
+        "title": "This die was just captured in the last attack and is no longer in play."
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(20)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "\u00A0" + "8" + "\u00A0" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][3], expectedDieProps);
     start();
   });
 });
 
+// This test demonstrates that when the active player loads the mat
+// in a game with warrior dice, the opponent's warrior dice are greyed, while
+// the player's warrior dice have the usual properties of active dice
 test("test_Game.gamePlayerDice_warrior", function(assert) {
   stop();
   BMTestUtils.GameType = 'shadowwarriors_fernworthy_newgame_active';
   Game.getCurrentGame(function() {
-    // opponent should have greyed warriors
-    Game.page = $('<div>');
-    Game.page.append(Game.gamePlayerDice('opponent', true));
-    assert.ok(Game.page.find('.die_greyed').length == 4,
-      "four of opponent's dice should be greyed out");
-    var htmlout = Game.page.html();
-    assert.ok(htmlout.match('This die is a Warrior die'),
-      "Opponent title text reports greyed warriors");
 
-    // player should have not greyed warriors
-    Game.page = $('<div>');
-    Game.page.append(Game.gamePlayerDice('player', true));
-    assert.ok(Game.page.find('.die_greyed').length == 0,
-      "none of player's dice should be greyed out");
-    var htmlout = Game.page.html();
-    assert.ok(!htmlout.match('This die is a Warrior die'),
-      "Player title text does not report any greyed warriors");
+    ///// opponent should have greyed warriors
+    var diceJQuery = Game.gamePlayerDice('opponent', true);
+    var diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
+
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3, "Opponent's dice object should have expected length");
+    assert.deepEqual(diceProps[0], "DIV", "Opponent's dice object should be a div");
+    assert.deepEqual(diceProps[1], { "class": "dice_opponent", }, "Opponent's dice object should have expected class");
+    assert.equal(diceProps[2].length, 8, "Opponent's dice object should contain one entry per die");
+
+    // opponent dieIdx 2: z(12)
+    var expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_opponent",
+        "id": "playerIdx_1_dieIdx_2",
+        "tabindex": "0",
+        "title": "Speed 12-sided die"
+      }, [
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "7" ] ] ]
+          ] ]
+        ],
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "z(12)" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][2], expectedDieProps, "Opponent's non-warrior z(12) should have correct properties");
+
+    // opponent dieIdx 5: `(6)
+    expectedDieProps = [ "DIV", {
+        "class": "die_container die_alive",
+        "id": "playerIdx_1_dieIdx_5",
+        "title": "Warrior 6-sided die. (This die is a Warrior die and can't be targeted.)"
+      }, [
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+          [ "DIV", { "class": "die_img die_greyed" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "6" ] ] ]
+          ] ]
+        ],
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "`(6)" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][5], expectedDieProps, "Opponent's warrior `(6) should have correct properties");
+
+
+    ///// player should have not greyed warriors
+    diceJQuery = Game.gamePlayerDice('player', true);
+    diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
+
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3, "Player's dice object should have expected length");
+    assert.deepEqual(diceProps[0], "DIV", "Player's dice object should be a div");
+    assert.deepEqual(diceProps[1], { "class": "dice_player", }, "Player's dice object should have expected class");
+    assert.equal(diceProps[2].length, 7, "Player's dice object should contain one entry per die");
+
+    // player dieIdx 0: (1)
+    expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_player",
+        "id": "playerIdx_0_dieIdx_0",
+        "tabindex": "0",
+        "title": "1-sided die"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(1)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "1" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][0], expectedDieProps, "Player's non-warrior (1) should have correct properties");
+
+    // player dieIdx 3: `(6)
+    expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_player",
+        "id": "playerIdx_0_dieIdx_3",
+        "tabindex": "0",
+        "title": "Warrior 6-sided die"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "`(6)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "6" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][3], expectedDieProps, "Player's warrior `(6) should have correct properties");
+
+    start();
+  });
+});
+
+// This test demonstrates two things:
+// * The active player's turned-down focus dice are greyed
+// * If due to previous activity (i.e. an unsuccessful previous
+//   attack) some dice are selected when Game.gamePlayerDice() is
+//   called, those dice should display the correct properties for selected dice.
+test("test_Game.gamePlayerDice_dizzy_selected", function(assert) {
+  stop();
+  // N.B. This particular game was captured as responder004, so the
+  // recording player is playerIdx_1 instead of the usual playerIdx_0
+  // (and the opponent is therefore playerIdx_0)
+  BMTestUtils.GameType = 'pikathulhu_phoenix_startturn_dizzy_secondplayer';
+
+  // Specify dice which were previously selected
+  Game.activity.dieSelectStatus = {
+    'playerIdx_0_dieIdx_0': false,
+    'playerIdx_0_dieIdx_1': true,
+    'playerIdx_0_dieIdx_2': false,
+    'playerIdx_0_dieIdx_3': false,
+    'playerIdx_0_dieIdx_4': true,
+    'playerIdx_1_dieIdx_0': true,
+    'playerIdx_1_dieIdx_1': false,
+    'playerIdx_1_dieIdx_2': false,
+    'playerIdx_1_dieIdx_3': false,
+    'playerIdx_1_dieIdx_4': false,
+  };
+
+  Game.getCurrentGame(function() {
+
+    ///// opponent's selected dice should be shown as selected
+    var diceJQuery = Game.gamePlayerDice('opponent', true);
+    var diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
+
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3, "Opponent's dice object should have expected length");
+    assert.deepEqual(diceProps[0], "DIV", "Opponent's dice object should be a div");
+    assert.deepEqual(diceProps[1], { "class": "dice_opponent", }, "Opponent's dice object should have expected class");
+    assert.equal(diceProps[2].length, 5, "Opponent's dice object should contain one entry per die");
+
+    // opponent dieIdx 2: z(12)
+    var expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive unselected_opponent",
+        "id": "playerIdx_0_dieIdx_2",
+        "tabindex": "0",
+        "title": "10-sided die"
+      }, [
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "5" ] ] ]
+          ] ]
+        ],
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "(10)" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][2], expectedDieProps, "Opponent's non-selected (10) should have correct properties");
+
+    // opponent dieIdx 4: c(X=6)
+    var expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive selected",
+        "id": "playerIdx_0_dieIdx_4",
+        "tabindex": "0",
+        "title": "Chance X Swing Die (with 6 sides)",
+      }, [
+        [ "DIV", { "class": "die_border" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "2" ] ] ]
+          ] ]
+        ],
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_opponent" }, [ "c(X=6)" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][4], expectedDieProps, "Opponent's selected c(X=6) should have correct properties");
+
+
+    ///// player's focus die should be dizzy, and selected dice should look right
+    diceJQuery = Game.gamePlayerDice('player', true);
+    diceProps = BMTestUtils.DOMNodePropArray(diceJQuery[0]);
+
+    // Overall properties of the dice object
+    assert.equal(diceProps.length, 3, "Player's dice object should have expected length");
+    assert.deepEqual(diceProps[0], "DIV", "Player's dice object should be a div");
+    assert.deepEqual(diceProps[1], { "class": "dice_player", }, "Player's dice object should have expected class");
+    assert.equal(diceProps[2].length, 5, "Player's dice object should contain one entry per die");
+
+    // player dieIdx 0: (4)
+    expectedDieProps = [ "DIV", {
+        "class": "hide_focus die_container die_alive selected",
+        "id": "playerIdx_1_dieIdx_0",
+        "tabindex": "0",
+        "title": "4-sided die"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "(4)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border" }, [
+          [ "DIV", { "class": "die_img" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "3" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][0], expectedDieProps, "Player's selected (4) should have correct properties");
+
+    // player dieIdx 2: f(8)
+    expectedDieProps = [ "DIV", {
+        "class": "die_container die_alive",
+        "id": "playerIdx_1_dieIdx_2",
+        "title": "Focus 8-sided die. (This die is dizzy because it was turned down.  It can't be used during this attack.)"
+      }, [
+        [ "DIV", {}, [
+          [ "SPAN", { "class": "die_recipe_player" }, [ "f(8)" ] ] ]
+        ],
+        [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+          [ "DIV", { "class": "die_img die_greyed" }, [
+            [ "SPAN", { "class": "die_overlay die_number_player" }, [ "1" ] ] ]
+          ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(diceProps[2][2], expectedDieProps, "Player's unselected dizzy f(8) should have correct properties");
 
     start();
   });

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1484,28 +1484,176 @@ test("test_Game.gamePlayerStatusWithValue", function(assert) {
   });
 });
 
+// This test shows a mat of the opponent's dice
+// Opponent's dice have the correct set of classes defined for the opponent,
+// and the recipe appears after the dice
 test("test_Game.gamePlayerDice", function(assert) {
   stop();
   BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
   Game.getCurrentGame(function() {
-    Game.page = $('<div>');
-    Game.page.append(Game.gamePlayerDice('opponent', true));
-    var htmlout = Game.page.html();
-    assert.ok(htmlout.match('die_container die_alive unselected'),
-      "dice should include some text with the correct CSS class");
+    var diceJQuery = Game.gamePlayerDice('opponent', true);
+    var expectedDiceProps = [
+      "DIV", { "class": "dice_opponent" }, [
+
+        // dieIdx 0: q(T=2)
+        [ "DIV", {
+            "class": "hide_focus die_container die_alive unselected_opponent",
+            "id": "playerIdx_1_dieIdx_0",
+            "tabindex": "0",
+            "title": "Queer T Swing Die (with 2 sides)"
+          }, [
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+              [ "DIV", { "class": "die_img" }, [
+                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "1" ] ] ]
+              ] ]
+            ],
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(T=2)" ] ] ]
+            ]
+          ]
+        ],
+
+        // dieIdx 1: q(T=2)
+        [ "DIV", {
+            "class": "hide_focus die_container die_alive unselected_opponent",
+            "id": "playerIdx_1_dieIdx_1",
+            "tabindex": "0",
+            "title": "Queer W Swing Die (with 4 sides)"
+          }, [
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+              [ "DIV", { "class": "die_img" }, [
+                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "4" ] ] ]
+              ] ]
+            ],
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(W=4)" ] ] ]
+            ]
+          ]
+        ],
+
+        // dieIdx 2: q(X=4)
+        [ "DIV", {
+            "class": "hide_focus die_container die_alive unselected_opponent",
+            "id": "playerIdx_1_dieIdx_2",
+            "tabindex": "0",
+            "title": "Queer X Swing Die (with 4 sides)"
+          }, [
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+              [ "DIV", { "class": "die_img" }, [
+                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "3" ] ] ]
+              ] ]
+            ],
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_opponent" }, [ "q(X=4)" ] ] ]
+            ]
+          ]
+        ],
+
+        // dieIdx 3: z(S=20)
+        [ "DIV", {
+            "class": "hide_focus die_container die_alive unselected_opponent",
+            "id": "playerIdx_1_dieIdx_3",
+            "tabindex": "0",
+            "title": "Speed S Swing Die (with 20 sides)"
+          }, [
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+              [ "DIV", { "class": "die_img" }, [
+                [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "12" ] ] ]
+              ] ]
+            ],
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_opponent" }, [ "z(S=20)" ] ] ]
+            ]
+          ]
+        ]
+      ]
+    ];
+    assert.deepEqual(BMTestUtils.DOMNodePropArray(diceJQuery[0]), expectedDiceProps);
     start();
   });
 });
 
+// This test shows a mat of the player's dice when it is the opponent's turn
+// so all the dice are greyed.
+// The recipe appears before the dice.
 test("test_Game.gamePlayerDice_disabled", function(assert) {
   stop();
   BMTestUtils.GameType = 'washu_hooloovoo_startturn_inactive';
   Game.getCurrentGame(function() {
-    Game.page = $('<div>');
-    Game.page.append(Game.gamePlayerDice('player', false));
-    var htmlout = Game.page.html();
-    assert.ok(htmlout.match('die_img die_greyed'),
-      "dice should include some text with the correct CSS class");
+    var diceJQuery = Game.gamePlayerDice('player', false);
+    var expectedDiceProps = [
+      "DIV", { "class": "dice_player" }, [
+
+        // dieIdx 0: (4)
+        [ "DIV", {
+            "class": "die_container die_alive",
+            "id": "playerIdx_0_dieIdx_0",
+            "title": "4-sided die"
+          }, [
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_player" }, [ "(4)" ] ] ]
+            ],
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+              [ "DIV", { "class": "die_img die_greyed" }, [
+                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "3" ] ]
+              ] ]
+            ] ]
+          ]
+        ],
+
+        // dieIdx 1: (6)
+        [ "DIV", {
+            "class": "die_container die_alive",
+            "id": "playerIdx_0_dieIdx_1",
+            "title": "6-sided die"
+          }, [
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_player" }, [ "(6)" ] ] ]
+            ],
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+              [ "DIV", { "class": "die_img die_greyed" }, [
+                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "1" ] ]
+              ] ]
+            ] ]
+          ]
+        ],
+
+        // dieIdx 2: (12)
+        [ "DIV", {
+            "class": "die_container die_alive",
+            "id": "playerIdx_0_dieIdx_2",
+            "title": "12-sided die"
+          }, [
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_player" }, [ "(12)" ] ]
+            ] ],
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+              [ "DIV", { "class": "die_img die_greyed" }, [
+                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "5" ] ]
+              ] ]
+            ] ]
+          ]
+        ],
+
+        // dieIdx 3: (X=5)
+        [ "DIV", {
+            "class": "die_container die_alive",
+            "id": "playerIdx_0_dieIdx_3",
+            "title": "X Swing Die (with 5 sides)"
+          }, [
+            [ "DIV", {}, [
+              [ "SPAN", { "class": "die_recipe_player" }, [ "(X=5)" ] ]
+            ] ],
+            [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+              [ "DIV", { "class": "die_img die_greyed" }, [
+                [ "SPAN", { "class": "die_overlay die_number_player" }, [ "3" ] ]
+              ] ]
+            ] ]
+          ]
+        ]
+      ]
+    ];
+    assert.deepEqual(BMTestUtils.DOMNodePropArray(diceJQuery[0]), expectedDiceProps);
     start();
   });
 });


### PR DESCRIPTION
* Related to #822 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/460/

This doesn't refactor anything yet --- it just significantly fleshes out the unit tests of `Game.gamePlayerDice()`, in particular:
* Using a test method i wrote some time ago but haven't used much yet, fully regression-test the set of DOM properties for some of the dice
* Add testing for dizzy dice (this is just a minor variant on the existing warrior test, of course, but it helps test coverage)
* Add testing for the case in which `Game.activity.dieSelectStatus` is set before loading the dice, to verify that dice will have the correct classes to be outlined in red in that case