### PR TITLE
Utility to replay a single game from a recorded archive

### DIFF
--- a/tools/api-client/python/replay_single_game
+++ b/tools/api-client/python/replay_single_game
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+##### replay_single_test
+# This script is designed for use on a VM which is replay-testing new
+# code against recorded games.  It replays a single game from a saved
+# archive, and is designed for manual debugging of previous output or
+# iterative testing of one-off changes to update_replay_games.
+# It relies on replay_loop to have been previously run to correctly
+# setup on-VM directories etc.
+
+import os
+import re
+import subprocess
+import sys
+import time
+
+USERNAME = 'ubuntu'
+
+PARENTDIR = '/srv/bmgames/chaos-test'
+GAMESDIR = '%s/archive' % (PARENTDIR)
+SRCDIR = '/buttonmen/src'
+TESTDIR = '/buttonmen/test'
+TESTFILE = '%s/src/api/responder99Test.php' % TESTDIR
+
+SLEEPSECS = 60
+
+# e.g. 390b58027049ef07562b17ff9503471d0f2aae38.games.20160205.163427.tar.bz2
+GAMEFILE_RE = re.compile('^([0-9a-f]{40})\.games\.([0-9]{8}\.[0-9]{6})\.tar\.bz2$')
+
+ORIGDIR = os.getcwd()
+HOMEBMDIR = "%s/src/buttonmen" % ORIGDIR
+
+GAMEFILE=sys.argv[1]
+TESTNUM=sys.argv[2]
+
+assert GAMEFILE_RE.match(GAMEFILE)
+assert len(TESTNUM) == 5
+
+def test_game(filename, gamenum):
+  gamefile = './output/game%s.pck' % gamenum
+  ## prep test file for replay
+  os.chdir(HOMEBMDIR)
+  if USERNAME == 'vagrant':
+    write_to_bm_prefix = 'sudo -u %s' % USERNAME
+  else:
+    write_to_bm_prefix = ''
+  tar_command = 'tar xf %s/%s %s' % (GAMESDIR, filename, gamefile)
+  for retry in range(3):
+    retval = os.system(tar_command)
+    if retval == 0:
+      break
+    print "tar failed - retrying: %s" % tar_command
+    time.sleep(SLEEPSECS)
+  else:
+    print "tar failed too many times - giving up"
+    sys.exit(1)
+  commands = [
+    'sudo -u %s touch %s' % (USERNAME, TESTFILE),
+    'sudo chown chaos %s' % TESTFILE,
+    'echo "<?php" | %s tee -a %s' % (write_to_bm_prefix, TESTFILE),
+    'echo "require_once \'responderTestFramework.php\';" | %s tee -a %s' % (write_to_bm_prefix, TESTFILE),
+    'echo "class responder99Test extends responderTestFramework {" | %s tee -a %s' % (write_to_bm_prefix, TESTFILE),
+    './update_replay_games ./output | %s tee -a %s > /dev/null' % (write_to_bm_prefix, TESTFILE),
+    '/bin/rm ./output/*',
+    'echo "}" | %s tee -a %s > /dev/null' % (write_to_bm_prefix, TESTFILE),
+  ]
+  if os.path.isfile(TESTFILE):
+    commands.insert(0, 'sudo -u %s rm -f %s' % (USERNAME, TESTFILE))
+  for command in commands:
+    retval = os.system(command)
+    if retval != 0:
+      print "command failed: %s" % command
+      sys.exit(1)
+  os.chdir(SRCDIR)
+
+  # actually run the test (with output to stdout/stderr)
+  cmdargs = 'sudo -u %s sh -c "php /etc/php5/deploy-includes/phpunit.phar --bootstrap /usr/local/etc/buttonmen_phpunit.php --group fulltest_deps /buttonmen/test/src/api/ 2>&1"' % (USERNAME)
+  print "About to execute: %s" % cmdargs
+  os.system(cmdargs)
+  return
+
+########################################################################
+test_game(GAMEFILE, TESTNUM)


### PR DESCRIPTION
I realised this would make my life easier if i wanted to get serious about actually testing around expected API changes, e.g. my comment in #2384.  Here's an example of what it looks like:

```
ip-172-31-34-85,[~],13:06(0)$ ./replay_single_game be49150ca786d69a093216fc2aae7666107afd5c.games.20180819.091048.tar.bz2 00034
<?php
require_once 'responderTestFramework.php';
class responder99Test extends responderTestFramework {
Updating and prepping game for replay from: ./output/game00034.pck
About to execute: sudo -u ubuntu sh -c "php /etc/php5/deploy-includes/phpunit.phar --bootstrap /usr/local/etc/buttonmen_phpunit.php --group fulltest_deps /buttonmen/test/src/api/ 2>&1"
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

.F

Time: 1.22 seconds, Memory: 40.75MB

There was 1 failure:

1) responder99Test::test_interface_game_00034
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'responder003 performed Skill attack using [^(1):1,q(U=8)!:5] against [(20):6]; Defender (20) was captured; Attacker ^(1) rerolled 1 => 1; Attacker q(U=8)! rerolled from 5. responder003 gets another turn because a Time and Space die rolled odd. Turbo die q(U=8)! changed size from 8 to 29 sides, recipe changed from q(U=8)! to q(U=29)!, rolled 1. '
+'responder003 performed Skill attack using [^(1):1,q(U=8)!:5] against [(20):6]; Defender (20) was captured; Attacker ^(1) rerolled 1 => 1; Attacker q(U=8)! rerolled from 5. Turbo die q(U=8)! changed size from 8 to 29 sides, recipe changed from q(U=8)! to q(U=29)!, rolled 1. responder003 gets another turn because a Time and Space die rolled odd. '

/buttonmen/test/src/api/responderTestFramework.php:1315
/buttonmen/test/src/api/responder99Test.php:88

FAILURES!
Tests: 2, Assertions: 54, Failures: 1.
ip-172-31-34-85,[~],13:07(0)$ 
```

I can do that by hand by remembering all the various commands to run, but it takes longer and is more error-prone.