### PR TITLE
Migrate action log entries of type determine_initiative to dedicated tables

### DIFF
--- a/deploy/database/schema.game.sql
+++ b/deploy/database/schema.game.sql
@@ -166,6 +166,32 @@ CREATE TABLE game_action_log_type_choose_die_values_option (
     INDEX (action_log_id)
 );
 
+CREATE TABLE game_action_log_type_determine_initiative (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    winner_id          SMALLINT UNSIGNED NOT NULL,
+    round_number       TINYINT UNSIGNED NOT NULL,
+    is_tie             BOOLEAN DEFAULT FALSE,
+    INDEX (action_log_id)
+);
+
+CREATE TABLE game_action_log_type_determine_initiative_slow_button (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    player_id          SMALLINT UNSIGNED NOT NULL,
+    INDEX (action_log_id)
+);
+
+CREATE TABLE game_action_log_type_determine_initiative_die (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    player_id          SMALLINT UNSIGNED NOT NULL,
+    recipe_status      VARCHAR(20) NOT NULL,
+    recipe             VARCHAR(20) NOT NULL,
+    included           BOOLEAN DEFAULT TRUE,
+    INDEX (action_log_id)
+);
+
 CREATE TABLE game_chat_log (
     id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     game_id            MEDIUMINT UNSIGNED NOT NULL,

--- a/deploy/database/updates/01991_action_log_determine_initiative.sql
+++ b/deploy/database/updates/01991_action_log_determine_initiative.sql
@@ -1,0 +1,25 @@
+CREATE TABLE game_action_log_type_determine_initiative (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    winner_id          SMALLINT UNSIGNED NOT NULL,
+    round_number       TINYINT UNSIGNED NOT NULL,
+    is_tie             BOOLEAN DEFAULT FALSE,
+    INDEX (action_log_id)
+);
+
+CREATE TABLE game_action_log_type_determine_initiative_slow_button (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    player_id          SMALLINT UNSIGNED NOT NULL,
+    INDEX (action_log_id)
+);
+
+CREATE TABLE game_action_log_type_determine_initiative_die (
+    id                 INTEGER UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    action_log_id      INTEGER UNSIGNED NOT NULL,
+    player_id          SMALLINT UNSIGNED NOT NULL,
+    recipe_status      VARCHAR(20) NOT NULL,
+    recipe             VARCHAR(20) NOT NULL,
+    included           BOOLEAN DEFAULT TRUE,
+    INDEX (action_log_id)
+);

--- a/deploy/database/updates/scripts/01991_migrate_choose_swing_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_choose_swing_action_logs
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+#####
+# Utility to migrate choose_swing action log entries to new (choose_die_values) format
+
+import json
+import MySQLdb
+
+def migrate_to_type_log_choose_die_values_from_choose_swing(row, crs):
+  row_id = row[0]
+  msgdata = json.loads(row[1])
+  round_number = msgdata['roundNumber']
+  swing_values = {}
+  if 'swingValues' in msgdata:
+    swing_values = msgdata['swingValues']
+  option_values = {}
+  if 'optionValues' in msgdata:
+    option_values = msgdata['optionValues']
+
+  insert_sql = 'INSERT INTO game_action_log_type_choose_die_values ' + \
+    '(action_log_id, round_number) VALUES ' + \
+    '(%s, %s);' % (row[0], round_number)
+  result = crs.execute(insert_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  if len(swing_values) > 0:
+    for [swing_type, swing_value] in sorted(swing_values.items()):
+      insert_sql = 'INSERT INTO game_action_log_type_choose_die_values_swing ' + \
+        '(action_log_id, swing_type, swing_value) VALUES ' + \
+        '(%s, "%s", %s);' % (row[0], swing_type, swing_value)
+      result = crs.execute(insert_sql)
+      if not result == 1:
+        raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  if len(option_values) > 0:
+    for [recipe, option_value] in sorted(option_values.items()):
+      insert_sql = 'INSERT INTO game_action_log_type_choose_die_values_option ' + \
+        '(action_log_id, recipe, option_value) VALUES ' + \
+        '(%s, "%s", %s);' % (row[0], recipe, option_value)
+      result = crs.execute(insert_sql)
+      if not result == 1:
+        raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  update_sql = 'UPDATE game_action_log SET message=NULL,action_type="choose_die_values" WHERE id=%d' % (row_id)
+  result = crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Moved row %s message %s to game_action_log_type_choose_die_values*" % (row[0], row[1])
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="choose_swing" ' + \
+  'AND message IS NOT NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_choose_die_values_from_choose_swing(row, crs)
+conn.commit()

--- a/deploy/database/updates/scripts/01991_migrate_determine_initiative_action_logs
+++ b/deploy/database/updates/scripts/01991_migrate_determine_initiative_action_logs
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+#####
+# Utility to migrate determine_initiative action log entries to new format
+
+import json
+import MySQLdb
+
+def migrate_to_type_log_determine_initiative(row, crs):
+  row_id = row[0]
+  msgdata = json.loads(row[1])
+  round_number = msgdata['roundNumber']
+  initiative_winner_id = msgdata['initiativeWinnerId']
+  is_initiative_tie = 'tiedPlayerIds' in msgdata and len(msgdata['tiedPlayerIds']) > 0
+  slow_button_players = []
+  initiative_dice = {}
+  for player_id, player_data in sorted(msgdata['playerData'].items()):
+    initiative_dice[player_id] = player_data['initiativeDice']
+    if 'slowButton' in player_data and player_data['slowButton']:
+      slow_button_players.append(player_id)
+
+  insert_sql = 'INSERT INTO game_action_log_type_determine_initiative ' + \
+    '(action_log_id, winner_id, round_number, is_tie) VALUES ' + \
+    '(%s, %s, %s, %s);' % (row[0], initiative_winner_id, round_number, is_initiative_tie)
+  result = crs.execute(insert_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  for player_id in slow_button_players:
+    insert_sql = 'INSERT INTO game_action_log_type_determine_initiative_slow_button ' + \
+      '(action_log_id, player_id) VALUES ' + \
+      '(%s, %s);' % (row[0], player_id)
+    result = crs.execute(insert_sql)
+    if not result == 1:
+      raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  for player_id, player_dice in sorted(initiative_dice.items()):
+    for init_die in player_dice:
+      insert_sql = 'INSERT INTO game_action_log_type_determine_initiative_die ' + \
+        '(action_log_id, player_id, recipe_status, recipe, included) VALUES ' + \
+        '(%s, %s, "%s", "%s", %s);' % (row[0], player_id, init_die['recipeStatus'], init_die['recipe'], init_die['included'])
+      result = crs.execute(insert_sql)
+      if not result == 1:
+        raise ValueError, "Got unexpected return %s from %s" % (result, insert_sql)
+
+  update_sql = 'UPDATE game_action_log SET message=NULL WHERE id=%d' % (row_id)
+  result = crs.execute(update_sql)
+  if not result == 1:
+    raise ValueError, "Got unexpected return %s from %s" % (result, update_sql)
+  print "Moved row %s message %s to game_action_log_type_determine_initiative*" % (row[0], row[1])
+
+conn = MySQLdb.connect(user='root', db='buttonmen')
+crs = conn.cursor()
+results = crs.execute(
+  'SELECT id,message FROM game_action_log WHERE action_type="determine_initiative" ' + \
+  'AND message IS NOT NULL')
+if results > 0:
+  for row in crs.fetchall():
+    migrate_to_type_log_determine_initiative(row, crs)
+conn.commit()

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -1017,20 +1017,25 @@ class BMGame {
             );
         $hasInitiativeArray = $response['hasPlayerInitiative'];
         $actionLogInfo = array(
-            'roundNumber' => $this->get__roundNumber(),
-            'playerData' => array(),
+            'roundNumber'       => $this->get__roundNumber(),
+            'isInitiativeTie'   => FALSE,
+            'slowButtonPlayers' => array(),
+            'initiativeDice'    => array(),
         );
         foreach ($response['actionLogInfo'] as $playerIdx => $playerActionLogData) {
-            $actionLogInfo['playerData'][$this->playerArray[$playerIdx]->playerId] = $playerActionLogData;
+            if ($playerActionLogData['slowButton']) {
+                $actionLogInfo['slowButtonPlayers'][] = $this->playerArray[$playerIdx]->playerId;
+            }
+            $actionLogInfo['initiativeDice'][$this->playerArray[$playerIdx]->playerId] =
+                $playerActionLogData['initiativeDice'];
         }
 
         if (array_sum($hasInitiativeArray) > 1) {
             $playersWithInit = array();
-            $actionLogInfo['tiedPlayerIds'] = array();
+            $actionLogInfo['isInitiativeTie'] = TRUE;
             foreach ($hasInitiativeArray as $playerIdx => $tempHasInitiative) {
                 if ($tempHasInitiative) {
                     $playersWithInit[] = $playerIdx;
-                    $actionLogInfo['tiedPlayerIds'][] = $this->playerArray[$playerIdx]->playerId;
                 }
             }
             $randIdx = bm_rand(0, count($playersWithInit) - 1);

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -981,12 +981,11 @@ class BMGameAction {
 
         // Now report all the initial die rolls without commentary
         $dieRollStrs = array();
-        $slowButtonPlayers = array();
         $slowDice = array();
-        foreach ($this->params['playerData'] as $playerId => $playerData) {
+        foreach ($this->params['initiativeDice'] as $playerId => $initiativeDice) {
             $dieVals = array();
             $slowDice[$playerId] = array();
-            foreach ($playerData['initiativeDice'] as $initDie) {
+            foreach ($initiativeDice as $initDie) {
                 $dieVals[] = $initDie['recipeStatus'];
                 if (!$initDie['included']) {
                     $slowDice[$playerId][] = $initDie['recipe'];
@@ -994,17 +993,14 @@ class BMGameAction {
             }
             $dieRollStrs[] = $this->outputPlayerIdNames[$playerId] . ' rolled [' .
                              implode(', ', $dieVals) . ']';
-            if ($playerData['slowButton']) {
-                $slowButtonPlayers[] = $playerId;
-            }
         }
         $messageArray[] = 'Initial die values: ' . implode(', ', $dieRollStrs);
 
         // Now report on slow buttons and dice: assume a 2-player game for now
-        if (count($slowButtonPlayers) == 2) {
+        if (count($this->params['slowButtonPlayers']) == 2) {
             $messageArray[] = 'Both buttons have the "slow" button special, and cannot win initiative normally';
-        } elseif (count($slowButtonPlayers) == 1) {
-            $messageArray[] = $this->outputPlayerIdNames[$slowButtonPlayers[0]] .
+        } elseif (count($this->params['slowButtonPlayers']) == 1) {
+            $messageArray[] = $this->outputPlayerIdNames[$this->params['slowButtonPlayers'][0]] .
                               '\'s button has the "slow" button special, and cannot win initiative normally';
         } else {
             foreach ($slowDice as $playerId => $playerSlowDice) {
@@ -1017,7 +1013,7 @@ class BMGameAction {
         }
 
         // Last, if initiative was resolved by coin flip, say that.
-        if (array_key_exists('tiedPlayerIds', $this->params)) {
+        if ($this->params['isInitiativeTie']) {
             $messageArray[] = 'Initiative was determined by a coin flip';
         }
 

--- a/test/src/engine/BMGameActionTest.php
+++ b/test/src/engine/BMGameActionTest.php
@@ -766,23 +766,19 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
     public function test_friendly_message_determine_initiative() {
         $testParams = array(
             'roundNumber' => 1,
-            'playerData' => array(
+            'initiativeDice' => array(
                 '1' => array(
-                    'initiativeDice' => array(
-                        array('recipe' => '(6)', 'min' => 1, 'max' => 6, 'value' => 3, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => '(6):3', 'included' => true),
-                        array('recipe' => '(10)', 'min' => 1, 'max' => 10, 'value' => 1, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => '(10):1', 'included' => true),
-                    ),
-                    'slowButton' => false,
+                    array('recipe' => '(6)', 'recipeStatus' => '(6):3', 'included' => true),
+                    array('recipe' => '(10)', 'recipeStatus' => '(10):1', 'included' => true),
                 ),
                 '2' => array(
-                    'initiativeDice' => array(
-                        array('recipe' => '(6)', 'min' => 1, 'max' => 6, 'value' => 2, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => '(6):2', 'included' => true),
-                        array('recipe' => '(10)', 'min' => 1, 'max' => 10, 'value' => 2, 'doesReroll' => TRUE, 'captured' => FALSE, 'recipeStatus' => '(10):2', 'included' => true),
-                    ),
-                    'slowButton' => false,
+                    array('recipe' => '(6)', 'recipeStatus' => '(6):2', 'included' => true),
+                    array('recipe' => '(10)', 'recipeStatus' => '(10):2', 'included' => true),
                 ),
             ),
+            'slowButtonPlayers' => array(),
             'initiativeWinnerId' => 1,
+            'isInitiativeTie' => FALSE,
         );
 
         $this->object = new BMGameAction(BMGameState::DETERMINE_INITIATIVE, 'determine_initiative', 0, $testParams);
@@ -791,7 +787,7 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
             $this->object->friendly_message($this->playerIdNames, 0, 0)
         );
 
-        $testParams['playerData']['1']['slowButton'] = true;
+        $testParams['slowButtonPlayers'] = array(1);
         $testParams['initiativeWinnerId'] = 2;
         $this->object = new BMGameAction(BMGameState::DETERMINE_INITIATIVE, 'determine_initiative', 0, $testParams);
         $this->assertEquals(
@@ -799,8 +795,8 @@ class BMGameActionTest extends PHPUnit_Framework_TestCase {
             $this->object->friendly_message($this->playerIdNames, 0, 0)
         );
 
-        $testParams['playerData']['2']['slowButton'] = true;
-        $testParams['tiedPlayerIds'] = array(1, 2);
+        $testParams['slowButtonPlayers'] = array(1, 2);
+        $testParams['isInitiativeTie'] = TRUE;
         $this->object = new BMGameAction(BMGameState::DETERMINE_INITIATIVE, 'determine_initiative', 0, $testParams);
         $this->assertEquals(
             "gameaction02 won initiative for round 1. Initial die values: gameaction01 rolled [(6):3, (10):1], gameaction02 rolled [(6):2, (10):2]. Both buttons have the \"slow\" button special, and cannot win initiative normally. Initiative was determined by a coin flip.",


### PR DESCRIPTION
* Also migrate very old "choose_swing" entries to "choose_die_values" in the database
* Partially addresses #1991 

A couple of relevant notes, if this passes:
* The "choose_swing" script is totally unrelated to everything else in the pull, and is a very simple modification of the choose_die_values script.  It only affects very old games, and should be a no-brainer and not distracting from the rest of the pull, but if you find that it is, complain, and i'll remove it.
* "determine_initiative" is the first action log entry type that iterates over dice, so there's a model for that here, where i retain only the information about each die which is actually used to construct the action log entry.  Obviously in the future when i'm creating "attack" type action log entries, what i retain will be much more info, but you can squint and see the model that's going to be used.