### PR TITLE
Made die value number smaller, added specific vertical spacing for Firefox

### DIFF
--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -287,16 +287,8 @@ select.center {
 .die_overlay {
     position:relative;
     font-size: 21px;
-    top: 14px;
-}
-
-/* Added slightly different vertical spacing for Firefox only */
-@-moz-document url-prefix() {
-    .die_overlay{
-        position:relative;
-        font-size: 21px;
-        top: 17px;
-    }
+    line-height: 25px;
+    top: 13.5px;
 }
 
 .die_number_player {

--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -286,8 +286,17 @@ select.center {
 
 .die_overlay {
     position:relative;
-    font-size: 24px;
-    top: 13px;
+    font-size: 21px;
+    top: 14px;
+}
+
+/* Added slightly different vertical spacing for Firefox only */
+@-moz-document url-prefix() {
+    .die_overlay{
+        position:relative;
+        font-size: 21px;
+        top: 17px;
+    }
 }
 
 .die_number_player {


### PR DESCRIPTION
Partially addresses #2070.

This changes the font size from 24 px to 20 px, and adds a Firefox-specific CSS rule that has different vertical spacing, to account for the unusual amount of padding at the bottom of the die value span that Firefox adds for some odd reason.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1199/ (if it passes)