### PR TITLE
Don't verify SSL cert when downloading phpunit

### DIFF
--- a/deploy/vagrant/modules/php/manifests/init.pp
+++ b/deploy/vagrant/modules/php/manifests/init.pp
@@ -24,7 +24,7 @@ class php::base {
 class php::base::feature::phpunit {
   exec {
     "php_wget_phpunit":
-      command => "/usr/bin/wget --no-verbose -O /etc/php5/deploy-includes/phpunit.phar https://phar.phpunit.de/phpunit-old.phar",
+      command => "/usr/bin/wget --no-verbose --no-check-certificate -O /etc/php5/deploy-includes/phpunit.phar https://phar.phpunit.de/phpunit-old.phar",
       creates => "/etc/php5/deploy-includes/phpunit.phar",
       require => File["/etc/php5/deploy-includes"];
   }


### PR DESCRIPTION
* Fixes #2362 
* Testing: applied the change when standing up a replay site and verified that puppet succeeded.