### PR TITLE
Backend changes to enable third party game creation

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -9,6 +9,7 @@
  * This class contains all the logic to do with games, specified at each game state
  *
  * @property      int   $gameId                  Game ID number in the database
+ * @property      int   $creatorId               Player ID of the player who created the game
  * @property      array $playerArray             Array of BMPlayer objects
  * @property-read int   $nPlayers                Number of players in the game
  * @property-read int   $roundNumber;            Current round number
@@ -74,6 +75,11 @@ class BMGame {
      * @var int
      */
     protected $gameId;
+
+    /**
+     * Player ID of the player who created the game
+     */
+    protected $creatorId;
 
     /**
      * Array of BMPlayer objects

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -344,6 +344,7 @@ class BMInterface {
     }
 
     protected function load_game_attributes($game, $row) {
+        $game->creatorId = $row['creator_id'];
         $game->gameState = $row['game_state'];
         $game->maxWins   = $row['n_target_wins'];
         $game->turnNumberInRound = $row['turn_number_in_round'];

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -1491,16 +1491,6 @@ class responderTest extends PHPUnit_Framework_TestCase {
         );
         $this->verify_api_failure($args, 'Game create failed because a button name was not valid.');
 
-        // Make sure that the first player in a game is the current logged in player
-        $args = array(
-            'type' => 'createGame',
-            'playerInfoArray' => array(array('responder001', 'Avis'),
-                                       array('responder004', 'Avis')),
-            'maxWins' => '3',
-        );
-        $this->verify_api_failure($args, 'Game create failed because you must be the first player.');
-
-
         // Successfully create a game with all players and buttons specified
         $retval = $this->verify_api_createGame(
             array(1, 1, 1, 1, 2, 2, 2, 2),
@@ -1527,6 +1517,18 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Game " . $retval['data']['gameId'] . " created successfully.", $retval['message']);
 
         $this->cache_json_api_output('createGame', 'Avis_None', $retval);
+
+
+        // Check that the first player in a game can be different from the current logged in player
+        $retval = $this->verify_api_createGame(
+            array(1, 1, 1, 1, 2, 2, 2, 2),
+            'responder001', 'responder002', 'Avis', 'Avis', 3, '', NULL, 'data'
+        );
+
+        $this->assertEquals('ok', $retval['status'], 'Game creation should succeed');
+        $this->assertEquals(array('gameId'), array_keys($retval['data']));
+        $this->assertTrue(is_numeric($retval['data']['gameId']));
+        $this->assertEquals("Game " . $retval['data']['gameId'] . " created successfully.", $retval['message']);
     }
 
     public function test_request_joinOpenGame() {

--- a/test/src/engine/BMInterfaceGameTest.php
+++ b/test/src/engine/BMInterfaceGameTest.php
@@ -15,7 +15,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_and_load_new_game() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             4
@@ -124,7 +124,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      */
     public function test_create_self_game() {
         // attempt to create a game with the same player on both sides
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId1WithoutAutopass),
             array('Bauer', 'Stark'),
             4
@@ -141,7 +141,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      */
     public function test_create_game_with_invalid_parameters() {
         // attempt to create a game with a non-integer number of max wins
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             4.5
@@ -151,7 +151,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
                             $this->object->message);
 
         // attempt to create a game with a zero number of max wins
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             0
@@ -161,7 +161,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
                             $this->object->message);
 
         // attempt to create a game with a large number of max wins
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             6
@@ -171,13 +171,37 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
                             $this->object->message);
 
         // attempt to create a game with an invalid button name
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('KJQOERUCHC', 'Stark'),
             3
         );
         $this->assertNull($retval);
         $this->assertEquals('Game create failed because a button name was not valid.',
+                            $this->object->message);
+
+        // attempt to create a game with no first player
+        $retval = $this->object->create_game(
+            array(NULL, self::$userId2WithoutAutopass),
+            array('Avis', 'Bauer'),
+            3,
+            '',
+            NULL,
+            self::$userId1WithoutAutopass,
+            TRUE
+        );
+        $this->assertNull($retval);
+        $this->assertEquals('Game create failed because the first player was not specified.',
+                            $this->object->message);
+
+        // attempt to create a game with no first button
+        $retval = $this->create_game_self_first(
+            array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
+            array('', 'Stark'),
+            3
+        );
+        $this->assertNull($retval);
+        $this->assertEquals('The first button needs to be set.',
                             $this->object->message);
     }
 
@@ -189,7 +213,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_game_with_ornery_mood_swing() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Skeeve', 'Skeeve'),
             4
@@ -337,7 +361,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_game_with_one_random_button() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Coil', '__random'),
             4
@@ -360,7 +384,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_game_with_one_random_button_and_one_unspecified() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('__random', NULL),
             4
@@ -402,7 +426,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_game_with_two_random_buttons() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('__random', '__random'),
             4
@@ -424,7 +448,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_game_with_two_random_buttons_with_one_unspecified_player() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, NULL),
             array('__random', '__random'),
             4
@@ -446,7 +470,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_and_load_new_game_with_empty_opponent() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, NULL),
             array('Bauer', 'Stark'),
             4
@@ -517,7 +541,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_and_load_new_game_with_empty_button() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', NULL),
             4
@@ -586,7 +610,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_create_and_load_new_game_with_empty_opponent_and_opponent_button() {
-        $retval = $this->object->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, NULL),
             array('Bauer', NULL),
             4
@@ -658,7 +682,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
             4,
             '',
             NULL,
-            NULL,
+            self::$userId1WithoutAutopass,
             FALSE
         );
 
@@ -674,7 +698,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
             4,
             '',
             NULL,
-            NULL,
+            self::$userId5WithoutAutoaccept,
             FALSE
         );
 
@@ -690,7 +714,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
             4,
             '',
             NULL,
-            NULL,
+            self::$userId1WithoutAutopass,
             FALSE
         );
 
@@ -708,6 +732,23 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $game = self::load_game($gameId);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[0]);
         $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
+
+        // check that a game created by another player will not be autoaccepted by the first player
+        $retval = $this->object->game()->create_game(
+            array(self::$userId5WithoutAutoaccept, self::$userId2WithoutAutopass),
+            array('Bauer', 'Stark'),
+            4,
+            '',
+            NULL,
+            self::$userId1WithoutAutopass,
+            FALSE
+        );
+
+        $gameId = $retval['gameId'];
+        $game = self::load_game($gameId);
+        $this->assertCount(2, $game->hasPlayerAcceptedGameArray);
+        $this->assertFalse($game->hasPlayerAcceptedGameArray[0]);
+        $this->assertTrue($game->hasPlayerAcceptedGameArray[1]);
     }
 
 
@@ -716,7 +757,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      */
     public function test_join_open_game() {
         // create an open game with an unspecified opponent
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, NULL),
             array('Bauer', 'Stark'),
             4
@@ -738,7 +779,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      */
     public function test_select_button() {
         // create an open game with an unspecified button
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', NULL),
             4
@@ -769,7 +810,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
     public function test_react_to_auxiliary_both_aux_decline() {
         // Lancelot : (10) (12) (20) (20) (X) +(X)
         // Gawaine  :  (4)  (4) (12) (20) (X) +(6)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Lancelot', 'Gawaine'),
             4
@@ -835,7 +876,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
     public function test_react_to_auxiliary_one_aux_decline() {
         // Kublai   :  (4) (8) (12) (20) (X)
         // Gawaine  :  (4) (4) (12) (20) (X) +(6)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Kublai', 'Gawaine'),
             4
@@ -912,7 +953,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
     public function test_react_to_auxiliary_one_aux_accept() {
         // Kublai   :  (4) (8) (12) (20) (X)
         // Gawaine  :  (4) (4) (12) (20) (X) +(6)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Kublai', 'Gawaine'),
             4
@@ -1000,7 +1041,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
     public function test_react_to_reserve_decline() {
         // Sailor Moon : (8) (8) (10) (20) r(6) r(10) r(20) r(20)
         // Queen Beryl : (4) (8) (12) (20) r(4) r(12) r(20) r(20)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Sailor Moon', 'Queen Beryl'),
             4
@@ -1087,7 +1128,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
     public function test_react_to_reserve_add() {
         // Sailor Moon : (8) (8) (10) (20) r(6) r(10) r(20) r(20)
         // Queen Beryl : (4) (8) (12) (20) r(4) r(12) r(20) r(20)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Sailor Moon', 'Queen Beryl'),
             4
@@ -1158,7 +1199,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
      */
     function test_fire() {
         // (4) (6) F(8) (20) (X) vs F(4) F(6) (6) (12) (X)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Poly', 'Adam Spam'),
             4

--- a/test/src/engine/BMInterfacePlayerTest.php
+++ b/test/src/engine/BMInterfacePlayerTest.php
@@ -135,7 +135,7 @@ class BMInterfacePlayerTest extends BMInterfaceTestAbstract {
      * @covers BMInterfacePlayer::update_last_action_time
      */
     public function test_update_last_action_time() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Avis', 'Hammer'),
             4

--- a/test/src/engine/BMInterfaceTest.php
+++ b/test/src/engine/BMInterfaceTest.php
@@ -16,7 +16,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_load_game_after_setting_swing_values() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             4
@@ -132,7 +132,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_play_turn() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Bauer', 'Stark'),
             4
@@ -194,7 +194,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
     public function test_load_poison() {
         // Coil: p4 12 p20 20 V
         // Bane: p2 p4 12 12 V
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Coil', 'Bane'),
             4
@@ -254,7 +254,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_swing_value_reset_at_end_of_round() {
         // create a dummy game that will be overwritten
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Tess', 'Coil'),
             4
@@ -426,7 +426,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_swing_value_reset_at_end_of_game() {
         // create a dummy game that will be overwritten
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Tess', 'Coil'),
             1
@@ -500,7 +500,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_swing_value_persistence() {
         // create a dummy game that will be overwritten
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Tess', 'Coil'),
             4
@@ -579,7 +579,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_all_pass() {
         // create a dummy game that will be overwritten
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Wiseman', 'Wiseman'),
             4
@@ -665,7 +665,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_autopass() {
         // create a dummy game that will be overwritten
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId3WithAutopass),
             array('Bunnies', 'Peace'),
             4
@@ -742,7 +742,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     function test_twin_die() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Cthulhu', 'Bill'),
             4
@@ -847,7 +847,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     function test_konstant() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Al-Khwarizmi', 'Carl Friedrich Gauss'),
             4
@@ -935,7 +935,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_surrender() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Sonia', 'Tamiya'),
             4
@@ -1034,7 +1034,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      */
     public function test_autoplay_bug() {
         // autoplay bug requires autopass turned on
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId4WithAutopass),
             array('Scorpion', 'Kakita'),
             4
@@ -1189,7 +1189,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
     public function test_reserve_swing_setting() {
         // Zomulgustar : t(4) p(5/23)! t(9) t(13) rdD(1) rsz(1) r^(1,1) rBqn(Z)?
         // Cammy Neko  : (4) (6) (12) (10,10) r(12) r(20) r(20) r(8,8)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Zomulgustar', 'Cammy Neko'),
             4
@@ -1248,7 +1248,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
     public function test_echo_vs_other() {
         // Echo : none
         // Avis : (4) (4) (10) (12) (X)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Echo', 'Avis'),
             4
@@ -1293,7 +1293,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
     public function test_echo_recipe_save() {
         // Echo : none
         // Avis : (4) (4) (10) (12) (X)
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Echo', 'Avis'),
             4
@@ -1324,7 +1324,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @coversNothing
      */
     public function test_declined_courtesy_auxiliary_swing_dice() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Ayeka', 'Merlin'),
             4
@@ -1367,7 +1367,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_option_game() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Apples', 'Green Apple'),
             4
@@ -1571,7 +1571,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @coversNothing
      */
     public function test_option_game_multiple_identical_option_bug() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Farrell', 'Farrell'),
             4
@@ -1594,7 +1594,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_mood_swing_round() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Gilly', 'Igor'),
             4
@@ -1709,7 +1709,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @covers BMInterface::load_game
      */
     public function test_twin_mood_swing_round() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('TheFool', 'TheFool'),
             4
@@ -1845,7 +1845,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @coversNothing
      */
     public function test_option_reset_bug() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Frasquito', 'Wiseman'),
             4
@@ -1962,7 +1962,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
      * @coversNothing
      */
     public function test_swing_reset_bug() {
-        $retval = $this->object->game()->create_game(
+        $retval = $this->create_game_self_first(
             array(self::$userId1WithoutAutopass, self::$userId2WithoutAutopass),
             array('Mau', 'Wiseman'),
             4

--- a/test/src/engine/BMInterfaceTestAbstract.php
+++ b/test/src/engine/BMInterfaceTestAbstract.php
@@ -54,4 +54,27 @@ class BMInterfaceTestAbstract extends PHPUnit_Framework_TestCase {
         $save_game = self::getMethod('save_game');
         return $save_game->invokeArgs($this->object, array($game));
     }
+
+    protected function create_game_self_first(
+        array $playerIdArray,
+        array $buttonNameArray,
+        $maxWins = 3,
+        $description = '',
+        $previousGameId = NULL,
+        $autoAccept = TRUE
+    ) {
+        if (0 == count($playerIdArray)) {
+            throw new LogicException('The player ID array cannot be empty');
+        }
+
+        return $this->object->game()->create_game(
+            $playerIdArray,
+            $buttonNameArray,
+            $maxWins,
+            $description,
+            $previousGameId,
+            $playerIdArray[0],
+            $autoAccept
+        );
+    }
 }


### PR DESCRIPTION
Starts to address #1784, but should leave user-visible behaviour untouched.

Note that it should now be possible to create third-party games by directly addressing the responder, e.g., via the Python client.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1219/ (if it passes)
