### PR TITLE
Display UI messages when joining an open game

### DIFF
--- a/src/ui/js/OpenGames.js
+++ b/src/ui/js/OpenGames.js
@@ -136,6 +136,12 @@ OpenGames.displayJoinResult = function(
         'type': 'error',
         'text': 'An internal error occurred while trying to join the game.',
       };
+    } else {
+      Env.message = {
+        'type': 'error',
+        'text': 'The list of open games was out of date. ' +
+                'It has been refreshed.',
+      };
     }
     OpenGames.getOpenGames(OpenGames.showPage);
     return;


### PR DESCRIPTION
Fixes #1755.

The message that is displayed causes the open games table to shift downwards, which I think is undesirable. It's probably better to always reserve the space for the message, but I don't know how to do this. Suggestions are welcome.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1226/ (if it passes)
