### PR TITLE
Added functionality for Gordo and Guillermo

### DIFF
--- a/src/engine/BMBtnSkillGordo.php
+++ b/src/engine/BMBtnSkillGordo.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * BMBtnSkillGordo: Code specific to Gordo
+ *
+ * @author: james
+ */
+
+/**
+ * This class currently supports the special skills of Gordo
+ */
+class BMBtnSkillGordo extends BMBtnSkillUniqueSwing {
+    /**
+     * An array containing the names of functions run by
+     * BMCanHaveSkill->run_hooks()
+     *
+     * @var array
+     */
+    public static $hooked_methods = array(
+        'are_unique_swing_values_valid',
+        'can_button_add_this_aux_die',
+        'unique_swing_setting_fail_message'
+    );
+
+    /**
+     * Hooked method applied when checking if a button has unique swing
+     *
+     * @param array $args
+     * @return array
+     */
+    public static function are_unique_swing_values_valid(array $args) {
+        $parent_result = parent::are_unique_swing_values_valid($args);
+
+        if (!$parent_result[__FUNCTION__]) {
+            return array(__FUNCTION__ => FALSE);
+        }
+
+        foreach ($args['activeDieArray'] as $die) {
+            if (!($die instanceof BMDieSwing)) {
+                if (in_array($die->max, $args['swingValueArray'])) {
+                    return array(__FUNCTION__ => FALSE);
+                }
+            }
+        }
+
+        return array(__FUNCTION__ => TRUE);
+    }
+
+    /**
+     * Hooked method applied when checking if a button restricts decisions on
+     * auxiliary dice
+     *
+     * @param array $args
+     * @return array
+     */
+    public static function can_button_add_this_aux_die($args) {
+        return array(__FUNCTION__ =>
+            (!($args['die'] instanceof BMDieSwing)) ||
+             !in_array($args['die']->swingType, array('V', 'W', 'X', 'Y', 'Z'))
+        );
+    }
+
+    /**
+     * Hooked method applied when swing setting has failed because die sizes
+     * would end up not unique
+     *
+     * @param array $args
+     * @return array
+     */
+    public static function unique_swing_setting_fail_message() {
+        return array(__FUNCTION__ => 'Cannot have multiple dice with the same size');
+    }
+
+    /**
+     * Description of skill
+     *
+     * @return string
+     */
+    public static function get_description() {
+        return 'None of Gordo\'s dice can be the same size. ' .
+               'Note that a player playing Gordo is required to decline an auxiliary die ' .
+               'that would force two of Gordo\'s dice to be the same size';
+    }
+}

--- a/src/engine/BMBtnSkillGuillermo.php
+++ b/src/engine/BMBtnSkillGuillermo.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * BMBtnSkillGuillermo: Code specific to Guillermo
+ *
+ * @author: james
+ */
+
+/**
+ * This class currently supports the special skills of Guillermo
+ */
+class BMBtnSkillGuillermo extends BMBtnSkillUniqueSwing {
+
+}

--- a/src/engine/BMBtnSkillUniqueSwing.php
+++ b/src/engine/BMBtnSkillUniqueSwing.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * BMBtnSkillUniqueSwing: Code to ensure that chosen swing values are all distinct
+ *
+ * @author: james
+ */
+
+/**
+ * This class is intended to be a base class for any button special requiring
+ * unique swing values to be selected, like BMBtnSkillGordo and BMBtnSkillGuillermo
+ */
+class BMBtnSkillUniqueSwing extends BMBtnSkill {
+    /**
+     * An array containing the names of functions run by
+     * BMCanHaveSkill->run_hooks()
+     *
+     * @var array
+     */
+    public static $hooked_methods = array('are_unique_swing_values_valid');
+
+    /**
+     * Hooked method applied when checking if a button has unique swing
+     *
+     * @param array $args
+     * @return array
+     */
+    public static function are_unique_swing_values_valid(array $args) {
+        return array(__FUNCTION__ =>
+            count(array_unique($args['swingValueArray'])) == count($args['swingValueArray'])
+        );
+    }
+
+    /**
+     * Description of skill
+     *
+     * @return string
+     */
+    public static function get_description() {
+        return 'Different swing types must be assigned unique values';
+    }
+}

--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1010,7 +1010,14 @@ class BMInterfaceGame extends BMInterface {
                         $this->set_message('Invalid auxiliary choice');
                         return FALSE;
                     }
+
                     $die = $player->activeDieArray[$dieIdx];
+
+                    if (!self::can_button_add_this_aux_die($player->button, $die)) {
+                        $this->set_message('This button cannot add this auxiliary die');
+                        return FALSE;
+                    }
+
                     $die->add_flag('AddAuxiliary');
                     $player->waitingOnAction = FALSE;
                     $game->log_action(
@@ -1046,6 +1053,23 @@ class BMInterfaceGame extends BMInterface {
             $this->set_message('Internal error while making auxiliary decision');
             return FALSE;
         }
+    }
+
+    /**
+     * Can this button add this auxiliary die?
+     *
+     * @param BMButton $button
+     * @param BMDie $die
+     * @return bool
+     */
+    protected static function can_button_add_this_aux_die(BMButton $button, BMDie $die) {
+        $hookResult = $button->run_hooks(
+            __FUNCTION__,
+            array('die' => $die)
+        );
+
+        return (!isset($hookResult['BMBtnSkill'.$button->name][__FUNCTION__]) ||
+                $hookResult['BMBtnSkill'.$button->name][__FUNCTION__]);
     }
 
     /**

--- a/test/src/engine/BMBtnSkillGiantTest.php
+++ b/test/src/engine/BMBtnSkillGiantTest.php
@@ -27,7 +27,7 @@ class BMBtnSkillGiantTest extends PHPUnit_Framework_TestCase {
      * @covers BMBtnSkillGiant::is_button_slow
      */
     public function testIs_button_slow() {
-        $retVal = BMBtnSkillGiant::is_button_slow(array('name' => 'Giant'));
+        $retVal = BMBtnSkillGiant::is_button_slow(array());
         $this->assertTrue($retVal['is_button_slow']);
     }
 }

--- a/test/src/engine/BMBtnSkillGordoTest.php
+++ b/test/src/engine/BMBtnSkillGordoTest.php
@@ -1,0 +1,111 @@
+<?php
+
+class BMBtnSkillGordoTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * @covers BMBtnSkillGordo::are_unique_swing_values_valid
+     */
+    public function testAre_unique_swing_values_valid() {
+        $die1 = BMDieSwing::create('V');
+        $die2 = BMDieSwing::create('W');
+        $die3 = BMDieSwing::create('X');
+        $die4 = BMDieSwing::create('Y');
+        $die5 = BMDieSwing::create('Z');
+
+        $die6 = BMDie::create(18);
+
+        // test with swing dice only and repeated swing values
+        $retVal = BMBtnSkillGordo::are_unique_swing_values_valid(array(
+            'activeDieArray' => array($die1, $die2, $die3, $die4, $die5),
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 4,
+                'Y' => 1,
+                'Z' => 4
+            )
+        ));
+        $this->assertFalse($retVal['are_unique_swing_values_valid']);
+
+        // test with swing dice only and no repeated swing values
+        $retVal = BMBtnSkillGordo::are_unique_swing_values_valid(array(
+            'activeDieArray' => array($die1, $die2, $die3, $die4, $die5),
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 5,
+                'Y' => 1,
+                'Z' => 18
+            )
+        ));
+        $this->assertTrue($retVal['are_unique_swing_values_valid']);
+
+        // test with swing dice and an 18-sider and repeated swing values
+        $retVal = BMBtnSkillGordo::are_unique_swing_values_valid(array(
+            'activeDieArray' => array($die1, $die2, $die3, $die4, $die5, $die6),
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 4,
+                'Y' => 1,
+                'Z' => 4
+            )
+        ));
+        $this->assertFalse($retVal['are_unique_swing_values_valid']);
+
+        // test with swing dice and an 18-sider and a swing value that is 18
+        $retVal = BMBtnSkillGordo::are_unique_swing_values_valid(array(
+            'activeDieArray' => array($die1, $die2, $die3, $die4, $die5, $die6),
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 5,
+                'Y' => 1,
+                'Z' => 18
+            )
+        ));
+        $this->assertFalse($retVal['are_unique_swing_values_valid']);
+
+        // test with swing dice and an 18-sider and no repeated swing values
+        $retVal = BMBtnSkillGordo::are_unique_swing_values_valid(array(
+            'activeDieArray' => array($die1, $die2, $die3, $die4, $die5, $die6),
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 5,
+                'Y' => 1,
+                'Z' => 7
+            )
+        ));
+        $this->assertTrue($retVal['are_unique_swing_values_valid']);
+    }
+
+    /**
+     * @covers BMBtnSkillGordo::can_button_add_this_aux_die
+     */
+    public function testCan_button_add_this_aux_die() {
+        $die1 = BMDie::create(6);
+        $die2 = BMDieSwing::create('X');
+        $die3 = BMDieSwing::create('R');
+
+        $retVal = BMBtnSkillGordo::can_button_add_this_aux_die(array('die' => $die1));
+        $this->assertTrue($retVal['can_button_add_this_aux_die']);
+
+        $retVal = BMBtnSkillGordo::can_button_add_this_aux_die(array('die' => $die2));
+        $this->assertFalse($retVal['can_button_add_this_aux_die']);
+
+        $retVal = BMBtnSkillGordo::can_button_add_this_aux_die(array('die' => $die3));
+        $this->assertTrue($retVal['can_button_add_this_aux_die']);
+    }
+
+    /**
+     * @covers BMBtnSkillGordo::unique_swing_setting_fail_message
+     */
+    public function testUnique_swing_setting_fail_message() {
+        $retVal = BMBtnSkillGordo::unique_swing_setting_fail_message(array());
+        $this->assertEquals(
+            'Cannot have multiple dice with the same size',
+            $retVal['unique_swing_setting_fail_message']
+        );
+    }
+}

--- a/test/src/engine/BMBtnSkillGuillermoTest.php
+++ b/test/src/engine/BMBtnSkillGuillermoTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class BMBtnSkillGuillermoTest extends PHPUnit_Framework_TestCase {
+
+    // this is to satisfy the PHPUnit audit
+    public function testDummy()
+    {
+    }
+}

--- a/test/src/engine/BMBtnSkillUniqueSwingTest.php
+++ b/test/src/engine/BMBtnSkillUniqueSwingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+class BMBtnSkillUniqueSwingTest extends PHPUnit_Framework_TestCase {
+    /**
+     * @var BMBtnSkillUniqueSwing
+     */
+    protected $object;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new BMBtnSkillUniqueSwing;
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers BMBtnSkillUniqueSwing::are_unique_swing_values_valid
+     */
+    public function testAre_unique_swing_values_valid() {
+        $retVal = BMBtnSkillUniqueSwing::are_unique_swing_values_valid(array(
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 4,
+                'Y' => 1,
+                'Z' => 4
+            )
+        ));
+        $this->assertFalse($retVal['are_unique_swing_values_valid']);
+
+        $retVal = BMBtnSkillUniqueSwing::are_unique_swing_values_valid(array(
+            'swingValueArray' => array(
+                'V' => 6,
+                'W' => 4,
+                'X' => 5,
+                'Y' => 1,
+                'Z' => 7
+            )
+        ));
+        $this->assertTrue($retVal['are_unique_swing_values_valid']);
+    }
+}

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -667,8 +667,10 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $button2->load($recipe2);
         $player1 = $this->object->playerArray[0];
         $player1->activeDieArray = $button1->dieArray;
+        $player1->button = $button1;
         $player2 = $this->object->playerArray[1];
         $player2->activeDieArray = $button2->dieArray;
+        $player2->button = $button2;
         $this->object->do_next_step();
         $this->assertFalse($this->object->playerArray[0]->waitingOnAction);
         $this->assertFalse($this->object->playerArray[1]->waitingOnAction);


### PR DESCRIPTION
Fixes #265.

This pull request enables Gordo and Guillermo. It enforces the uniqueness of all die sizes for Gordo, and just swing values for Guillermo. It also stops players from accepting an aux die for Gordo that is a swing die with a type already in Gordo's recipe.

I've tested this with Gordo vs Guillermo, Gordo vs King Arthur, and Gordo vs Lancelot.

In addition, I've removed an unused argument in Giant's button special, which I noticed when I was using it as a template for these button specials.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1398/ (if it passes)