### PR TITLE
Ignore frequent doorknob-rattling rejection that's making error log mail hard to scan

### DIFF
--- a/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
+++ b/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
@@ -9,4 +9,5 @@
   | grep -v "File does not exist: " \
   | grep -v " not found or unable to stat" \
   | grep -v " Graceful restart requested, doing restart" \
-  | grep -v " resuming normal operations"
+  | grep -v " resuming normal operations" \
+  | grep -v "client denied by server configuration: /var/www/database/"


### PR DESCRIPTION
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/503/ (if it passes)

Tested on virtualbox that i didn't break the file syntactically:
```bash
sandbox,[~],00:18(0)$ sudo /usr/local/sbin/monitor_apache_logs
[Sun Aug 20 00:16:36 2017] [notice] caught SIGTERM, shutting down
[Sun Aug 20 00:16:46 2017] [notice] caught SIGTERM, shutting down
sandbox,[~],00:18(0)$ sudo /usr/local/sbin/monitor_apache_logs
sandbox,[~],00:20(1)$ 
``