### PR TITLE
Get phpunit from a version stashed on a local webserver to work around changes in phar.phpunit.de's SSL accessibility

### DIFF
--- a/deploy/vagrant/modules/php/manifests/init.pp
+++ b/deploy/vagrant/modules/php/manifests/init.pp
@@ -23,8 +23,9 @@ class php::base {
 
 class php::base::feature::phpunit {
   exec {
+    # TODO: once we upgrade PHP, start getting the latest version of phpunit again
     "php_wget_phpunit":
-      command => "/usr/bin/wget --no-verbose --no-check-certificate -O /etc/php5/deploy-includes/phpunit.phar https://phar.phpunit.de/phpunit-old.phar",
+      command => "/usr/bin/wget --no-verbose -O /etc/php5/deploy-includes/phpunit.phar http://www.glassonion.org/misc/phpunit-4.8.36.phar",
       creates => "/etc/php5/deploy-includes/phpunit.phar",
       require => File["/etc/php5/deploy-includes"];
   }


### PR DESCRIPTION
* Fixes download of phpunit.phar failing yet again

This isn't a great solution, but the version of phpunit.phar we're downloading is over a year old anyway, so we're not really missing updates, and i'd rather pick a workaround that keeps us moving for now and focus on upgrading php / ubuntu, than sink a lot of time into debugging why the handshake is unhappy.