### PR TITLE
Fix bug in (hackish) handling of trip turbo range in RandomAI

### DIFF
--- a/tools/api-client/python/lib/random_ai.py
+++ b/tools/api-client/python/lib/random_ai.py
@@ -858,6 +858,8 @@ class LoggingBMClient():
         if not swing_size in SWING_RANGES:
           raise ValueError("Could not figure out turbo trip die: %s" % die)
         post_trip_sides = SWING_RANGES[swing_size][-1]
+        if ',' in die['recipe']:
+          post_trip_sides *= 2
     return post_trip_sides
 
   def _min_trip_value(self, die):


### PR DESCRIPTION
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/515/ (if it passes)

I went to check in on my long-running replay site and found it had stopped its loop due to this bug, which it encountered in CestWest vs Wyoming.  The problem was immediately reproducible.  With this fix, it successfully played over 20 CestWest vs Wyoming games without blocking.