### PR TITLE
Strip excess zeros when looking for potential skill attacks

### DIFF
--- a/src/engine/BMAttackSkill.php
+++ b/src/engine/BMAttackSkill.php
@@ -74,10 +74,29 @@ class BMAttackSkill extends BMAttack {
                 }
                 $validDice[] = $die;
             }
-
         }
 
+        self::strip_excess_zeros($validDice);
+
         $this->hitTable = new BMUtilityHitTable($validDice);
+    }
+
+    protected static function strip_excess_zeros(&$dieArray) {
+        $zeroCount = 0;
+        $zeroIdxArray = array();
+
+        foreach ($dieArray as $dieIdx => $die) {
+            if (0 === $die->value) {
+                $zeroCount++;
+                $zeroIdxArray[] = $dieIdx;
+            }
+        }
+
+        while ($zeroCount > 2) {
+            $zeroCount--;
+            array_splice($dieArray, $zeroIdxArray[$zeroCount], 1);
+            unset($zeroIdxArray[$zeroCount]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #2304.

I've tested this with wtrollkin vs eon, replicated the situation, and then used a t(1) to trip a s%(S=20)! die 40 times in a row, which generated 40 t(0) dice. With the fix, the site did not lose responsiveness.

Naturally, this doesn't address the issue of whether it's too silly to be actually generating 40 t(0) dice, but that's something for further discussion elsewhere.

http://jenkins.buttonweavers.com:8080/job/buttonmen-blackshadowshade/1441/