### PR TITLE
replay_loop should retry tar command

### DIFF
--- a/tools/api-client/python/replay_loop
+++ b/tools/api-client/python/replay_loop
@@ -94,8 +94,17 @@ def test_file(filename):
     write_to_bm_prefix = 'sudo -u %s' % USERNAME
   else:
     write_to_bm_prefix = ''
+  tar_command = 'tar xf %s/%s' % (GAMESDIR, filename)
+  for retry in range(3):
+    retval = os.system(tar_command)
+    if retval == 0:
+      break
+    print "tar failed - retrying: %s" % command
+    time.sleep(SLEEPSECS)
+  else:
+    print "tar failed too many times - giving up"
+    sys.exit(1)
   commands = [
-    'tar xf %s/%s' % (GAMESDIR, filename),
     'sudo -u %s cp -f %s.test %s' % (USERNAME, TESTFILE, TESTFILE),
     'sudo chown chaos %s' % TESTFILE,
     './update_replay_games ./output | %s tee -a %s > /dev/null' % (write_to_bm_prefix, TESTFILE),


### PR DESCRIPTION
I sometimes see replay_loop commands error out with this exception:

```
Testing fecc05e96963fd94775e7e0e16bdc53dff6608e3.games.20180515.034014.tar.bz2...
tar: This does not look like a tar archive

bzip2: Compressed file ends unexpectedly;
        perhaps it is corrupted?  *Possible* reason follows.
bzip2: Inappropriate ioctl for device
        Input file = (stdin), output file = (stdout)

It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.

You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.

tar: Child returned status 2
tar: Error is not recoverable: exiting now
command failed: tar xf /srv/bmgames/chaos-test/archive/fecc05e96963fd94775e7e0e16bdc53dff6608e3.games.20180515.034014.tar.bz2
```

The goal of this change is to retry the tar a few times, so that if the error is transient we can keep going.
