### PR TITLE
Fixed bug with fire decline turndown and turbo

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1320,7 +1320,10 @@ class BMInterfaceGame extends BMInterface {
                         $argArray['fireValueArray'][$dieIdx] = $dieValueArray[$tempIdx];
                     }
                     break;
-                case 'no_turndown':  // fallthrough to allow multiple cases with the same logic
+                case 'no_turndown':
+                    $argArray['dieIdxArray'] = $dieIdxArray;
+                    $argArray['dieValueArray'] = $dieValueArray;
+                    break;
                 case 'cancel':
                     $argArray['dieIdxArray'] = $dieIdxArray;
                     $argArray['dieValueArray'] = $dieValueArray;
@@ -1356,7 +1359,6 @@ class BMInterfaceGame extends BMInterface {
                 'Caught exception in BMInterface::adjust_fire: ' .
                 $e->getMessage()
             );
-            var_dump($e->getMessage());
             $this->set_message('Internal error while adjusting fire dice');
             return FALSE;
         }


### PR DESCRIPTION
Fixes #2258.

There's no easy fix to the database to get these games running again with the correct logging.

I propose that we set the status of these games to BROKEN (status = 5), which will hide them from the Overview screen.

If that is considered to be too drastic, we could set the game_state in the 'game' table manually back to 40 (START_TURN), and toggle the is_awaiting_action values in the 'game_player_map' table for both players. That will get the games going, but the logging will be incorrect for the one broken attack.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1378/