### PR TITLE
Overview.addDescCol() should not blow up if description is null

### DIFF
--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -423,7 +423,7 @@ Overview.addScoreCol = function(gameRow, gameInfo) {
 
 Overview.addDescCol = function(gameRow, description) {
   var descText = '';
-  if (typeof(description) == "string") {
+  if (typeof(description) == 'string') {
     descText = description.substring(0, 30) +
                ((description.length > 30) ? '...' : '');
   }

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -422,10 +422,14 @@ Overview.addScoreCol = function(gameRow, gameInfo) {
 };
 
 Overview.addDescCol = function(gameRow, description) {
+  var descText = '';
+  if (typeof(description) == "string") {
+    descText = description.substring(0, 30) +
+               ((description.length > 30) ? '...' : '');
+  }
   gameRow.append($('<td>', {
     'class': 'gameDescDisplay',
-    'text': description.substring(0, 30) +
-            ((description.length > 30) ? '...' : ''),
+    'text': descText,
   }));
 };
 


### PR DESCRIPTION
* Mitigates the effect of #2081 
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/475/ (if it passes)

This is just the fix i already manually applied to the dev and prod sites.  Obviously the backend mismatch is what we need to fix, but regardless it's not bad for the UI to be resilient if the backend gives it bad data.