### PR TITLE
Added third-party creator to game page

### DIFF
--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -3598,6 +3598,7 @@ class BMGame {
             'validAttackTypeArray'       => $this->get_validAttackTypeArray(),
             'gameSkillsInfo'             => $this->get_gameSkillsInfo(),
             'playerDataArray'            => $this->get_playerDataArray($requestingPlayerIdx),
+            'creatorDataArray'           => array('creatorId' => $this->creatorId),
         );
         return $dataArray;
     }

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -199,6 +199,9 @@ class BMInterface {
             $data['playerDataArray'][0]['playerColor'] = $gameColors['playerA'];
             $data['playerDataArray'][1]['playerColor'] = $gameColors['playerB'];
 
+            $data['creatorDataArray']['creatorName'] =
+                $this->get_player_name_from_id($data['creatorDataArray']['creatorId']);
+
             return $data;
         }
         return NULL;

--- a/src/ui/js/Api.js
+++ b/src/ui/js/Api.js
@@ -514,6 +514,9 @@ var Api = (function () {
                          data.playerDataArray[my.game.opponentIdx],
                          my.game.opponentIdx);
 
+    my.game.creatorId = data.creatorDataArray.creatorId;
+    my.game.creatorName = data.creatorDataArray.creatorName;
+
     my.game.pendingGameCount = data.pendingGameCount;
 
     return true;

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -1748,6 +1748,14 @@ Game.pageAddGameHeader = function(action_desc) {
   } else {
     gameTitle += 'Round #' + Api.game.roundNumber;
   }
+
+  // add creator if the game has been created by a third party
+  if (('CHOOSE_JOIN_GAME' == Api.game.gameState) &&
+      (Api.game.creatorId != Api.game.player.playerId) &&
+      (Api.game.creatorId != Api.game.opponent.playerId)) {
+    gameTitle += Game.SPACE_BULLET + 'Created by ' + Api.game.creatorName;
+  }
+
   $('title').html(gameTitle + ' &mdash; Button Men Online');
 
   Game.page.append(

--- a/test/src/api/responderTest.php
+++ b/test/src/api/responderTest.php
@@ -618,6 +618,10 @@ class responderTest extends PHPUnit_Framework_TestCase {
                     'isChatPrivate' => false,
                 ),
             ),
+            'creatorDataArray' => array(
+                'creatorId' => $playerId1,
+                'creatorName' => $username1,
+            ),
             'gameActionLog' => array(
                 array('timestamp' => 'TIMESTAMP', 'player' => '', 'message' => 'Game created by ' . $username1),
             ),

--- a/test/tools/api-client/python/lib/test_bmapi.py
+++ b/test/tools/api-client/python/lib/test_bmapi.py
@@ -126,7 +126,7 @@ class TestBMClient(unittest.TestCase):
 
   def test_load_game_data(self):
     known_keys = [
-      'activePlayerIdx', 'currentPlayerIdx', 'description',
+      'activePlayerIdx', 'creatorDataArray', 'currentPlayerIdx', 'description',
       'dieBackgroundType', 'gameActionLog', 'gameActionLogCount',
       'gameChatEditable', 'gameChatLog', 'gameChatLogCount',
       'gameId', 'gameSkillsInfo',


### PR DESCRIPTION
Addresses part of #1784.

Currently, what I've done here is add the creator info to the response sent from the backend, then if the creator is not one of the two players in the game, I've shown the creator on the game screen. There's no change to the Overview screen yet.

If we want any changes to the Overview screen, I'd suggest that we do that in a separate pull request.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1357/ (if it passes)