### PR TITLE
Add a CircleCI step which tries to verify that the dummy API files have landed before running QUnit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
           name: Install dummy API files created by PHPUnit into test webserver
           command: sudo rsync -av src/api/dummy_data/ /var/www/api/dummy_data/
       - run:
+          name: Verify dummy API files were fully installed
+          command: bash ./deploy/circleci/verify_dummy_responder_files.sh src/api/dummy_data/ /var/www/api/dummy_data/
+      - run:
           name: Run QUnit tests
           command: /usr/bin/phantomjs --web-security=false /usr/local/etc/run-jscover-qunit.js http://localhost/test-ui/phantom-index.html
       - run:

--- a/deploy/circleci/verify_dummy_responder_files.sh
+++ b/deploy/circleci/verify_dummy_responder_files.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+##### Verify dummy responder files are available for QUnit testing
+
+# This script attempts to workaround some hypothesized virtual disk
+# caching used within CircleCI, and make sure the dummy data files
+# produced by phpunit testing are available on disk before they
+# need to be used by QUnit testing.
+#
+# The assumption is that if this script, which is being run in a
+# separate process from the rsync that wrote the files, can see the
+# files and see that they have nonzero size, then it is safe to proceed
+
+# echo what the script does
+set -x
+
+# target directory
+SOURCEDIR=$1
+TARGETDIR=$2
+
+srccount=$(find ${SOURCEDIR} | wc -l | awk '{print $1}')
+srcsize=$(du -sm ${SOURCEDIR} | awk '{print $1}')
+
+for retry in 1 2 3 4 5 6 7 8 9 10; do
+  if [ -d "${TARGETDIR}" ]; then
+    tgtcount=$(find ${TARGETDIR} | wc -l | awk '{print $1}')
+    if [ "${srccount}" = "${tgtcount}" ]; then
+      tgtsize=$(du -sm ${TARGETDIR} | awk '{print $1}')
+      if [ "${srcsize}" = "${tgtsize}" ]; then
+        exit 0
+      fi
+    fi
+  fi
+  sleep 5
+done
+
+echo "Could not verify existence of files in ${TARGETDIR} after 10 attempts"
+exit 1


### PR DESCRIPTION
* Partially addresses #2342 
* I can't prove this works or that i've diagnosed the problem correctly --- my test CircleCI run passed on the first try, and we know we're getting spurious QUnit failures pretty often in CircleCI (i'd say at least 1/5 of the time?), so if we merge this and don't see more spurious failures, or if we merge this and ever see it need to sleep once before continuing, we should feel very confident in it.  And if we merge this and do see another spurious failure, we can go back to the drawing board.