### PR TITLE
Implement the concept of private chat in the backend and chat-loading layers

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -45,6 +45,7 @@ CREATE TABLE game_player_map (
     was_game_dismissed BOOLEAN DEFAULT FALSE NOT NULL,
     is_button_random   BOOLEAN DEFAULT FALSE NOT NULL,
     has_player_accepted BOOLEAN DEFAULT TRUE NOT NULL,
+    is_chat_private    BOOLEAN DEFAULT FALSE NOT NULL,
     INDEX (game_id, player_id)
 );
 

--- a/deploy/database/updates/00464_chat_privacy.sql
+++ b/deploy/database/updates/00464_chat_privacy.sql
@@ -1,4 +1,6 @@
-# Database views for game-related tables
+ALTER TABLE game_player_map
+ADD COLUMN is_chat_private BOOLEAN DEFAULT FALSE NOT NULL
+AFTER has_player_accepted;
 
 DROP VIEW IF EXISTS game_player_view;
 CREATE VIEW game_player_view
@@ -34,23 +36,3 @@ LEFT JOIN button AS b
 ON m.button_id = b.id
 LEFT JOIN game AS g
 ON m.game_id = g.id;
-
-DROP VIEW IF EXISTS open_game_possible_button_view;
-CREATE VIEW open_game_possible_button_view
-AS SELECT
-    g.id,
-    pb.button_id,
-    ps.set_id,
-    b.name AS button_name,
-    s.name AS set_name
-FROM game AS g
-LEFT JOIN open_game_possible_buttons AS pb
-ON g.id = pb.game_id
-LEFT JOIN open_game_possible_buttonsets AS ps
-ON g.id = ps.game_id
-LEFT JOIN button AS b
-ON pb.button_id = b.id
-LEFT JOIN buttonset AS s
-ON ps.set_id = s.id
-WHERE g.status_id = (SELECT id FROM game_status WHERE name = "OPEN");
-

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -165,8 +165,8 @@ class BMInterface {
                 $data['gameActionLogCount'] = $actionLogArray['nEntries'];
             }
 
-            $chatLogArray = $this->game_chat()->load_game_chat_log($game, $logEntryLimit);
-            if (empty($actionLogArray)) {
+            $chatLogArray = $this->game_chat()->load_game_chat_log($playerId, $game, $logEntryLimit);
+            if (empty($chatLogArray)) {
                 $data['gameChatLog'] = NULL;
                 $data['gameChatLogCount'] = 0;
             } else {
@@ -284,7 +284,8 @@ class BMInterface {
                  'UNIX_TIMESTAMP(v.last_action_time) AS player_last_action_timestamp, '.
                  'v.was_game_dismissed, '.
                  'v.has_player_accepted, '.
-                 'v.is_on_vacation '.
+                 'v.is_on_vacation, '.
+                 'v.is_chat_private '.
                  'FROM game AS g '.
                  'LEFT JOIN game_status AS s '.
                  'ON s.id = g.status_id '.
@@ -396,6 +397,7 @@ class BMInterface {
         }
 
         $player->isOnVacation = (bool) $row['is_on_vacation'];
+        $player->isChatPrivate = (bool) $row['is_chat_private'];
 
         if (isset($row['current_player_id']) &&
             isset($row['player_id']) &&
@@ -1832,12 +1834,12 @@ class BMInterface {
     // different action and chat log SELECT queries
     protected function build_game_log_query_restrictions(
         BMGame $game,
-        $isChat,
+        $doQueryPreviousGame,
         $isCount,
         array &$sqlParameters
     ) {
         $restrictions = 'WHERE game_id = :game_id ';
-        if ($isChat && $game->gameState < BMGameState::END_GAME && !is_null($game->previousGameId)) {
+        if ($doQueryPreviousGame) {
             $restrictions .= 'OR game_id = :previous_game_id ';
             $sqlParameters[':previous_game_id'] = $game->previousGameId;
         }

--- a/src/engine/BMPlayer.php
+++ b/src/engine/BMPlayer.php
@@ -32,6 +32,7 @@
  * @property      int      $lastActionTime         Time of last action
  * @property      BMGame   $ownerObject            BMGame that owns this BMPlayer object
  * @property      bool     $isOnVacation           Is player on vacation? (Used by BMInterface only)
+ * @property      bool     $isChatPrivate          Has player set chat to private for this game?
  *
  * @SuppressWarnings(PMD.TooManyFields)
  */
@@ -237,6 +238,13 @@ class BMPlayer {
      * @var bool
      */
     protected $isOnVacation;
+
+    /**
+     * Has current player set chat to private? Currently only used by BMInterface*.
+     *
+     * @var bool
+     */
+    protected $isChatPrivate;
 
     /**
      * Find indices of active dice that do not have reserve
@@ -481,6 +489,19 @@ class BMPlayer {
         }
 
         $this->isOnVacation = $value;
+    }
+
+    /**
+     * Set isChatPrivate
+     *
+     * @param bool $value
+     */
+    protected function set__isChatPrivate($value) {
+        if (!is_bool($value)) {
+            throw new InvalidArgumentException('isChatPrivate must be a boolean');
+        }
+
+        $this->isChatPrivate = $value;
     }
 
     // utility methods

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2155,6 +2155,7 @@ Game.pageAddLogFooter = function() {
       $.each(Api.game.chatLog, function(logindex, logentry) {
         var chatrow = $('<tr>');
         var chatplayer;
+        var chatplayeropts;
         if (logentry.player == Api.game.player.playerName) {
           chatplayer = 'player';
         } else if (logentry.player == Api.game.opponent.playerName) {
@@ -2162,13 +2163,17 @@ Game.pageAddLogFooter = function() {
         } else {
           chatplayer = 'noone';
         }
-        chatrow.append($('<td>', {
+        chatplayeropts = {
           'class': 'chat',
           'style': 'background-color: ' + Game.color[chatplayer],
           'nowrap': 'nowrap',
-          'text': logentry.player + ' (' +
-            Env.formatTimestamp(logentry.timestamp) + ')',
-        }));
+          'text': logentry.player,
+        };
+        if (logentry.timestamp > 0) {
+          chatplayeropts.text += ' (' +
+            Env.formatTimestamp(logentry.timestamp) + ')';
+        }
+        chatrow.append($('<td>', chatplayeropts));
         var messageClass = 'left logmessage';
         if (Api.game.isParticipant && Api.game.player.lastActionTime &&
           logentry.timestamp > Api.game.player.lastActionTime) {

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -3194,7 +3194,6 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @depends test_request_savePlayerInfo
-     * @group fulltest_deps
      *
      * In this scenario, a 1-round Haruspex mirror battle is played,
      * letting us test a completed game, and a number of "continue

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -3194,6 +3194,7 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @depends test_request_savePlayerInfo
+     * @group fulltest_deps
      *
      * In this scenario, a 1-round Haruspex mirror battle is played,
      * letting us test a completed game, and a number of "continue
@@ -3581,6 +3582,27 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
 
 
+        // now load the game as a non-player, and verify that chat
+	// text from the current game is shown, but chat from a
+	// previous game is not shown
+        $expData['gameChatEditable'] = FALSE;
+        $expData['currentPlayerIdx'] = FALSE;
+        $expData['playerDataArray'][0]['playerColor'] = '#cccccc';
+        $expData['playerDataArray'][1]['playerColor'] = '#dddddd';
+        $expData['gameChatLogCount'] = 2;
+        $savedChat = array_splice($expData['gameChatLog'], 2, 1);
+        $_SESSION = $this->mock_test_user_login('responder002');
+        $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+        $_SESSION = $this->mock_test_user_login('responder003');
+
+        $expData['gameChatEditable'] = 'TIMESTAMP';
+        $expData['currentPlayerIdx'] = 0;
+        $expData['playerDataArray'][0]['playerColor'] = '#dd99dd';
+        $expData['playerDataArray'][1]['playerColor'] = '#ddffdd';
+        $expData['gameChatLogCount'] = 3;
+        $expData['gameChatLog'][]= $savedChat;
+
+
         ////////////////////
         // Move 02 (game 3) - player 2 wins game without chatting
 
@@ -3660,6 +3682,19 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // load the game and check its state
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+
+
+        // Now load the game as a non-player, and verify that chat
+        // text from a previous game is not shown
+        $expData['gameChatEditable'] = FALSE;
+        $expData['currentPlayerIdx'] = FALSE;
+        $expData['playerDataArray'][0]['playerColor'] = '#cccccc';
+        $expData['playerDataArray'][1]['playerColor'] = '#dddddd';
+        $expData['gameChatLogCount'] = 1;
+        array_splice($expData['gameChatLog'], 1, 2);
+        $_SESSION = $this->mock_test_user_login('responder002');
+        $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+        $_SESSION = $this->mock_test_user_login('responder003');
     }
 
     /**


### PR DESCRIPTION
* Partially addresses #464 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/472/

This pull adds a private chat flag to the game_player_map database table, and implements the concept that, if that flag is set for either player in a game, non-players cannot load the chat for that game, but instead load, as part of the normal chat stream, a message saying that game chat is private.

This pull does not provide support for setting the private chat flag, so it does not make any chat privacy functionality available to players.

This pull changes the behavior of continuation chat in all games per https://github.com/buttonmen-dev/buttonmen/issues/464#issuecomment-231558844 option 4 --- non-players no longer see chat from previous games when they load a game which is a continuation, but do still see the "Continued from game N" message (both of those things hold regardless of the chat privacy settings on either the original or continuation games).