### PR TITLE
Added logic to migrate up to PHP 7

### DIFF
--- a/deploy/database/schema.player.sql
+++ b/deploy/database/schema.player.sql
@@ -6,7 +6,7 @@ CREATE TABLE player_status (
 CREATE TABLE player (
     id                  SMALLINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name_ingame         VARCHAR(25) UNIQUE NOT NULL,
-    password_hashed     VARCHAR(128),
+    password_hashed     VARCHAR(255),
     name_irl            VARCHAR(40) NOT NULL,
     email               VARCHAR(254),
     is_email_public     BOOLEAN DEFAULT 0 NOT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE player (
 CREATE TABLE player_auth (
     id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     player_id  SMALLINT UNSIGNED,
-    auth_key   VARCHAR(253) UNIQUE NOT NULL,
+    auth_key   VARCHAR(255) UNIQUE NOT NULL,
     login_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/deploy/database/updates/01167_php7_01.sql
+++ b/deploy/database/updates/01167_php7_01.sql
@@ -1,0 +1,2 @@
+ALTER TABLE player MODIFY password_hashed VARCHAR(255);
+ALTER TABLE player_auth MODIFY auth_key VARCHAR(255) UNIQUE NOT NULL;

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -947,7 +947,7 @@ class ApiResponder {
                 // object, invoke the function, and return the result
                 $interface = $this->create_interface($args, $check);
                 apache_note('BMAPIMethod', $args['type']);
-                $data = $this->$check['funcname']($interface, $args);
+                $data = $this->{$check['funcname']}($interface, $args);
 
                 $output = array(
                     'data' => $data,

--- a/src/engine/BMInterfaceNewuser.php
+++ b/src/engine/BMInterfaceNewuser.php
@@ -107,11 +107,9 @@ class BMInterfaceNewuser {
             $statement = self::$conn->prepare($query);
             $statement->execute(array(':username' => $username));
             $fetchResult = $statement->fetchAll();
-
             if (count($fetchResult) > 0) {
                 $user_id = $fetchResult[0]['id'];
-                $this->message = $username . ' already exists (id=' .
-                                 $user_id . ')';
+                $this->message = $username . ' already exists (id=' . $user_id . ')';
                 return NULL;
             }
 
@@ -123,8 +121,7 @@ class BMInterfaceNewuser {
 
             if (count($fetchResult) > 0) {
                 $user_id = $fetchResult[0]['id'];
-                $this->message = 'Email address ' . $email .
-                                 ' already exists (id=' .  $user_id . ')';
+                $this->message = 'Email address ' . $email . ' already exists (id=' .  $user_id . ')';
                 return NULL;
             }
 
@@ -138,8 +135,16 @@ class BMInterfaceNewuser {
                     '(SELECT ps.id FROM player_status ps WHERE ps.name = :status)' .
                 ');';
             $statement = self::$conn->prepare($query);
+
+            // support versions of PHP older than 5.5.0
+            if (version_compare(phpversion(), "5.5.0", "<")) {
+                $passwordHash = crypt($password);
+            } else {
+                $passwordHash = password_hash($password, PASSWORD_DEFAULT);
+            }
+
             $statement->execute(array(':username' => $username,
-                                      ':password' => crypt($password),
+                                      ':password' => $passwordHash,
                                       ':email' => $email,
                                       ':status' => 'UNVERIFIED'));
 
@@ -159,7 +164,6 @@ class BMInterfaceNewuser {
 
             // now generate a verification code and e-mail it to the user
             $this->send_email_verification($playerId, $username, $playerEmail);
-
             $this->message = 'User ' . $username . ' created successfully.  ' .
                              'A verification code has been e-mailed to ' . $playerEmail . '.  ' .
                              'Follow the link in that message to start beating people up! ' .


### PR DESCRIPTION
Addresses the codebase part of #1167. Fixes #884.

The changes here fall into two categories:

1. Indirect expressions are handled differently in PHP 7.

See http://php.net/manual/en/migration70.incompatible.php for details.

2. New functions for password hashing and verification were added in PHP 5.5, and the use of a manual salt was deprecated in PHP 7.0.

See http://php.net/manual/en/function.password-hash.php for details.

I've added code here to convert short hashes (length 34) to long hashes (length 60) on successful login. I've also added a database update to increase the hash field sizes to 255, on the basis of advice from the PHP doc page for password_hash.

I've tested the following with my MAMP stack under PHP 7.1.13: logging in, logging out, creating a new user, and validating a new user. Game loading and play looks unchanged.