### PR TITLE
Die background is now correctly always specified by the viewing player's preferences

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -152,7 +152,7 @@ class BMInterface {
                 $playerNameArray[] = $playerName;
                 $data['playerDataArray'][$gamePlayerIdx]['playerName'] = $playerName;
                 $data['playerDataArray'][$gamePlayerIdx]['dieBackgroundType'] =
-                    $this->load_die_background_type($gamePlayer->playerId);
+                    $this->load_die_background_type($playerId);
                 $isOnVacation = (bool) $game->playerArray[$gamePlayerIdx]->isOnVacation;
                 $data['playerDataArray'][$gamePlayerIdx]['isOnVacation'] = $isOnVacation;
             }

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -2421,10 +2421,11 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][0]['optRequestArray'] = array('4' => array(2, 20));
 
-        // in test_request_savePlayerInfo() responder002 was set to be on vacation - make sure the game reflects that.
-        $expData['playerDataArray'][1]['isOnVacation'] = TRUE;
         $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
         $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
+
+        // in test_request_savePlayerInfo() responder002 was set to be on vacation - make sure the game reflects that.
+        $expData['playerDataArray'][1]['isOnVacation'] = TRUE;
 
         // now load the game and check its state
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
@@ -2432,8 +2433,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder003 and check its state
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
 
         ////////////////////
         // Move 01 - specify option dice
@@ -2476,8 +2481,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // check the game state as a nonplayer so the UI tests have access to a game in START_TURN from a nonplayer perspective
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
 
 
         ////////////////////
@@ -3619,8 +3628,8 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
 
         // now load the game as a non-player, and verify that chat
-	// text from the current game is shown, but chat from a
-	// previous game is not shown
+        // text from the current game is shown, but chat from a
+        // previous game is not shown
         $expData['gameChatEditable'] = FALSE;
         $expData['currentPlayerIdx'] = FALSE;
         $expData['playerDataArray'][0]['playerColor'] = '#cccccc';
@@ -3628,8 +3637,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $expData['gameChatLogCount'] = 2;
         $savedChat = array_splice($expData['gameChatLog'], 2, 1);
         $_SESSION = $this->mock_test_user_login('responder002');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
         $expData['gameChatEditable'] = 'TIMESTAMP';
         $expData['currentPlayerIdx'] = 0;
@@ -3729,8 +3742,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
         $expData['gameChatLogCount'] = 1;
         array_splice($expData['gameChatLog'], 1, 2);
         $_SESSION = $this->mock_test_user_login('responder002');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
     }
 
     /**
@@ -5195,8 +5212,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder001 and check its state
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
         ////////////////////
         // Move 07 - responder003 abandons the Fire-assisted Skill attack and gets another attack
@@ -6472,8 +6493,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder001 and check its state
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
         ////////////////////
         // Move 15 - responder004 added a reserve die: rz(S)
@@ -8565,8 +8590,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder001 and check its state
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
 
         // responder003 rerolled a chance die, but did not gain initiative: c(6) rerolled 3 => 4
@@ -9614,8 +9643,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder001 and check its state
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder003');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
         ////////////////////
         // Move 01 - responder003 chose to use auxiliary die +s(X) in this game
@@ -12957,8 +12990,12 @@ class responderTest extends PHPUnit_Framework_TestCase {
 
         // now load the game as non-participating player responder001 and check its state
         $_SESSION = $this->mock_test_user_login('responder001');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'symmetric';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'symmetric';
         $this->verify_api_loadGameData_as_nonparticipant($expData, $gameId, 10);
         $_SESSION = $this->mock_test_user_login('responder005');
+        $expData['playerDataArray'][0]['dieBackgroundType'] = 'realistic';
+        $expData['playerDataArray'][1]['dieBackgroundType'] = 'realistic';
 
         ////////////////////
         // Move 07 - responder005 abandons the Fire-assisted Skill attack and gets another attack


### PR DESCRIPTION
Fixes #2094.

This is the minimal quick fix that resolves the symptoms but does it in a way that leaves the API response inappropriate. #2097 is probably a better solution, but I'll leave this one up in case it's simpler.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1220/