### PR TITLE
In jenkins, run grunt scripts before processing build.xml

### DIFF
--- a/deploy/vagrant/modules/jenkins/templates/buttonmen_config.xml.erb
+++ b/deploy/vagrant/modules/jenkins/templates/buttonmen_config.xml.erb
@@ -27,13 +27,13 @@
   <triggers class="vector"/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
+    <hudson.tasks.Shell>
+      <command>sh ./util/grunt/jenkins-grunt.sh</command>
+    </hudson.tasks.Shell>
     <hudson.tasks.Ant>
       <targets></targets>
       <buildFile>deploy/jenkins/build.xml</buildFile>
     </hudson.tasks.Ant>
-    <hudson.tasks.Shell>
-      <command>sh ./util/grunt/jenkins-grunt.sh</command>
-    </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.plugins.checkstyle.CheckStylePublisher>


### PR DESCRIPTION
Technically, we don't config-manage config.xml for each individual jenkins project, so i manually made this change to `/srv/jenkins-jobs/buttonmen-cgolubi1/config.xml`, and then reran jenkins (not on this branch, but it doesn't matter) - http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/487/console - where you can see it ran jshint at the beginning instead of the end.

If this is approved, i'll deploy the template change in the usual way, and reconfigure the existing jobs.