### PR TITLE
Fix typo in error message causing retry not to work

### DIFF
--- a/tools/api-client/python/replay_loop
+++ b/tools/api-client/python/replay_loop
@@ -99,7 +99,7 @@ def test_file(filename):
     retval = os.system(tar_command)
     if retval == 0:
       break
-    print "tar failed - retrying: %s" % command
+    print "tar failed - retrying: %s" % tar_command
     time.sleep(SLEEPSECS)
   else:
     print "tar failed too many times - giving up"


### PR DESCRIPTION
Fixes this:

```
...
Prepping game for replay from: ./output/game00100.pck
Testing 3d32b0989a9e10028aa3797140d64bbc9ca1abdf.games.20180619.135321.tar.bz2...
tar: This does not look like a tar archive

bzip2: Compressed file ends unexpectedly;
        perhaps it is corrupted?  *Possible* reason follows.
bzip2: Inappropriate ioctl for device
        Input file = (stdin), output file = (stdout)

It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.

You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.

tar: Child returned status 2
tar: Error is not recoverable: exiting now
Traceback (most recent call last):
  File "./replay_loop", line 172, in <module>
    test_file(nextfile)
  File "./replay_loop", line 102, in test_file
    print "tar failed - retrying: %s" % command
UnboundLocalError: local variable 'command' referenced before assignment
```

Sigh.