### PR TITLE
Added forum markup to link to other forum threads

### DIFF
--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -855,6 +855,11 @@ div.forum div.splitRight {
     width: 40%;
 }
 
+div.forum div.splitRight span.postTag {
+  color: #e0e0e0;
+  margin-right: 2em;
+}
+
 /* END: Forum*/
 
 /* BB Code (OK technically also forum but chat too) */

--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -826,6 +826,8 @@ Forum.buildPostRow = function(post) {
     'text': postDates,
   }));
   var buttonHolder = $('<div>', { 'class': 'splitRight', });
+  var postTag = '[forum=' + Api.forum_thread.threadId + ',' + post.postId + ']';
+  buttonHolder.append($('<span>', { 'class': 'postTag', 'text': postTag, }));
   if (post.posterName == Login.player && !post.deleted) {
     var editButton = $('<input>', {
       'type': 'button',
@@ -913,6 +915,12 @@ Forum.buildHelp = function() {
   helpDiv.append($('<div>', {
     'class': 'help',
     'html': '[set=Soldiers]: <a href="buttons.html?set=Soldiers">Soldiers</a>',
+  }));
+  helpDiv.append($('<div>', {
+    'class': 'help',
+    'html': '[forum=1,6]text[/forum]: ' +
+            '<a href="forum.html#!threadId=1&postId=6">' +
+            'Forum thread: text</a>',
   }));
   helpDiv.append($('<div>', {
     'class': 'help',


### PR DESCRIPTION
Fixes #1905.

The current solution only allows linking to forum threads, not posts. To allow links to posts, the simplest way would be to not escape the parameter, but I'm uncertain whether we should be allowing unescaped parameters here.

Edit: the new solution allows linking to forum posts too.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1395/ (if it passes)