### PR TITLE
Implement setChatVisibility API method

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -473,6 +473,21 @@ class ApiResponder {
     }
 
     /**
+     * Interface redirect for setChatVisibility
+     *
+     * @param BMInterface $interface
+     * @param array $args
+     * @return NULL|array
+     */
+    protected function get_interface_response_setChatVisibility($interface, $args) {
+        return $interface->game_chat()->set_chat_visibility(
+            $_SESSION['user_id'],
+            $args['game'],
+            'true' == $args['private']
+        );
+    }
+
+    /**
      * Interface redirect for submitDieValues
      *
      * @param BMInterface $interface

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -566,6 +566,12 @@ class ApiSpec {
                 'new_email' => 'email',
             ),
         ),
+        'setChatVisibility' => array(
+            'mandatory' => array(
+                'game' => 'number',
+                'private' => 'boolean',
+            ),
+        ),
         'submitDieValues' => array(
             'mandatory' => array(
                 'game' => 'number',

--- a/src/api/DummyApiResponder.php
+++ b/src/api/DummyApiResponder.php
@@ -246,6 +246,13 @@ class DummyApiResponder {
         );
     }
 
+    protected function get_interface_response_setChatVisibility($args) {
+        return $this->load_json_data_from_file(
+            'setChatVisibility',
+            $args['game'] . '.json'
+        );
+    }
+
     protected function get_interface_response_submitDieValues($args) {
         return $this->load_json_data_from_file(
             'submitDieValues',

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -154,6 +154,9 @@ class BMInterface {
                 $data['playerDataArray'][$gamePlayerIdx]['playerName'] = $playerName;
                 $isOnVacation = (bool) $game->playerArray[$gamePlayerIdx]->isOnVacation;
                 $data['playerDataArray'][$gamePlayerIdx]['isOnVacation'] = $isOnVacation;
+
+                $isChatPrivate = (bool) $game->playerArray[$gamePlayerIdx]->isChatPrivate;
+                $data['playerDataArray'][$gamePlayerIdx]['isChatPrivate'] = $isChatPrivate;
             }
 
             $actionLogArray = $this->game_action()->load_game_action_log($game, $logEntryLimit);

--- a/test/tools/api-client/python/lib/test_bmapi.py
+++ b/test/tools/api-client/python/lib/test_bmapi.py
@@ -142,7 +142,7 @@ class TestBMClient(unittest.TestCase):
 
     player_data_keys = [
       'activeDieArray', 'button', 'canStillWin', 'capturedDieArray',
-      'gameScoreArray', 'hasDismissedGame',
+      'gameScoreArray', 'hasDismissedGame', 'isChatPrivate',
       'isOnVacation', 'lastActionTime',
       'optRequestArray', 'outOfPlayDieArray',
       'playerColor', 'playerId', 'playerName',


### PR DESCRIPTION
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/491/ (if it passes)
* Partially addresses #464 

This pull builds on the backend chat privacy work i did last year in #2065 by implementing an API method, `setChatVisibility`, which can be used to turn chat privacy on and off.

This change does not yet make chat visibility usable by UI players, but it gives us the last API piece we need for that.  The next PR will be the UI piece to display chat privacy information in a friendly way, and to provide a way to call this new API method.