### PR TITLE
creatorDataArray is a key that will not change during replay

### DIFF
--- a/tools/api-client/python/lib/random_ai.py
+++ b/tools/api-client/python/lib/random_ai.py
@@ -37,6 +37,7 @@ STRING_KEYS = [
 ]
 
 UNUSED_DURING_AUTOPLAY_KEYS = [
+  'creatorDataArray',
   'gameChatEditable',
   'gameChatLog',
   'gameId',


### PR DESCRIPTION
* Jenkins: http://jenkins.buttonweavers.com:8080/job/buttonmen-cgolubi1/516/ (if it passes)

Shadowshade: sorry for the inconvenience.  It would be fair to ask how i can possibly accept so many pulls that break replay testing without noticing.  I think i'm just not good at remembering that API changes that obviously aren't game logic regressions, nevertheless impact replay testing.  Anyway, this is all in service of getting to the point where i can do replay testing for things in the queue that actually might impact game logic, so help me keep churning through these, and thanks in advance.