### PR TITLE
refactor the Game.gamePlayerDice() function

### DIFF
--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2688,8 +2688,288 @@ Game.gamePlayerStatus = function(player, reversed, game_active) {
   return statusDiv;
 };
 
-// Return a display of all dice for the requested player, specifying
-// whether the dice should be selectable
+/**
+ * Should a die be displayed as clickable in a given player mat?
+ *
+ * The return object contains a boolean saying whether the die is clickable,
+ * and a string describing the reason why or why not.
+ *
+ * @param  object  die            The die to be displayed
+ * @param  boolean die_status     Status of the die ('active' or 'captured')
+ * @param  string  player         Whose is the die? ('player' or 'opponent')
+ * @param  boolean player_active  Is the player displaying the die active?
+ * @return object
+ */
+Game.dieClickableInfo = function(die, player, die_status, player_active) {
+  if (die_status == 'captured') {
+    if (die.properties.indexOf('WasJustCaptured') >= 0) {
+      return {
+        'isClickable': false,
+        'reason': 'This die was just captured in the last attack and is no ' +
+                  'longer in play.',
+      };
+    }
+    return {
+      'isClickable': false,
+      'reason': 'This die was captured during an earlier attack.',
+    };
+  }
+
+  if (!player_active) {
+    return {
+      'isClickable': false,
+      'reason':
+        'The game is not awaiting action from the player loading the mat.',
+    };
+  }
+
+  if (die.properties.indexOf('Dizzy') >= 0) {
+    return {
+      'isClickable': false,
+      'reason': 'This die is dizzy because it was turned ' +
+                'down.  It can\'t be used during this attack.',
+    };
+  }
+
+  // The opponent's Warrior dice are not clickable
+  if ((player != 'player') && (die.skills.indexOf('Warrior') >= 0)) {
+    return {
+      'isClickable': false,
+      'reason': 'This die is a Warrior die and can\'t be targeted.',
+    };
+  }
+
+  // Otherwise the die is clickable
+  return {
+    'isClickable': true,
+    'reason': 'Active dice are clickable by default.',
+  };
+};
+
+/**
+ * Return a div containing a die recipe for use in a game battle mat
+ *
+ * @param  object die      The die whose recipe is to be displayed
+ * @param  string player   Whose is the die? ('player' or 'opponent')
+ * @return object          jQuery containing the recipe DIV
+ */
+Game.createGameMatDieRecipeDiv = function(die, player) {
+  var dieRecipeDiv = $('<div>');
+  dieRecipeDiv.append($('<span>', {
+    'class': 'die_recipe_' + player,
+    'text': Game.dieRecipeText(die),
+  }));
+  return dieRecipeDiv;
+};
+
+/**
+ * Return a div containing a die for use in a game battle mat.
+ *
+ * This function creates the circular die image itself, and any
+ * background or decoration which attaches directly to the image.
+ *
+ * @param  object  die          The die whose recipe is to be displayed
+ * @param  string  player       Whose is the die? ('player' or 'opponent')
+ * @param  string  dieStatus    Status of the die ('active' or 'captured')
+ * @param  boolean isClickable  Is the die clickable?
+ * @return object               jQuery containing the die DIV
+ */
+Game.createGameMatDieDiv = function(die, player, dieStatus, isClickable) {
+  var divOpts = {
+    'class': 'die_img',
+  };
+  if ((dieStatus == 'active') && !(isClickable)) {
+    divOpts['class'] += ' die_greyed';
+  }
+
+  var dieNumberSpanOpts = {
+    'class': 'die_overlay die_number_' + player,
+  };
+  if (dieStatus == 'active') {
+    dieNumberSpanOpts.text = die.value;
+  } else {
+    dieNumberSpanOpts.html = '&nbsp;' + die.value + '&nbsp;';
+  }
+
+  var dieDiv = $('<div>', divOpts);
+  dieDiv.append($('<span>', dieNumberSpanOpts));
+  return dieDiv;
+};
+
+/**
+ * Return a div containing a border for a die.
+ *
+ * If the die is not currently selected, insert a border in the
+ * background color of the player's mat, to hide the visible red border.
+ *
+ * @param  string  player       Whose is the die? ('player' or 'opponent')
+ * @param  boolean isSelected   Is the die currently selected?
+ * @return object               jQuery containing the border DIV
+ */
+Game.createGameMatBorderDiv = function(player, isSelected) {
+  var borderDivOpts = {
+    'class': 'die_border',
+  };
+  if (!(isSelected)) {
+    borderDivOpts.style = 'border: 2px solid ' + Game.color[player];
+  }
+
+  var dieBorderDiv = $('<div>', borderDivOpts);
+  return dieBorderDiv;
+};
+
+/**
+ * Return a div containing a die with a selectable border,
+ * for use in a game battle mat.
+ *
+ * This is a thin wrapper which creates the die div, creates
+ * the border div, and attaches the die to the border.
+ *
+ * @param  object  die          The die whose recipe is to be displayed
+ * @param  string  player       Whose is the die? ('player' or 'opponent')
+ * @param  string  dieStatus    Status of the die ('active' or 'captured')
+ * @param  boolean isClickable  Is the die clickable?
+ * @param  boolean isSelected   Is the die currently selected?
+ * @return object               jQuery containing the die/border DIV
+ */
+Game.createGameMatDieWithBorderDiv = function(
+    die, player, dieStatus, isClickable, isSelected) {
+  var dieDiv = Game.createGameMatDieDiv(die, player, dieStatus, isClickable);
+  var dieBorderDiv = Game.createGameMatBorderDiv(player, isSelected);
+  dieBorderDiv.append(dieDiv);
+  return dieBorderDiv;
+};
+
+/**
+ * Return a dict containing the set of attributes to be attached to the
+ * outside container for any battle mat die
+ *
+ * @param  object  die              The die whose recipe is to be displayed
+ * @param  string  player           Whose is the die? ('player' or 'opponent')
+ * @param  boolean player_active    Is the game awaiting action from the player
+ *                                  who is loading the page?
+ * @param  string  dieStatus        Status of the die ('active' or 'captured')
+ * @param  string  dieIndex         Backend index for this die, or null if the
+ *                                  die is captured
+ * @param  object  dieClickableInfo Whether the die is clickable, and why
+ * @return object                   dict containing the div options to use
+ */
+Game.getDieContainerDivOptions = function(
+    die, player, player_active, dieStatus, dieIndex, dieClickableInfo,
+    isSelected) {
+  var divOptions = {
+    'class': 'die_container',
+  };
+  if (dieIndex) {
+    divOptions.id = dieIndex;
+  }
+
+  divOptions.title = die.description;
+
+  // If the loading player is active, describe why any unclickable dice
+  // are not clickable
+  if ((player_active) && !(dieClickableInfo.isClickable)) {
+    if (divOptions.title) {
+      divOptions.title += '. (' + dieClickableInfo.reason + ')';
+    } else {
+      divOptions.title = dieClickableInfo.reason;
+    }
+  }
+
+  if (dieStatus == 'active') {
+    divOptions.class += ' die_alive';
+  } else {
+    divOptions.class += ' die_dead';
+  }
+
+  // configure clickable dice to be selectable via keyboard,
+  // and indicate whether they are currently selected
+  if (dieClickableInfo.isClickable) {
+    divOptions.tabIndex = 0;
+    divOptions.class += ' hide_focus';
+    if (isSelected) {
+      divOptions.class += ' selected';
+    } else {
+      divOptions.class += ' unselected_' + player;
+    }
+  }
+
+  return divOptions;
+};
+
+/**
+ * Return a filled-in "container" div for a die on a battle mat
+ *
+ * This function fully renders a die, including its image, its
+ * recipe, its border, and all needed HTML class attributes, for
+ * inclusion on a battle mat.  It is largely a wrapper which calls
+ * other functions and assembles the divs they return.
+ *
+ * @param  object  die              The die which is to be displayed
+ * @param  string  player           Whose is the die? ('player' or 'opponent')
+ * @param  boolean player_active    Is the game awaiting action from the player
+ *                                  who is loading the page?
+ * @param  string  dieStatus        Status of the die ('active' or 'captured')
+ * @param  string  dieIndex         Backend index for this die, or null if the
+ *                                  die is captured
+ * @param  object  dieClickableInfo Whether the die is clickable, and why
+ * @param  boolean isSelected       Is the die currently selected?
+ * @return object                   jQuery containing the die container DIV
+ */
+Game.createDieContainerDiv = function(
+    die, player, player_active, dieStatus, dieIndex, dieClickableInfo,
+    isSelected) {
+  var containerDivOpts = Game.getDieContainerDivOptions(
+    die, player, player_active, dieStatus, dieIndex, dieClickableInfo,
+    isSelected);
+  var dieBorderDiv = Game.createGameMatDieWithBorderDiv(
+    die, player, dieStatus, dieClickableInfo.isClickable, isSelected);
+  var dieRecipeDiv = Game.createGameMatDieRecipeDiv(die, player);
+
+  var dieContainerDiv = $('<div>', containerDivOpts);
+
+  // If the dice belong to the player, the recipe is above the dice.
+  // If the dice belong to the opponent, the recipe is below the dice.
+  if (player == 'player') {
+    dieContainerDiv.append(dieRecipeDiv);
+    dieContainerDiv.append(dieBorderDiv);
+  } else {
+    dieContainerDiv.append(dieBorderDiv);
+    dieContainerDiv.append(dieRecipeDiv);
+  }
+
+  // If the die is clickable, install keyboard handlers
+  if (dieClickableInfo.isClickable) {
+    if (player == 'player') {
+      Env.addClickKeyboardHandlers(
+        dieContainerDiv,
+        Game.dieBorderTogglePlayerHandler,
+        Game.dieBorderTogglePlayerHandler,
+        Game.form
+      );
+    } else {
+      Env.addClickKeyboardHandlers(
+        dieContainerDiv,
+        Game.dieBorderToggleOpponentHandler,
+        Game.dieBorderToggleOpponentHandler,
+        Game.form
+      );
+    }
+    Game.dieFocusOutlineHandler(dieContainerDiv);
+  }
+  return dieContainerDiv;
+};
+
+
+/**
+ * Return a game-mat-style display of all dice belonging to the
+ * requested player
+ *
+ * @param  string  player        Whose dice to display ('player' or 'opponent')
+ * @param  boolean player_active Is the game awaiting action from the player
+ *                               who is loading the page?
+ * @return object                jQuery containing the div of dice
+ */
 Game.gamePlayerDice = function(player, player_active) {
   var nonplayer;
   if (player == 'player') {
@@ -2701,110 +2981,24 @@ Game.gamePlayerDice = function(player, player_active) {
     'class': 'dice_' + player,
   });
 
-  var dieDiv;
-  var dieRecipeDiv;
+  var die;
+  var dieIndex;
+  var dieClickableInfo;
+  var isSelected;
   var dieContainerDiv;
-  var dieBorderDiv;
 
   for (var i = 0; i < Api.game[player].activeDieArray.length; i++) {
-    var die = Api.game[player].activeDieArray[i];
+    die = Api.game[player].activeDieArray[i];
+    dieIndex = Game.dieIndexId(player, i);
+    dieClickableInfo = Game.dieClickableInfo(
+      die, player, 'active', player_active);
+    isSelected = (('dieSelectStatus' in Game.activity) &&
+      (dieIndex in Game.activity.dieSelectStatus) &&
+      (Game.activity.dieSelectStatus[dieIndex]));
 
-    // Find out whether this die is clickable: it is if the player
-    // is active and this particular die is not dizzy
-    var clickable;
-    if (player_active) {
-      if (die.properties.indexOf('Dizzy') >= 0) {
-        clickable = false;
-      } else if ((player != 'player') && (die.skills.indexOf('Warrior') >= 0)) {
-        clickable = false;
-      } else {
-        clickable = true;
-      }
-    } else {
-      clickable = false;
-    }
-
-    var dieIndex = Game.dieIndexId(player, i);
-
-    var containerDivOpts = {
-      'id': dieIndex,
-      'title': die.description,
-    };
-    var borderDivOpts = {
-      'class': 'die_border',
-    };
-    var divOpts = { };
-
-    if (clickable) {
-      // clickable dice should be selectable via keyboard as well
-      containerDivOpts.tabIndex = 0;
-      if (('dieSelectStatus' in Game.activity) &&
-          (dieIndex in Game.activity.dieSelectStatus) &&
-          (Game.activity.dieSelectStatus[dieIndex])) {
-        containerDivOpts['class'] =
-          'hide_focus die_container die_alive selected';
-      } else {
-        containerDivOpts['class'] =
-          'hide_focus die_container die_alive unselected_' + player;
-        borderDivOpts.style = 'border: 2px solid ' + Game.color[player];
-      }
-      divOpts['class'] = 'die_img';
-      dieContainerDiv = $('<div>', containerDivOpts);
-      dieBorderDiv = $('<div>', borderDivOpts);
-      dieDiv = $('<div>', divOpts);
-      if (player == 'player') {
-        Env.addClickKeyboardHandlers(
-          dieContainerDiv,
-          Game.dieBorderTogglePlayerHandler,
-          Game.dieBorderTogglePlayerHandler,
-          Game.form
-        );
-      } else {
-        Env.addClickKeyboardHandlers(
-          dieContainerDiv,
-          Game.dieBorderToggleOpponentHandler,
-          Game.dieBorderToggleOpponentHandler,
-          Game.form
-        );
-      }
-      Game.dieFocusOutlineHandler(dieContainerDiv);
-    } else {
-      borderDivOpts.style = 'border: 2px solid ' + Game.color[player];
-      divOpts['class'] = 'die_img die_greyed';
-      if (player_active) {
-        if (player == 'player') {
-          containerDivOpts.title +=
-            '. (This die is dizzy because it was turned ' +
-            'down.  It can\'t be used during this attack.)';
-        } else {
-          containerDivOpts.title +=
-            '. (This die is a Warrior die and can\'t be targeted.)';
-        }
-      }
-      containerDivOpts['class'] = 'die_container die_alive';
-      dieContainerDiv = $('<div>', containerDivOpts);
-      dieBorderDiv = $('<div>', borderDivOpts);
-      dieDiv = $('<div>', divOpts);
-    }
-    dieDiv.append($('<span>', {
-      'class': 'die_overlay die_number_' + player,
-      'text': die.value,
-    }));
-
-    dieRecipeDiv = $('<div>');
-    dieRecipeDiv.append($('<span>', {
-      'class': 'die_recipe_' + player,
-      'text': Game.dieRecipeText(die),
-    }));
-
-    dieBorderDiv.append(dieDiv);
-    if (player == 'player') {
-      dieContainerDiv.append(dieRecipeDiv);
-      dieContainerDiv.append(dieBorderDiv);
-    } else {
-      dieContainerDiv.append(dieBorderDiv);
-      dieContainerDiv.append(dieRecipeDiv);
-    }
+    dieContainerDiv = Game.createDieContainerDiv(
+      die, player, player_active, 'active', dieIndex,
+      dieClickableInfo, isSelected);
     allDice.append(dieContainerDiv);
   }
 
@@ -2812,37 +3006,12 @@ Game.gamePlayerDice = function(player, player_active) {
   // having been captured just now.
   $.each(Api.game[nonplayer].capturedDieArray, function(i, die) {
     if (die.properties.indexOf('WasJustCaptured') >= 0) {
-      dieContainerDiv = $('<div>', {
-        'class': 'die_container die_dead' ,
-        'title':
-          'This die was just captured in the last attack and is no longer ' +
-          'in play.',
-      });
-      dieBorderDiv = $('<div>', {
-        'class': 'die_border',
-        'style': 'border: 2px solid ' + Game.color[player],
-      });
-      dieDiv = $('<div>', { 'class': 'die_img', });
+      dieClickableInfo = Game.dieClickableInfo(
+        die, player, 'captured', player_active);
 
-      dieDiv.append($('<span>', {
-        'class': 'die_overlay die_number_' + player,
-        'html': '&nbsp;' + die.value + '&nbsp;',
-      }));
-
-      dieRecipeDiv = $('<div>');
-      dieRecipeDiv.append($('<span>', {
-        'class': 'die_recipe_' + player,
-        'text': Game.dieRecipeText(die),
-      }));
-
-      dieBorderDiv.append(dieDiv);
-      if (player == 'player') {
-        dieContainerDiv.append(dieRecipeDiv);
-        dieContainerDiv.append(dieBorderDiv);
-      } else {
-        dieContainerDiv.append(dieBorderDiv);
-        dieContainerDiv.append(dieRecipeDiv);
-      }
+      dieContainerDiv = Game.createDieContainerDiv(
+	die, player, player_active, 'captured', null,
+        dieClickableInfo, false);
       allDice.append(dieContainerDiv);
     }
   });

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2778,7 +2778,7 @@ Game.createGameMatDieDiv = function(die, player, dieStatus, isClickable) {
   var divOpts = {
     'class': 'die_img',
   };
-  if ((dieStatus == 'active') && !(isClickable)) {
+  if ((dieStatus == 'active') && !isClickable) {
     divOpts['class'] += ' die_greyed';
   }
 
@@ -2810,7 +2810,7 @@ Game.createGameMatBorderDiv = function(player, isSelected) {
   var borderDivOpts = {
     'class': 'die_border',
   };
-  if (!(isSelected)) {
+  if (!isSelected) {
     borderDivOpts.style = 'border: 2px solid ' + Game.color[player];
   }
 
@@ -2869,7 +2869,7 @@ Game.getDieContainerDivOptions = function(
     divOptions.title = dieClickableInfo.reason;
   } else {
     divOptions.title = die.description;
-    if ((player_active) && !(dieClickableInfo.isClickable)) {
+    if (player_active && !dieClickableInfo.isClickable) {
       divOptions.title += '. (' + dieClickableInfo.reason + ')';
     }
   }
@@ -2992,7 +2992,7 @@ Game.gamePlayerDice = function(player, player_active) {
       die, player, 'active', player_active);
     isSelected = (('dieSelectStatus' in Game.activity) &&
       (dieIndex in Game.activity.dieSelectStatus) &&
-      (Game.activity.dieSelectStatus[dieIndex]));
+      Game.activity.dieSelectStatus[dieIndex]);
 
     dieContainerDiv = Game.createDieContainerDiv(
       die, player, player_active, 'active', dieIndex,

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2864,15 +2864,13 @@ Game.getDieContainerDivOptions = function(
     divOptions.id = dieIndex;
   }
 
-  divOptions.title = die.description;
-
-  // If the loading player is active, describe why any unclickable dice
-  // are not clickable
-  if ((player_active) && !(dieClickableInfo.isClickable)) {
-    if (divOptions.title) {
+  // Set descriptions for active, captured, and unclickable dice
+  if (dieStatus == 'captured') {
+    divOptions.title = dieClickableInfo.reason;
+  } else {
+    divOptions.title = die.description;
+    if ((player_active) && !(dieClickableInfo.isClickable)) {
       divOptions.title += '. (' + dieClickableInfo.reason + ')';
-    } else {
-      divOptions.title = dieClickableInfo.reason;
     }
   }
 

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1535,9 +1535,20 @@ test("test_Game.getDieContainerDivOptions", function(assert) {
     false);
   var expectedDivOpts = {
     "class": "die_container die_dead",
-    "title": "6-sided die. (because captured)"
+    "title": "because captured"
   };
   assert.deepEqual(containerDivOpts, expectedDivOpts, "Got expected div options for a captured die");
+
+  var containerDivOpts = Game.getDieContainerDivOptions(
+    die, 'player', true, 'active', 'indexindex',
+    { 'isClickable': false, 'reason': 'because not clickable', },
+    false);
+  var expectedDivOpts = {
+    "class": "die_container die_alive",
+    "id": "indexindex",
+    "title": "6-sided die. (because not clickable)"
+  };
+  assert.deepEqual(containerDivOpts, expectedDivOpts, "Got expected div options for an unclickable die");
 
   var containerDivOpts = Game.getDieContainerDivOptions(
     die, 'player', true, 'active', 'indexindexindex',

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -764,7 +764,7 @@ test("test_Game.actionPlayTurnActive_prevvals", function(assert) {
     Game.actionPlayTurnActive();
     Login.arrangePage(Game.page, Game.form, '#game_action_button');
     var item = document.getElementById('playerIdx_0_dieIdx_0');
-    assert.deepEqual(item.className, 'hide_focus die_container die_alive selected',
+    assert.deepEqual(item.className, 'die_container die_alive hide_focus selected',
       'Previous attacking die selection is retained');
     var item = document.getElementById('attack_type_select');
     assert.ok(item.innerHTML.match('selected'),
@@ -1484,6 +1484,245 @@ test("test_Game.gamePlayerStatusWithValue", function(assert) {
   });
 });
 
+/**
+ * This test uses hand-written test data (not API data)
+ */
+test("test_Game.dieClickableInfo", function(assert) {
+  var die = {
+    description: "6-sided die",
+    properties: [],
+    recipe: '(6)',
+    sides: 6,
+    skills: [],
+    value: 2
+  };
+
+  assert.deepEqual(
+    Game.dieClickableInfo(die, 'player', 'active', false),
+    { "isClickable": false, "reason": "The game is not awaiting action from the player loading the mat." },
+    "If the player is not active, the die should not be clickable");
+  assert.equal(Game.dieClickableInfo(die, 'player', 'active', true).isClickable, true, "If the player is active, the player's die the should be clickable");
+  assert.equal(Game.dieClickableInfo(die, 'opponent', 'active', true).isClickable, true, "If the player is active, the opponent's die the should be clickable");
+
+  die.properties = ['Dizzy'];
+  assert.equal(Game.dieClickableInfo(die, 'player', 'active', true).isClickable, false, "If the die is dizzy, it should not be clickable");
+
+  die.properties = ['WasJustCaptured'];
+  assert.equal(Game.dieClickableInfo(die, 'player', 'captured', false).isClickable, false, "If the die was captured, it should not be clickable");
+
+  die.properties = [];
+  die.skills = ['Warrior'];
+  assert.equal(Game.dieClickableInfo(die, 'player', 'active', true).isClickable, true, "The active player's own warrior die should be clickable");
+  assert.equal(Game.dieClickableInfo(die, 'opponent', 'active', true).isClickable, false, "The active player's opponent's warrior die should not be clickable");
+});
+
+/**
+ * This test uses hand-written test data (not API data).
+ *
+ */
+test("test_Game.getDieContainerDivOptions", function(assert) {
+  var die = {
+    description: "6-sided die",
+    properties: [],
+    recipe: '(6)',
+    sides: 6,
+    skills: [],
+    value: 2
+  };
+  var containerDivOpts = Game.getDieContainerDivOptions(
+    die, 'player', true, 'captured', null,
+    { 'isClickable': false, 'reason': 'because captured', },
+    false);
+  var expectedDivOpts = {
+    "class": "die_container die_dead",
+    "title": "6-sided die. (because captured)"
+  };
+  assert.deepEqual(containerDivOpts, expectedDivOpts, "Got expected div options for a captured die");
+
+  var containerDivOpts = Game.getDieContainerDivOptions(
+    die, 'player', true, 'active', 'indexindexindex',
+    { 'isClickable': true, 'reason': 'just because', },
+    true);
+  var expectedDivOpts = {
+    "class": "die_container die_alive hide_focus selected",
+    "id": "indexindexindex",
+    "tabIndex": 0,
+    "title": "6-sided die",
+  };
+  assert.deepEqual(containerDivOpts, expectedDivOpts, "Got expected div options for an active selected die");
+
+});
+
+/**
+ * This test uses hand-written test data (not API data).
+ *
+ * It does not test very deeply, because Game.createDieContainerDiv()
+ * is primarily a wrapper which invokes other functions.  The major
+ * pieces of logic within the function itself are:
+ * * adding the keyboard handlers, which is hard to test
+ * * placing the recipe above or below the die
+ */
+test("test_Game.createDieContainerDiv", function(assert) {
+  var die = {
+    description: "6-sided die",
+    properties: [],
+    recipe: '(6)',
+    sides: 6,
+    skills: [],
+    value: 2
+  };
+  var dieClickableInfo = {
+    'isClickable': 'false',
+    'reason': 'no reason',
+  };
+
+  var dieContainerDivJQuery = Game.createDieContainerDiv(
+    die, 'player', false, 'active', 2, dieClickableInfo,
+    false);
+  var dieContainerDivProps = BMTestUtils.DOMNodePropArray(dieContainerDivJQuery[0]);
+  var expectedDivProps = [ "DIV", {
+      "class": "die_container die_alive hide_focus unselected_player",
+      "id": "2",
+      "tabindex": "0",
+      "title": "6-sided die"
+    }, [
+      [ "DIV", {}, [
+        [ "SPAN", { "class": "die_recipe_player" }, [ "(6)" ] ] ]
+      ],
+      [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [
+        [ "DIV", { "class": "die_img" }, [
+          [ "SPAN", { "class": "die_overlay die_number_player" }, [ "2" ] ] ]
+        ] ]
+      ]
+    ]
+  ];
+  assert.deepEqual(dieContainerDivProps, expectedDivProps, "Player's die should have expected properties, including recipe above die");
+
+  dieContainerDivJQuery = Game.createDieContainerDiv(
+    die, 'opponent', true, 'active', 2, dieClickableInfo,
+    false);
+  dieContainerDivProps = BMTestUtils.DOMNodePropArray(dieContainerDivJQuery[0]);
+  expectedDivProps = [ "DIV", {
+      "class": "die_container die_alive hide_focus unselected_opponent",
+      "id": "2",
+      "tabindex": "0",
+      "title": "6-sided die"
+    }, [
+      [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [
+        [ "DIV", { "class": "die_img" }, [
+          [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "2" ] ] ]
+        ] ]
+      ],
+      [ "DIV", {}, [
+        [ "SPAN", { "class": "die_recipe_opponent" }, [ "(6)" ] ] ]
+      ]
+    ]
+  ];
+  assert.deepEqual(dieContainerDivProps, expectedDivProps, "Opponent's die should have expected properties, including recipe below die");
+});
+
+/**
+ * This test uses API data to test Game.createGameMatDieWithBorderDiv(),
+ * a wrapper function which assembles a div of a die surrounded by a border
+ */
+test("test_Game.createGameMatDieWithBorderDiv", function(assert) {
+  stop();
+  BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
+  Game.getCurrentGame(function() {
+    var die = Api.game.opponent.activeDieArray[3];
+    var dieBorderDivJQuery = Game.createGameMatDieWithBorderDiv(die, 'opponent', 'active', true, false);
+    var dieBorderDivProps = BMTestUtils.DOMNodePropArray(dieBorderDivJQuery[0]);
+
+    var expectedDivProps = [ "DIV", {
+        "class": "die_border",
+        "style": "border: 2px solid #ddffdd"
+      }, [
+        [ "DIV", { "class": "die_img" }, [
+          [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "12" ] ] ]
+        ]
+      ]
+    ];
+    assert.deepEqual(dieBorderDivProps, expectedDivProps);
+    start();
+  });
+});
+
+/**
+ * This test uses hand-created (not API) data to test Game.createGameMatDieDiv()
+ */
+test("test_Game.createGameMatDieDiv", function(assert) {
+  var die = {
+    description: "6-sided die",
+    properties: [],
+    recipe: '(6)',
+    sides: 6,
+    skills: [],
+    value: 2
+  };
+
+  var dieDivJQuery = Game.createGameMatDieDiv(die, 'player', 'active', true);
+  var dieDivProps = BMTestUtils.DOMNodePropArray(dieDivJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_img" }, [
+    [ "SPAN", { "class": "die_overlay die_number_player" }, [ "2" ] ] ]
+  ];
+  assert.deepEqual(dieDivProps, expectedDivProps, "dieDiv looks correct for clickable active die");
+
+  var dieDivJQuery = Game.createGameMatDieDiv(die, 'opponent', 'active', false);
+  var dieDivProps = BMTestUtils.DOMNodePropArray(dieDivJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_img die_greyed" }, [
+    [ "SPAN", { "class": "die_overlay die_number_opponent" }, [ "2" ] ] ]
+  ];
+  assert.deepEqual(dieDivProps, expectedDivProps, "dieDiv looks correct for unclickable active die");
+
+  var dieDivJQuery = Game.createGameMatDieDiv(die, 'player', 'captured', false);
+  var dieDivProps = BMTestUtils.DOMNodePropArray(dieDivJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_img" }, [
+    [ "SPAN", { "class": "die_overlay die_number_player" }, [ "\u00A0" + "2" + "\u00A0" ] ] ]
+  ];
+  assert.deepEqual(dieDivProps, expectedDivProps, "dieDiv looks correct for captured die");
+});
+
+/**
+ * This test uses hand-created (not API) data to test Game.createGameMatBorderDiv()
+ */
+test("test_Game.createGameMatBorderDiv", function(assert) {
+  var dieBorderJQuery = Game.createGameMatBorderDiv('player', true);
+  var dieBorderProps = BMTestUtils.DOMNodePropArray(dieBorderJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_border" }, [] ];
+  assert.deepEqual(dieBorderProps, expectedDivProps, "die border looks correct for player's selected die");
+
+  var dieBorderJQuery = Game.createGameMatBorderDiv('player', false);
+  var dieBorderProps = BMTestUtils.DOMNodePropArray(dieBorderJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_border", "style": "border: 2px solid #dd99dd" }, [] ];
+  assert.deepEqual(dieBorderProps, expectedDivProps, "die border looks correct for player's unselected die");
+
+  var dieBorderJQuery = Game.createGameMatBorderDiv('opponent', false);
+  var dieBorderProps = BMTestUtils.DOMNodePropArray(dieBorderJQuery[0]);
+  var expectedDivProps = [ "DIV", { "class": "die_border", "style": "border: 2px solid #ddffdd" }, [] ];
+  assert.deepEqual(dieBorderProps, expectedDivProps, "die border looks correct for opponent's unselected die");
+});
+
+
+/**
+ * This test uses API data to test Game.createGameMatDieRecipeDiv(),
+ * a simple wrapper function which assembles a recipe div
+ */
+test("test_Game.createGameMatDieRecipeDiv", function(assert) {
+  stop();
+  BMTestUtils.GameType = 'washu_hooloovoo_cant_win';
+  Game.getCurrentGame(function() {
+    var die = Api.game.opponent.activeDieArray[3];
+    var recipeDivJQuery = Game.createGameMatDieRecipeDiv(die, 'opponent');
+    var recipeDivProps = BMTestUtils.DOMNodePropArray(recipeDivJQuery[0]);
+
+    var expectedDivProps = [ "DIV", {}, [
+      [ "SPAN", { "class": "die_recipe_opponent" }, [ "z(S=20)" ] ] ]
+    ];
+    assert.deepEqual(recipeDivProps, expectedDivProps);
+    start();
+  });
+});
+
 // This test shows a mat of the opponent's dice
 // Opponent's dice have the correct set of classes defined for the opponent,
 // and the recipe appears after the dice
@@ -1502,7 +1741,7 @@ test("test_Game.gamePlayerDice", function(assert) {
 
     // dieIdx 0: q(T=2)
     var expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_opponent",
+        "class": "die_container die_alive hide_focus unselected_opponent",
         "id": "playerIdx_1_dieIdx_0",
         "tabindex": "0",
         "title": "Queer T Swing Die (with 2 sides)"
@@ -1517,11 +1756,11 @@ test("test_Game.gamePlayerDice", function(assert) {
         ]
       ]
     ];
-    assert.deepEqual(diceProps[2][0], expectedDieProps);
+    assert.deepEqual(diceProps[2][0], expectedDieProps, "Opponent's unselected die q(T=2) has expected properties");
 
     // dieIdx 3: z(S=20)
     expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_opponent",
+        "class": "die_container die_alive hide_focus unselected_opponent",
         "id": "playerIdx_1_dieIdx_3",
         "tabindex": "0",
         "title": "Speed S Swing Die (with 20 sides)"
@@ -1596,7 +1835,7 @@ test("test_Game.gamePlayerDice_captured", function(assert) {
 
     // dieIdx 0: (6)
     var expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_player",
+        "class": "die_container die_alive hide_focus unselected_player",
         "id": "playerIdx_0_dieIdx_0",
         "tabindex": "0",
         "title": "6-sided die"
@@ -1670,7 +1909,7 @@ test("test_Game.gamePlayerDice_warrior", function(assert) {
 
     // opponent dieIdx 2: z(12)
     var expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_opponent",
+        "class": "die_container die_alive hide_focus unselected_opponent",
         "id": "playerIdx_1_dieIdx_2",
         "tabindex": "0",
         "title": "Speed 12-sided die"
@@ -1718,7 +1957,7 @@ test("test_Game.gamePlayerDice_warrior", function(assert) {
 
     // player dieIdx 0: (1)
     expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_player",
+        "class": "die_container die_alive hide_focus unselected_player",
         "id": "playerIdx_0_dieIdx_0",
         "tabindex": "0",
         "title": "1-sided die"
@@ -1737,7 +1976,7 @@ test("test_Game.gamePlayerDice_warrior", function(assert) {
 
     // player dieIdx 3: `(6)
     expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_player",
+        "class": "die_container die_alive hide_focus unselected_player",
         "id": "playerIdx_0_dieIdx_3",
         "tabindex": "0",
         "title": "Warrior 6-sided die"
@@ -1798,7 +2037,7 @@ test("test_Game.gamePlayerDice_dizzy_selected", function(assert) {
 
     // opponent dieIdx 2: z(12)
     var expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive unselected_opponent",
+        "class": "die_container die_alive hide_focus unselected_opponent",
         "id": "playerIdx_0_dieIdx_2",
         "tabindex": "0",
         "title": "10-sided die"
@@ -1817,7 +2056,7 @@ test("test_Game.gamePlayerDice_dizzy_selected", function(assert) {
 
     // opponent dieIdx 4: c(X=6)
     var expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive selected",
+        "class": "die_container die_alive hide_focus selected",
         "id": "playerIdx_0_dieIdx_4",
         "tabindex": "0",
         "title": "Chance X Swing Die (with 6 sides)",
@@ -1847,7 +2086,7 @@ test("test_Game.gamePlayerDice_dizzy_selected", function(assert) {
 
     // player dieIdx 0: (4)
     expectedDieProps = [ "DIV", {
-        "class": "hide_focus die_container die_alive selected",
+        "class": "die_container die_alive hide_focus selected",
         "id": "playerIdx_1_dieIdx_0",
         "tabindex": "0",
         "title": "4-sided die"
@@ -2040,16 +2279,16 @@ test("test_Game.dieBorderTogglePlayerHandler", function(assert) {
     // and unselected on click
     var dieobj = $('#playerIdx_0_dieIdx_0');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive unselected_player'),
+    assert.ok(html.match('die_container die_alive hide_focus unselected_player'),
       "die is unselected before click");
 
     $('#playerIdx_0_dieIdx_0').trigger('click');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive selected'), "die is selected after first click");
+    assert.ok(html.match('die_container die_alive hide_focus selected'), "die is selected after first click");
 
     $('#playerIdx_0_dieIdx_0').trigger('click');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive unselected_player'),
+    assert.ok(html.match('die_container die_alive hide_focus unselected_player'),
       "die is unselected after second click");
 
     start();
@@ -2068,16 +2307,16 @@ test("test_Game.dieBorderToggleOpponentHandler", function(assert) {
     // and unselected on click
     var dieobj = $('#playerIdx_1_dieIdx_0');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive unselected_opponent'),
+    assert.ok(html.match('die_container die_alive hide_focus unselected_opponent'),
       "die is unselected before click");
 
     $('#playerIdx_1_dieIdx_0').trigger('click');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive selected'), "die is selected after first click");
+    assert.ok(html.match('die_container die_alive hide_focus selected'), "die is selected after first click");
 
     $('#playerIdx_1_dieIdx_0').trigger('click');
     var html = $('<div>').append(dieobj.clone()).remove().html();
-    assert.ok(html.match('die_container die_alive unselected_opponent'),
+    assert.ok(html.match('die_container die_alive hide_focus unselected_opponent'),
       "die is unselected after second click");
 
     start();


### PR DESCRIPTION
* Related to #822 and #2047, a suggested replacement refactor for #1981
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/461/ (if it passes)

This splits the monolith `Game.gamePlayerDice()` function into a number of distinct functions, which ideally has the effect of splitting things cleanly into functions which gather information and functions which lay out particular elements, and making operation consistent across active and captured dice.

The refactor *should* be a total noop --- the only difference is that it reorders class attributes in a couple of cases, but it should not add or remove attributes in any case, but only move code around.