### PR TITLE
Changes to allow History page to show new games

### DIFF
--- a/deploy/database/data.game.sql
+++ b/deploy/database/data.game.sql
@@ -22,7 +22,8 @@ INSERT INTO game_status (name) VALUES
 ('ACTIVE'),
 ('COMPLETE'),
 ('CANCELLED'),
-('BROKEN');
+('BROKEN'),
+('NEW');
 
 DELETE FROM die_status;
 INSERT INTO die_status (name) VALUES

--- a/deploy/database/updates/01839_new_in_progress_history_01.sql
+++ b/deploy/database/updates/01839_new_in_progress_history_01.sql
@@ -1,0 +1,5 @@
+INSERT INTO game_status (name) VALUES ('NEW');
+
+UPDATE game
+SET status_id = (SELECT id FROM game_status WHERE name = 'NEW')
+WHERE game_state = 13;

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -267,7 +267,7 @@ class ApiSpec {
                 ),
                 'status' => array(
                     'arg_type' => 'exactString',
-                    'values' => array('ACTIVE', 'COMPLETE', 'CANCELLED'),
+                    'values' => array('ACTIVE', 'UNSTARTED', 'COMPLETE', 'CANCELLED'),
                 ),
             ),
         ),

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -299,8 +299,8 @@ class BMInterface {
                    'LEFT JOIN game AS g ON g.id = gpm.game_id '.
                 'WHERE gpm.player_id = :player_id '.
                    'AND gpm.is_awaiting_action = 1 '.
-                   'AND g.status_id = '.
-                       '(SELECT id FROM game_status WHERE name = \'ACTIVE\') ';
+                   'AND g.status_id IN '.
+                       '(SELECT id FROM game_status WHERE name IN (\'NEW\', \'ACTIVE\'))';
 
             $statement = self::$conn->prepare($query);
             $statement->execute($parameters);
@@ -1073,6 +1073,8 @@ class BMInterface {
         } elseif (in_array(NULL, $game->playerIdArray) ||
                   in_array(NULL, $game->buttonArray)) {
             $status = 'OPEN';
+        } elseif (BMGameState::CHOOSE_JOIN_GAME == $game->gameState) {
+            $status = 'NEW';
         } else {
             $status = 'ACTIVE';
         }
@@ -1583,9 +1585,9 @@ class BMInterface {
                      'WHERE v2.player_id = :player_id '.
                      'AND v1.player_id != v2.player_id ';
             if ('ACTIVE' == $type) {
-                $query .= 'AND s.name = "ACTIVE" AND g.game_state > 13 ';
+                $query .= 'AND s.name = "ACTIVE"';
             } elseif ('NEW' == $type) {
-                $query .= 'AND s.name = "ACTIVE" AND g.game_state <= 13 ';
+                $query .= 'AND s.name = "NEW"';
             } elseif ('COMPLETE' == $type) {
                 $query .= 'AND s.name = "COMPLETE" AND v2.was_game_dismissed = 0 ';
             } elseif ('CANCELLED' == $type) {
@@ -1832,8 +1834,8 @@ class BMInterface {
                         'LEFT JOIN game AS g ON g.id = gpm.game_id '.
                      'WHERE gpm.player_id = :player_id '.
                         'AND gpm.is_awaiting_action = 1 '.
-                        'AND g.status_id = '.
-                           '(SELECT id FROM game_status WHERE name = \'ACTIVE\') ';
+                        'AND g.status_id IN '.
+                           '(SELECT id FROM game_status WHERE name IN (\'NEW\', \'ACTIVE\'))';
             foreach ($skippedGames as $index => $skippedGameId) {
                 $parameterName = ':skipped_game_id_' . $index;
                 $query = $query . 'AND gpm.game_id <> ' . $parameterName . ' ';

--- a/src/engine/BMInterfaceHistory.php
+++ b/src/engine/BMInterfaceHistory.php
@@ -377,13 +377,14 @@ class BMInterfaceHistory extends BMInterface {
         }
 
         if (isset($searchFilters['status'])) {
-            $where .= 'AND s.name = :status_%%% ';
-            $whereParameters[':status_%%%'] = $searchFilters['status'];
-        } else {
-            // We'll only display games that have actually started
-            $where .= 'AND (s.name = "COMPLETE" ' .
-                      'OR s.name = "ACTIVE" ' .
-                      'OR s.name = "CANCELLED") ';
+            if ($searchFilters['status'] == 'UNSTARTED') {
+                $where .= 'AND ((s.name = :status1_%%%) OR (s.name = :status2_%%%)) ';
+                $whereParameters[':status1_%%%'] = 'NEW';
+                $whereParameters[':status2_%%%'] = 'OPEN';
+            } else {
+                $where .= 'AND s.name = :status_%%% ';
+                $whereParameters[':status_%%%'] = $searchFilters['status'];
+            }
         }
     }
 

--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -487,6 +487,10 @@ Env.escapeRegexp = function(str) {
 
 // Utility function to link to a profile page given a player name
 Env.buildProfileLink = function(playerName, textOnly) {
+  if ((typeof(playerName) === 'undefined') || (playerName === null)) {
+    return '–';
+  }
+
   var url = 'profile.html?player=' + encodeURIComponent(playerName);
   if (textOnly) {
     return url;

--- a/src/ui/js/History.js
+++ b/src/ui/js/History.js
@@ -75,6 +75,7 @@ History.searchParameterInfo = {
     'source': {
       'COMPLETE': 'Completed',
       'ACTIVE': 'In Progress',
+      'UNSTARTED': 'Unstarted',
       'CANCELLED': 'Cancelled',
     },
     'dataType': 'string',
@@ -655,6 +656,11 @@ History.buildResultsTableBody = function() {
         'text': 'Cancelled',
         'style': 'color: #aaaaaa;'
       }));
+    } else if ((game.status == 'NEW') || (game.status == 'OPEN')) {
+      gameRow.append($('<td>', {
+        'text': 'Unstarted',
+        'style': 'color: #aaaaaa;'
+      }));
     } else {
       gameRow.append($('<td>', {
         'text': 'In Progress',
@@ -668,7 +674,9 @@ History.buildResultsTableBody = function() {
 
 History.scoreCol = function(game) {
   var score;
-  if (game.status == 'CANCELLED') {
+  if ((game.status == 'CANCELLED') ||
+      (game.status == 'NEW') ||
+      (game.status == 'OPEN')) {
     score = '–/–/–';
   } else {
     score = game.roundsWonA + '/' + game.roundsWonB + '/' + game.roundsDrawn;


### PR DESCRIPTION
Fixes #1839. Fixes #1840.

I've tested this with OPEN games (i.e., ones where the opponent is not specified), NEW games (i.e., not yet accepted by opponent), ACTIVE games, COMPLETED games, and CANCELLED games. They all show correctly, and filtering by type also seems to work.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1411/