### PR TITLE
Make randomAI able to do replay testing now that we have isChatPrivate in the API response

### DIFF
--- a/tools/api-client/python/lib/random_ai.py
+++ b/tools/api-client/python/lib/random_ai.py
@@ -21,6 +21,7 @@ NUMERIC_KEYS = [
   'sideScore',
   'waitingOnAction',
   'isOnVacation',
+  'isChatPrivate',
 
   # keys within activeDieArray
   'sides',


### PR DESCRIPTION
Without this change, `replay_loop` blows up on `prep_replay_games`.  I should do replay-testing on my own pulls which change the API; that was my bad.
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/496/ (if it passes)