### PR TITLE
testing: Fixed default attack when fire overshooting is off

### DIFF
--- a/src/engine/BMAttackDefault.php
+++ b/src/engine/BMAttackDefault.php
@@ -194,7 +194,10 @@ class BMAttackDefault extends BMAttack {
         if ($fireTurndownAvailable > 0) {
             // power attack with the possibility of fire assistance
             if (in_array('Power', $validAttackTypes) && ($attacker->value < $attacker->max)) {
-                return TRUE;
+                if (($attacker->value < $defender->value) ||
+                    $game->fireOvershootingArray[$game->attackerPlayerIdx]) {
+                    return TRUE;
+                }
             }
 
             // skill attack with the need for fire assistance


### PR DESCRIPTION
Proposed fix for #1721.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1232/ (if it passes)
