### PR TITLE
Pass the version cookie to Loader.js and use it when loading default BM modules

### DIFF
--- a/src/ui/active_players.html
+++ b/src/ui/active_players.html
@@ -30,7 +30,8 @@
           ],
           function() {
             Login.showLoginHeader(ActivePlayers);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/buttons.html
+++ b/src/ui/buttons.html
@@ -31,7 +31,8 @@
           ],
           function() {
             Login.showLoginHeader(Buttons);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/create_game.html
+++ b/src/ui/create_game.html
@@ -31,7 +31,8 @@
           ],
           function() {
             Login.showLoginHeader(Newgame);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/create_user.html
+++ b/src/ui/create_user.html
@@ -31,7 +31,8 @@
           ],
           function() {
             Login.showLoginHeader(Newuser);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/forum.html
+++ b/src/ui/forum.html
@@ -32,7 +32,8 @@
           ],
           function() {
             Login.showLoginHeader(Forum);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/game.html
+++ b/src/ui/game.html
@@ -30,7 +30,8 @@
           ],
           function() {
             Login.showLoginHeader(Game);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/history.html
+++ b/src/ui/history.html
@@ -32,7 +32,8 @@
           ],
           function() {
             Login.showLoginHeader(History);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -30,7 +30,8 @@
           ],
           function() {
             Login.showLoginHeader(Overview);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/js/Loader.js
+++ b/src/ui/js/Loader.js
@@ -5,19 +5,33 @@ var Loader = {};
 Loader.defaultScripts = [
   'js/extern/jquery.cookie.js',
   'js/extern/moment.js',
-  'js/Api.js',
-  'js/Config.js',
-  'js/Env.js',
-  'js/Login.js',
 ];
 
-Loader.loadScripts = function(scripts, callback) {
+// These BM modules are loaded by every page, and we autoversion them
+// to avoid caching problems after deployments
+Loader.defaultBMModules = [
+  'Api',
+  'Config',
+  'Env',
+  'Login',
+];
+
+Loader.loadScripts = function(scripts, callback, version) {
   // The function to be called when all the scripts have been loaded.
   Loader.callback = callback;
 
   // Tracks which scripts are still loading and which have finished
   Loader.loadStatus = { };
   $.each(Loader.defaultScripts, function(index, script) {
+    Loader.loadStatus[script] = false;
+  });
+  $.each(Loader.defaultBMModules, function(index, module) {
+    var script;
+    if (version) {
+      script = 'js/' + module + '.' + version + '.js';
+    } else {
+      script = 'js/' + module + '.js';
+    }
     Loader.loadStatus[script] = false;
   });
   $.each(scripts, function(index, script) {

--- a/src/ui/open_games.html
+++ b/src/ui/open_games.html
@@ -25,9 +25,13 @@
         dataType: 'script',
         cache: true,
         success: function() {
-          Loader.loadScripts([ 'js/OpenGames.VERSION_COOKIE.js' ], function() {
+          Loader.loadScripts([
+           'js/OpenGames.VERSION_COOKIE.js'
+          ],
+          function() {
             Login.showLoginHeader(OpenGames);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/prefs.html
+++ b/src/ui/prefs.html
@@ -32,7 +32,8 @@
           ],
           function() {
             Login.showLoginHeader(UserPrefs);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/profile.html
+++ b/src/ui/profile.html
@@ -30,7 +30,8 @@
           ],
           function() {
             Login.showLoginHeader(Profile);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/src/ui/verify.html
+++ b/src/ui/verify.html
@@ -31,7 +31,8 @@
           ],
           function() {
             Login.showLoginHeader(Verify);
-          });
+          },
+          'VERSION_COOKIE');
         }
       });
     });

--- a/test/src/ui/js/test_Loader.js
+++ b/test/src/ui/js/test_Loader.js
@@ -3,6 +3,7 @@ module("Loader", {
     // The usual default scripts would already have loaded with the testing
     // harness, so we'll load a special dummy one instead
     Loader.defaultScripts = [ 'js/dummy1.js', ];
+    Loader.defaultBMModules = [ ];
 
     BMTestUtils.LoaderPre = BMTestUtils.getAllElements();
   },


### PR DESCRIPTION
* Fixes #2260
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/514/

I didn't do significant testing that this fixes the particular problem, because that's hard to setup.  But i tested that the pages still seem to load, which is the important part.  Given that it doesn't break page loads, it *should* fix the problem (given that the version cookie business helped for other JS files), and the implementation is such that it shouldn't have any impact on your plan for keeping things working on your windows stack - the sed stuff didn't change at all, so your existing set of symlinks should still be just fine.