### PR TITLE
Fix isset() and empty() calls broken by PHP version upgrade

### DIFF
--- a/deploy/amp/phpunit_bootstrap.php
+++ b/deploy/amp/phpunit_bootstrap.php
@@ -40,5 +40,6 @@ function bm_skill_rand($min = FALSE, $max = FALSE) {
     return mt_rand();
 }
 
+
 // Now include the bootstrap file from the code itself
 require_once __DIR__.'/../../src/lib/bootstrap.php';

--- a/deploy/circleci/phpunit_bootstrap.php
+++ b/deploy/circleci/phpunit_bootstrap.php
@@ -40,5 +40,6 @@ function bm_skill_rand($min = FALSE, $max = FALSE) {
     return mt_rand();
 }
 
+
 // Now include the bootstrap file from the code itself
 require_once __DIR__.'/../../src/lib/bootstrap.php';

--- a/src/engine/BMAttack.php
+++ b/src/engine/BMAttack.php
@@ -371,7 +371,7 @@ abstract class BMAttack {
      */
     protected function ensure_defenders_have_value(array $defenders) {
         foreach ($defenders as &$def) {
-            if (empty($def->value)) {
+            if (is_null($def->value)) {
                 $def->roll(FALSE);
             }
         }

--- a/src/engine/BMButton.php
+++ b/src/engine/BMButton.php
@@ -373,7 +373,7 @@ class BMButton extends BMCanHaveSkill {
      */
     public function __unset($property) {
         if (isset($this->$property)) {
-            unset($this->$property);
+            $this->$property = NULL;
             return TRUE;
         } else {
             return FALSE;

--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -317,7 +317,7 @@ class BMDie extends BMCanHaveSkill {
              $doHooksAllowReroll);
 
         if ($turboDieIsAboutToBeReplaced) {
-            unset($this->value);
+            $this->value = NULL;
         } elseif ($needsToReroll) {
             $this->set__value(bm_rand($this->min, $this->max));
         }
@@ -604,7 +604,7 @@ class BMDie extends BMCanHaveSkill {
      */
     public function split() {
         $oldRecipe = $this->get_recipe(TRUE);
-        unset($this->value);
+        $this->value = NULL;
         $newdie = clone $this;
 
         $remainder = $newdie->max % 2;
@@ -641,7 +641,7 @@ class BMDie extends BMCanHaveSkill {
             if ($size < $this->max) {
                 $this->add_flag('HasJustShrunk', $this->get_recipe());
                 $this->max = $size;
-                unset($this->value);
+                $this->value = NULL;
                 return;
             }
         }
@@ -659,7 +659,7 @@ class BMDie extends BMCanHaveSkill {
                 $this->add_flag('HasJustGrown', $this->get_recipe());
                 $this->max = $size;
                 $this->min = 1;  // deal explicitly with the possibility of 0-siders
-                unset($this->value);
+                $this->value = NULL;
                 return;
             }
         }
@@ -1297,7 +1297,7 @@ class BMDie extends BMCanHaveSkill {
      */
     public function __unset($property) {
         if (isset($this->$property)) {
-            unset($this->$property);
+            $this->$property = NULL;
             return TRUE;
         } else {
             return FALSE;

--- a/src/engine/BMDieTwin.php
+++ b/src/engine/BMDieTwin.php
@@ -260,7 +260,7 @@ class BMDieTwin extends BMDie {
      */
     public function split() {
         $oldRecipe = $this->get_recipe(TRUE);
-        unset($this->value);
+        $this->value = NULL;
         $newdie = clone $this;
 
         foreach ($this->dice as $dieIdx => &$die) {

--- a/src/engine/BMEmail.php
+++ b/src/engine/BMEmail.php
@@ -195,4 +195,14 @@ class BMEmail {
                 $this->$property = $value;
         }
     }
+
+    /**
+     * Define behaviour of isset()
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->$property);
+    }
 }

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -902,7 +902,7 @@ class BMGame {
                     }
                 }
 
-                if (!isset($player->activeDieArray[$dieIdx]->max)) {
+                if (is_null($player->activeDieArray[$dieIdx]->max)) {
                     $player->waitingOnAction = TRUE;
                     continue 2;
                 }
@@ -993,7 +993,7 @@ class BMGame {
                     }
                 }
 
-                if (!isset($die->value)) {
+                if (is_null($die->value)) {
                     $player->activeDieArray[$dieIdx] = $die->make_play_die(FALSE);
                 }
             }
@@ -1893,7 +1893,7 @@ class BMGame {
             }
         }
 
-        unset($this->fireCache);
+        $this->fireCache = NULL;
         $this->gameState = BMGameState::CHOOSE_TURBO_SWING;
     }
 
@@ -1946,10 +1946,10 @@ class BMGame {
 
             $preTurboDice[] = $die->get_action_log_data();
             $oldRecipe = $die->get_recipe(TRUE);
-            unset($die->value);
+            $die->value = NULL;
             if (isset($die->dice)) {
                 foreach ($die->dice as $subdie) {
-                    unset($subdie->value);
+                    $subdie->value = NULL;
                 }
             }
 
@@ -2025,7 +2025,7 @@ class BMGame {
      */
     protected function update_game_state_choose_turbo_swing() {
         if (!$this->isWaitingOnAnyAction()) {
-            unset($this->turboCache);
+            $this->turboCache = NULL;
             $this->gameState = BMGameState::END_TURN;
         }
 
@@ -2850,7 +2850,7 @@ class BMGame {
         // If plasma, then it is unspecified if the skills are unclear.
         // james: not written yet
 
-        return (isset($die->max));
+        return (!is_null($die->max));
     }
 
     /**
@@ -2967,7 +2967,7 @@ class BMGame {
         $this->nRecentPasses = 0;
         $this->turnNumberInRound = 0;
         $this->setAllToNotWaiting();
-        unset($this->forceRoundResult);
+        $this->forceRoundResult = NULL;
     }
 
     /**
@@ -3619,7 +3619,7 @@ class BMGame {
      */
     public function __unset($property) {
         if (isset($this->$property)) {
-            unset($this->$property);
+            $this->$property = NULL;
             return TRUE;
         } else {
             return FALSE;
@@ -3950,7 +3950,7 @@ class BMGame {
 
         foreach ($dieArrayArray as $playerIdx => $dieArray) {
             foreach ($dieArray as $dieIdx => $die) {
-                if (isset($die->dice) && is_array($die->dice)) {
+                if (!is_null($die->dice) && is_array($die->dice)) {
                     foreach ($die->dice as $subdieIdx => $subdie) {
                         if (($subdie instanceof BMDieSwing) &&
                             $this->shouldDieDataBeHidden($playerIdx, $requestingPlayerIdx)) {
@@ -4019,12 +4019,12 @@ class BMGame {
     ) {
         $areAllPropertiesNull = TRUE;
 
-        if (isset($subdie->max)) {
+        if (!is_null($subdie->max)) {
             $subdieArrayArray[$playerIdx][$dieIdx][$subdieIdx]['sides'] = $subdie->max;
             $areAllPropertiesNull = FALSE;
         }
 
-        if (isset($subdie->value) &&
+        if (!is_null($subdie->value) &&
             !$this->isGameStateBeforeSpecifyingDice()) {
             $subdieArrayArray[$playerIdx][$dieIdx][$subdieIdx]['value'] = $subdie->value;
             $areAllPropertiesNull = FALSE;
@@ -4224,7 +4224,7 @@ class BMGame {
         $courtesySwingArray = array();
 
         foreach ($this->playerArray as $playerIdx => $player) {
-            if (isset($player->button->dieArray)) {
+            if (!is_null($player->button->dieArray)) {
                 foreach ($player->button->dieArray as $die) {
                     if (isset($die->swingType)) {
                         $swingRequestArrayArray[$playerIdx][$die->swingType][] = $die;

--- a/src/engine/BMGameAction.php
+++ b/src/engine/BMGameAction.php
@@ -1116,4 +1116,14 @@ class BMGameAction {
                 $this->$property = $value;
         }
     }
+
+    /**
+     * Define behaviour of isset()
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->$property);
+    }
 }

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -1308,7 +1308,7 @@ class BMInterface {
      * @param BMGame $game
      */
     protected function save_player_with_initiative($game) {
-        if (isset($game->playerWithInitiativeIdx)) {
+        if (!is_null($game->playerWithInitiativeIdx)) {
             // set all players to not having initiative
             $query = 'UPDATE game_player_map '.
                      'SET did_win_initiative = 0 '.
@@ -2662,5 +2662,15 @@ class BMInterface {
             default:
                 $this->$property = $value;
         }
+    }
+
+    /**
+     * Define behaviour of isset()
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->$property);
     }
 }

--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1418,7 +1418,7 @@ class BMInterfaceGame extends BMInterface {
             if ($isSuccessful) {
                 $game->proceed_to_next_user_action();
 
-                if (isset($game->turboCache) && !empty($game->turboCache)) {
+                if (!is_null($game->turboCache) && (count($game->turboCache) > 0)) {
                     $this->set_turbo_sizes(
                         $playerId,
                         $game,

--- a/src/engine/BMInterfaceNewuser.php
+++ b/src/engine/BMInterfaceNewuser.php
@@ -473,4 +473,14 @@ class BMInterfaceNewuser {
                 $this->$property = $value;
         }
     }
+
+    /**
+     * Define behaviour of isset()
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->$property);
+    }
 }

--- a/src/engine/BMPlayer.php
+++ b/src/engine/BMPlayer.php
@@ -593,7 +593,7 @@ class BMPlayer {
      */
     public function __unset($property) {
         if (isset($this->$property)) {
-            unset($this->$property);
+            $this->$property = NULL;
             return TRUE;
         } else {
             return FALSE;

--- a/src/engine/BMSkillMaximum.php
+++ b/src/engine/BMSkillMaximum.php
@@ -30,7 +30,7 @@ class BMSkillMaximum extends BMSkill {
 
         $die = $args['die'];
 
-        if (!$die->doesReroll && isset($die->value)) {
+        if (!$die->doesReroll && !is_null($die->value)) {
             return FALSE;
         }
 

--- a/src/engine/BMSkillMighty.php
+++ b/src/engine/BMSkillMighty.php
@@ -32,7 +32,7 @@ class BMSkillMighty extends BMSkill {
         }
 
         // don't trigger skill when rolling the die into the beginning of the round
-        if (!isset($die->value) &&
+        if (is_null($die->value) &&
             ($die->ownerObject->turnNumberInRound <= 1)) {
             return;
         }

--- a/src/engine/BMSkillTimeAndSpace.php
+++ b/src/engine/BMSkillTimeAndSpace.php
@@ -47,7 +47,7 @@ class BMSkillTimeAndSpace extends BMSkill {
             return;
         }
 
-        if (!isset($die->value)) {
+        if (is_null($die->value)) {
             return;
         }
 

--- a/src/engine/BMSkillTrip.php
+++ b/src/engine/BMSkillTrip.php
@@ -71,7 +71,7 @@ class BMSkillTrip extends BMSkill {
         $attacker->add_flag('IsAboutToPerformTripAttack');
         $attacker->roll(TRUE);
         $attackerValue = '';
-        if (isset($attacker->value)) {
+        if (!is_null($attacker->value)) {
             $attackerValue = $attacker->value;
         }
 
@@ -85,7 +85,7 @@ class BMSkillTrip extends BMSkill {
             foreach ($attacker->dice as $subdie) {
                 $subdieValue = '';
 
-                if (isset($subdie->value)) {
+                if (!is_null($subdie->value)) {
                     $subdieValue = $subdie->value;
                 }
 

--- a/src/engine/BMSkillTurbo.php
+++ b/src/engine/BMSkillTurbo.php
@@ -31,7 +31,7 @@ class BMSkillTurbo extends BMSkill {
 
         $die = $args['die'];
 
-        if (isset($die->value)) {
+        if (!is_null($die->value)) {
             if ($die->has_flag('JustPerformedTripAttack')) {
                 return TRUE;
             }

--- a/src/engine/BMSkillWeak.php
+++ b/src/engine/BMSkillWeak.php
@@ -32,7 +32,7 @@ class BMSkillWeak extends BMSkill {
         }
 
         // don't trigger skill when rolling the die into the beginning of the round
-        if (!isset($die->value) &&
+        if (is_null($die->value) &&
             ($die->ownerObject->turnNumberInRound <= 1)) {
             return;
         }

--- a/src/engine/BMUtilityHitTable.php
+++ b/src/engine/BMUtilityHitTable.php
@@ -140,4 +140,14 @@ class BMUtilityHitTable {
             "BMUtilityHitTable->$property cannot be set (attempting to set value $value)."
         );
     }
+
+    /**
+     * Define behaviour of isset()
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->$property);
+    }
 }

--- a/test/src/engine/BMButtonTest.php
+++ b/test/src/engine/BMButtonTest.php
@@ -319,10 +319,10 @@ class BMButtonTest extends PHPUnit_Framework_TestCase {
      * @covers BMButton::__isset
      */
     public function test__isset() {
-        $this->assertFalse(isset($this->object->name));
+        $this->assertTrue(is_null($this->object->name));
 
         $this->object->name = 'TestName';
-        $this->assertTrue(isset($this->object->name));
+        $this->assertFalse(is_null($this->object->name));
     }
 
     /**
@@ -334,6 +334,6 @@ class BMButtonTest extends PHPUnit_Framework_TestCase {
 
         $this->object->name = 'TestName';
         unset($this->object->name);
-        $this->assertFalse(isset($this->object->name));
+        $this->assertTrue(is_null($this->object->name));
     }
 }

--- a/test/src/engine/BMDieOptionTest.php
+++ b/test/src/engine/BMDieOptionTest.php
@@ -30,7 +30,7 @@ class BMDieOptionTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(1, $this->object->min);
         $this->assertEquals(array(4,6), $this->object->optionValueArray);
-        $this->assertFalse(isset($this->object->max));
+        $this->assertTrue(is_null($this->object->max));
 
         $this->assertFalse($this->object->has_skill('Testing'));
         $this->assertFalse($this->object->has_skill('Testing2'));
@@ -40,7 +40,7 @@ class BMDieOptionTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(1, $this->object->min);
         $this->assertEquals(array(5,8), $this->object->optionValueArray);
-        $this->assertFalse(isset($this->object->max));
+        $this->assertTrue(is_null($this->object->max));
 
         $this->assertTrue($this->object->has_skill('Testing2'));
         $this->assertFalse($this->object->has_skill('Testing'));
@@ -86,7 +86,7 @@ class BMDieOptionTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(1, $die->min);
         $this->assertEquals(array(4,6), $die->optionValueArray);
-        $this->assertFalse(isset($die->max));
+        $this->assertTrue(is_null($die->max));
 
         $this->assertFalse($die->has_skill('Testing'));
         $this->assertFalse($die->has_skill('Testing2'));
@@ -96,7 +96,7 @@ class BMDieOptionTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(1, $die->min);
         $this->assertEquals(array(5,8), $die->optionValueArray);
-        $this->assertFalse(isset($die->max));
+        $this->assertTrue(is_null($die->max));
 
         $this->assertTrue($die->has_skill('Testing2'));
         $this->assertFalse($die->has_skill('Testing'));

--- a/test/src/engine/BMGameTest.php
+++ b/test/src/engine/BMGameTest.php
@@ -1820,8 +1820,8 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->object->activePlayerIdx = 1;
         $this->object->nRecentPasses = 0;
         $this->object->do_next_step();
-        $this->assertFalse(isset($this->object->activePlayerIdx));
-        $this->assertFalse(isset($this->object->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($this->object->activePlayerIdx));
+        $this->assertTrue(is_null($this->object->playerWithInitiativeIdx));
         $this->assertEquals(array(array('W' => 4, 'L' => 3, 'D' => 1),
                                   array('W' => 3, 'L' => 4, 'D' => 1)),
                             $this->object->gameScoreArrayArray);
@@ -1846,8 +1846,8 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->object->activePlayerIdx = 1;
         $this->object->nRecentPasses = 0;
         $this->object->do_next_step();
-        $this->assertFalse(isset($this->object->activePlayerIdx));
-        $this->assertFalse(isset($this->object->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($this->object->activePlayerIdx));
+        $this->assertTrue(is_null($this->object->playerWithInitiativeIdx));
         $this->assertEquals(array(array('W' => 4, 'L' => 2, 'D' => 2),
                                   array('W' => 2, 'L' => 4, 'D' => 2)),
                             $this->object->gameScoreArrayArray);
@@ -1872,12 +1872,12 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->object->gameScoreArrayArray = array(array(1,2,1), array(2,1,1));
         $this->object->gameState = BMGameState::END_ROUND;
         $this->object->do_next_step();
-        $this->assertFalse(isset($this->object->activePlayerIdx));
-        $this->assertFalse(isset($this->object->playerWithInitiativeIdx));
-        $this->assertFalse(isset($this->object->activeDieArrayArray));
+        $this->assertTrue(is_null($this->object->activePlayerIdx));
+        $this->assertTrue(is_null($this->object->playerWithInitiativeIdx));
+        $this->assertEquals(array(array(), array()), $this->object->activeDieArrayArray);
         $this->assertEquals(array(array(), array()), $this->object->capturedDieArrayArray);
         $this->assertEquals(0, $this->object->nRecentPasses);
-        $this->assertFalse(isset($this->object->roundScoreArray));
+        $this->assertEquals(array(0, 0), $this->object->roundScoreArray);
         $this->assertEquals(array(array('W' => 1, 'L' => 3, 'D' => 1),
                                   array('W' => 3, 'L' => 1, 'D' => 1)),
                             $this->object->gameScoreArrayArray);
@@ -1919,7 +1919,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->object->gameState = BMGameState::END_GAME;
         $this->object->activePlayerIdx = 1;
         $this->object->do_next_step();
-        $this->assertFalse(isset($this->object->activePlayerIdx));
+        $this->assertTrue(is_null($this->object->activePlayerIdx));
     }
 
     /**
@@ -2022,7 +2022,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
      * @covers BMGame::request_swing_values
      */
     public function test_request_swing_values() {
-        $this->assertFalse(isset($this->object->swingRequestArrayArray));
+        $this->assertEquals(array(array(), array()), $this->object->swingRequestArrayArray);
 
         $die = new BMDieSwing;
         $swingtype = 'X';
@@ -2146,14 +2146,14 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->object->waitingOnActionArray = array(FALSE, TRUE);
 
         $method->invoke($this->object);
-        $this->assertFalse(isset($this->object->activePlayerIdx));
-        $this->assertFalse(isset($this->object->playerWithInitiativeIdx));
-        $this->assertFalse(isset($this->object->activeDieArrayArray));
+        $this->assertTrue(is_null($this->object->activePlayerIdx));
+        $this->assertTrue(is_null($this->object->playerWithInitiativeIdx));
+        $this->assertEquals(array(array(), array()), $this->object->activeDieArrayArray);
         $this->assertEquals(0, $this->object->nRecentPasses);
         $this->assertEquals(array(array(), array()), $this->object->capturedDieArrayArray);
-        $this->assertFalse(isset($this->object->roundScoreArray));
+        $this->assertEquals(array(0, 0), $this->object->roundScoreArray);
         $this->assertEquals(array(FALSE, FALSE), $this->object->waitingOnActionArray);
-        $this->assertFalse(isset($this->object->attack));
+        $this->assertTrue(is_null($this->object->attack));
     }
 
     /**
@@ -2194,8 +2194,10 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $this->assertNull($game->buttonArray[0]);
         $this->assertNull($game->buttonArray[1]);
         $this->assertEquals(3, $game->maxWins);
-        // the gameScoreArrayArray must remain unset until BMGameState::APPLY_HANDICAPS
-        $this->assertTrue(!isset($this->object->gameScoreArrayArray));
+
+        $this->assertEquals(array(array('W' => 0, 'L' => 0, 'D' => 0),
+                                  array('W' => 0, 'L' => 0, 'D' => 0)),
+                            $this->object->gameScoreArrayArray);
         $this->assertEquals(array(FALSE, FALSE), $game->waitingOnActionArray);
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
@@ -2829,7 +2831,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $player1 = new BMPlayer;
         $player2 = new BMPlayer;
         $this->object->playerArray = array($player1, $player2);
-        $this->assertTrue(isset($this->object->playerArray));
+        $this->assertFalse(is_null($this->object->playerArray));
     }
 
     /**
@@ -2842,8 +2844,8 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $button1 = new BMButton;
         $button2 = new BMButton;
         $this->object->buttonArray = array($button1, $button2);
-        unset($this->object->buttonArray);
-        $this->assertFalse(isset($this->object->buttonArray));
+        unset($this->object->gameId);
+        $this->assertNull($this->object->gameId);
     }
 
 
@@ -3932,7 +3934,7 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
         $game->proceed_to_next_user_action();
 
         // round 2
-        $this->assertTrue(!isset($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
         $this->assertEquals(BMGameState::SPECIFY_DICE, $game->gameState);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
         $this->assertEquals(array(array('X' => 19), array('X' => 4)), $game->prevSwingValueArrayArray);
@@ -4302,8 +4304,8 @@ class BMGameTest extends PHPUnit_Framework_TestCase {
                             $game->gameScoreArrayArray);
         $this->assertEquals(BMGameState::END_GAME, $game->gameState);
         $this->assertEquals(array(FALSE, FALSE), $game->waitingOnActionArray);
-        $this->assertTrue(empty($game->activeDieArrayArray[0]));
-        $this->assertTrue(empty($game->activeDieArrayArray[1]));
+        $this->assertEmpty($game->activeDieArrayArray[0]);
+        $this->assertEmpty($game->activeDieArrayArray[1]);
     }
 
     /**

--- a/test/src/engine/BMInterfaceGameTest.php
+++ b/test/src/engine/BMInterfaceGameTest.php
@@ -30,10 +30,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertEquals(self::$userId2WithoutAutopass, $game->playerIdArray[1]);
         $this->assertEquals(BMGameState::SPECIFY_DICE, $game->gameState);
-        $this->assertFalse(isset($game->activePlayerIdx));
-        $this->assertFalse(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -65,15 +65,15 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
                 } else {
                     $this->assertEquals($expectedSizes[$playerIdx][$dieIdx],
                                         $activeDieArray[$dieIdx]->max);
-                    $this->assertTrue(isset($activeDieArray[$dieIdx]->value));
+                    $this->assertFalse(is_null($activeDieArray[$dieIdx]->value));
                 }
             }
         }
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing details
@@ -102,12 +102,12 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertEquals(array(TRUE, TRUE), $game->waitingOnActionArray);
 
         // check score
-        $this->assertFalse(isset($game->roundScoreArray));
+        $this->assertEquals(array(0, 0), $game->roundScoreArray);
         $this->assertCount(2, $game->gameScoreArrayArray);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['W']);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['L']);
@@ -228,10 +228,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertEquals(self::$userId2WithoutAutopass, $game->playerIdArray[1]);
         $this->assertEquals(BMGameState::SPECIFY_DICE, $game->gameState);
-        $this->assertFalse(isset($game->activePlayerIdx));
-        $this->assertFalse(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -260,10 +260,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
             }
         }
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing
@@ -349,7 +349,7 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
     }
@@ -370,9 +370,9 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
 
         $game = self::load_game($gameId);
 
-        $this->assertFalse(empty($game->playerArray[0]->button));
+        $this->assertNotEmpty($game->playerArray[0]->button);
         $this->assertEquals('Coil', $game->playerArray[0]->button->name);
-        $this->assertFalse(empty($game->playerArray[1]->button));
+        $this->assertNotEmpty($game->playerArray[1]->button);
         $this->assertNotEquals('__random', $game->playerArray[1]->button->name);
         $this->assertGreaterThan(BMGameState::START_GAME, $game->gameState);
     }
@@ -392,16 +392,16 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $gameId = $retval['gameId'];
 
         $game = self::load_game($gameId);
-        $this->assertTrue(empty($game->playerArray[0]->button));
+        $this->assertEmpty($game->playerArray[0]->button);
         $this->assertTrue($game->playerArray[0]->isButtonChoiceRandom);
-        $this->assertTrue(empty($game->playerArray[1]->button));
+        $this->assertEmpty($game->playerArray[1]->button);
         $this->assertFalse($game->playerArray[1]->isButtonChoiceRandom);
 
         self::save_game($game);
         $game = self::load_game($gameId);
-        $this->assertTrue(empty($game->playerArray[0]->button));
+        $this->assertEmpty($game->playerArray[0]->button);
         $this->assertTrue($game->playerArray[0]->isButtonChoiceRandom);
-        $this->assertTrue(empty($game->playerArray[1]->button));
+        $this->assertEmpty($game->playerArray[1]->button);
         $this->assertFalse($game->playerArray[1]->isButtonChoiceRandom);
         $this->assertEquals(BMGameState::START_GAME, $game->gameState);
 
@@ -412,9 +412,9 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         );
         $this->assertTrue($retval);
         $game = self::load_game($gameId);
-        $this->assertFalse(empty($game->playerArray[0]->button));
+        $this->assertNotEmpty($game->playerArray[0]->button);
         $this->assertTrue($game->playerArray[0]->isButtonChoiceRandom);
-        $this->assertFalse(empty($game->playerArray[1]->button));
+        $this->assertNotEmpty($game->playerArray[1]->button);
         $this->assertTrue($game->playerArray[1]->isButtonChoiceRandom);
         $this->assertGreaterThan(BMGameState::START_GAME, $game->gameState);
     }
@@ -458,9 +458,9 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $gameId = $retval['gameId'];
 
         $game = self::load_game($gameId);
-        $this->assertTrue(empty($game->buttonArray[0]));
+        $this->assertEmpty($game->buttonArray[0]);
         $this->assertTrue($game->playerArray[0]->isButtonChoiceRandom);
-        $this->assertTrue(empty($game->buttonArray[1]));
+        $this->assertEmpty($game->buttonArray[1]);
         $this->assertTrue($game->playerArray[1]->isButtonChoiceRandom);
         $this->assertEquals(BMGameState::START_GAME, $game->gameState);
     }
@@ -486,10 +486,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertNull($game->playerIdArray[1]);
         $this->assertEquals(BMGameState::START_GAME, $game->gameState);
-        $this->assertFalse(isset($game->activePlayerIdx));
-        $this->assertFalse(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -506,14 +506,14 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertCount(2, $game->activeDieArrayArray);
         $this->assertEquals(array(array(), array()), $game->activeDieArrayArray);
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing details
-        $this->assertFalse(isset($game->swingRequestArrayArray));
+        $this->assertEquals(array(array(), array()), $game->swingRequestArrayArray);
         $this->assertEquals(array(array(), array()), $game->swingValueArrayArray);
 
         // check round info
@@ -521,12 +521,12 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
 
         // check score
-        $this->assertFalse(isset($game->roundScoreArray));
+        $this->assertEquals(array(0, 0), $game->roundScoreArray);
         $this->assertCount(2, $game->gameScoreArrayArray);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['W']);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['L']);
@@ -557,10 +557,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertEquals(self::$userId2WithoutAutopass, $game->playerIdArray[1]);
         $this->assertEquals(BMGameState::START_GAME, $game->gameState);
-        $this->assertFalse(isset($game->activePlayerIdx));
-        $this->assertFalse(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -575,14 +575,14 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertCount(2, $game->activeDieArrayArray);
         $this->assertEquals(array(array(), array()), $game->activeDieArrayArray);
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing details
-        $this->assertFalse(isset($game->swingRequestArrayArray));
+        $this->assertEquals(array(array(), array()), $game->swingRequestArrayArray);
         $this->assertEquals(array(array(), array()), $game->swingValueArrayArray);
 
         // check round info
@@ -590,12 +590,12 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
 
         // check score
-        $this->assertFalse(isset($game->roundScoreArray));
+        $this->assertEquals(array(0, 0), $game->roundScoreArray);
         $this->assertCount(2, $game->gameScoreArrayArray);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['W']);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['L']);
@@ -626,10 +626,10 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertNull($game->playerIdArray[1]);
         $this->assertEquals(BMGameState::START_GAME, $game->gameState);
-        $this->assertFalse(isset($game->activePlayerIdx));
-        $this->assertFalse(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertTrue(is_null($game->activePlayerIdx));
+        $this->assertTrue(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -644,14 +644,14 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertCount(2, $game->activeDieArrayArray);
         $this->assertEquals(array(array(), array()), $game->activeDieArrayArray);
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing details
-        $this->assertFalse(isset($game->swingRequestArrayArray));
+        $this->assertEquals(array(array(), array()), $game->swingRequestArrayArray);
         $this->assertEquals(array(array(), array()), $game->swingValueArrayArray);
 
         // check round info
@@ -659,12 +659,12 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertEquals(array(FALSE, TRUE), $game->waitingOnActionArray);
 
         // check score
-        $this->assertFalse(isset($game->roundScoreArray));
+        $this->assertEquals(array(0, 0), $game->roundScoreArray);
         $this->assertCount(2, $game->gameScoreArrayArray);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['W']);
         $this->assertEquals(0, $game->gameScoreArrayArray[0]['L']);
@@ -1244,12 +1244,12 @@ class BMInterfaceGameTest extends BMInterfaceTestAbstract {
         $this->assertEquals( 6, $game->activeDieArrayArray[0][1]->max);
         $this->assertEquals( 8, $game->activeDieArrayArray[0][2]->max);
         $this->assertEquals(20, $game->activeDieArrayArray[0][3]->max);
-        $this->assertFalse(isset($game->activeDieArrayArray[0][4]->max));
+        $this->assertTrue(is_null($game->activeDieArrayArray[0][4]->max));
         $this->assertEquals( 4, $game->activeDieArrayArray[1][0]->max);
         $this->assertEquals( 6, $game->activeDieArrayArray[1][1]->max);
         $this->assertEquals( 6, $game->activeDieArrayArray[1][2]->max);
         $this->assertEquals(12, $game->activeDieArrayArray[1][3]->max);
-        $this->assertFalse(isset($game->activeDieArrayArray[1][4]->max));
+        $this->assertTrue(is_null($game->activeDieArrayArray[1][4]->max));
         $this->assertTrue($game->activeDieArrayArray[0][2]->has_skill('Fire'));
         $this->assertTrue($game->activeDieArrayArray[1][0]->has_skill('Fire'));
         $this->assertTrue($game->activeDieArrayArray[1][1]->has_skill('Fire'));

--- a/test/src/engine/BMInterfaceTest.php
+++ b/test/src/engine/BMInterfaceTest.php
@@ -35,10 +35,10 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertEquals(self::$userId1WithoutAutopass, $game->playerIdArray[0]);
         $this->assertEquals(self::$userId2WithoutAutopass, $game->playerIdArray[1]);
         $this->assertEquals(BMGameState::START_TURN, $game->gameState);
-        $this->assertTrue(isset($game->activePlayerIdx));
-        $this->assertTrue(isset($game->playerWithInitiativeIdx));
-        $this->assertFalse(isset($game->attackerPlayerIdx));
-        $this->assertFalse(isset($game->defenderPlayerIdx));
+        $this->assertFalse(is_null($game->activePlayerIdx));
+        $this->assertFalse(is_null($game->playerWithInitiativeIdx));
+        $this->assertTrue(is_null($game->attackerPlayerIdx));
+        $this->assertTrue(is_null($game->defenderPlayerIdx));
         $this->assertEquals(array(FALSE, FALSE), $game->isPrevRoundWinnerArray);
 
         // check buttons
@@ -73,15 +73,15 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
                 } else {
                     $this->assertEquals($expectedSizes[$playerIdx][$dieIdx],
                                         $activeDieArray[$dieIdx]->max);
-                    $this->assertTrue(isset($activeDieArray[$dieIdx]->value));
+                    $this->assertFalse(is_null($activeDieArray[$dieIdx]->value));
                 }
             }
         }
 
-        $this->assertFalse(isset($game->attackerAllDieArray));
-        $this->assertFalse(isset($game->defenderAllDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
-        $this->assertFalse(isset($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAllDieArray));
+        $this->assertTrue(is_null($game->defenderAllDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
+        $this->assertTrue(is_null($game->attackerAttackDieArray));
         $this->assertEquals(array(array(), array()), $game->capturedDieArrayArray);
 
         // check swing details
@@ -112,7 +112,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4, $game->maxWins);
 
         // check action info
-        $this->assertFalse(isset($game->attack));
+        $this->assertTrue(is_null($game->attack));
         $this->assertEquals(0, $game->nRecentPasses);
         $this->assertTrue($game->playerArray[$game->activePlayerIdx]->waitingOnAction);
 
@@ -407,7 +407,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
                             $game->gameScoreArrayArray);
 
         $this->assertEquals(array('X'), array_keys($game->swingValueArrayArray[0]));
-        $this->assertFalse(isset($game->swingValueArrayArray[0]['X']));
+        $this->assertTrue(is_null($game->swingValueArrayArray[0]['X']));
         $this->assertEquals(array('V'), array_keys($game->swingValueArrayArray[1]));
         $this->assertNotNull($game->swingValueArrayArray[1]['V']);
         $this->assertNotNull($game->activeDieArrayArray[1][4]->swingValue);
@@ -1266,7 +1266,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         $this->assertEquals(4,  $game->activeDieArrayArray[0][1]->max);
         $this->assertEquals(10, $game->activeDieArrayArray[0][2]->max);
         $this->assertEquals(12, $game->activeDieArrayArray[0][3]->max);
-        $this->assertFalse(isset($game->activeDieArrayArray[0][4]->max));
+        $this->assertTrue(is_null($game->activeDieArrayArray[0][4]->max));
         $this->assertEquals(0, $game->activeDieArrayArray[0][0]->playerIdx);
         $this->assertEquals(0, $game->activeDieArrayArray[0][1]->playerIdx);
         $this->assertEquals(0, $game->activeDieArrayArray[0][2]->playerIdx);
@@ -1396,7 +1396,7 @@ class BMInterfaceTest extends BMInterfaceTestAbstract {
         self::save_game($game);
         $game = self::load_game($game->gameId);
 
-        $this->assertFalse(isset($game->activeDieArrayArray[0][2]->max));
+        $this->assertTrue(is_null($game->activeDieArrayArray[0][2]->max));
 
         // specify option dice partially
         $player = $game->playerArray[0];

--- a/test/src/engine/BMSkillBerserkTest.php
+++ b/test/src/engine/BMSkillBerserkTest.php
@@ -113,7 +113,7 @@ class BMSkillBerserkTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue($newDie === $att);
 
         $this->assertEquals(9, $newDie->max);
-        $this->assertFalse(isset($newDie->value));
+        $this->assertTrue(is_null($newDie->value));
         $this->assertFalse($newDie->has_skill('Berserk'));
         $this->assertTrue($att === $newDie);
         $this->assertTrue($newDie->has_flag('JustPerformedBerserkAttack'));

--- a/test/src/engine/BMSkillRadioactiveTest.php
+++ b/test/src/engine/BMSkillRadioactiveTest.php
@@ -318,8 +318,8 @@ class BMSkillRadioactiveTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(8, $game->activeDieArrayArray[0][2]->max);
         $this->assertEquals(30, $game->activeDieArrayArray[0][3]->max);
 
-        $this->assertFalse(isset($game->activeDieArrayArray[0][1]->value));
-        $this->assertFalse(isset($game->activeDieArrayArray[0][2]->value));
+        $this->assertTrue(is_null($game->activeDieArrayArray[0][1]->value));
+        $this->assertTrue(is_null($game->activeDieArrayArray[0][2]->value));
 
         $this->assertFalse($game->activeDieArrayArray[0][1]->has_skill('Radioactive'));
         $this->assertFalse($game->activeDieArrayArray[0][2]->has_skill('Radioactive'));

--- a/test/src/engine/BMSkillRageTest.php
+++ b/test/src/engine/BMSkillRageTest.php
@@ -132,7 +132,7 @@ class BMSkillRageTest extends PHPUnit_Framework_TestCase {
         // rage replacement die
         $this->assertEquals(8, $game->activeDieArrayArray[1][2]->max);
         $this->assertFalse($game->activeDieArrayArray[1][2]->captured);
-        $this->assertFalse(isset($game->activeDieArrayArray[1][2]->value));
+        $this->assertTrue(is_null($game->activeDieArrayArray[1][2]->value));
         $this->assertTrue($game->activeDieArrayArray[1][2]->has_flag('IsRageTargetReplacement'));
         $this->assertFalse($game->activeDieArrayArray[1][2]->has_flag('WasJustCaptured'));
 
@@ -228,7 +228,7 @@ class BMSkillRageTest extends PHPUnit_Framework_TestCase {
         // rage replacement die
         $this->assertEquals(8, $game->activeDieArrayArray[1][2]->max);
         $this->assertFalse($game->activeDieArrayArray[1][2]->captured);
-        $this->assertFalse(isset($game->activeDieArrayArray[1][2]->value));
+        $this->assertTrue(is_null($game->activeDieArrayArray[1][2]->value));
         $this->assertFalse($game->activeDieArrayArray[1][2]->has_skill('Rage'));
         $this->assertTrue($game->activeDieArrayArray[1][2]->has_flag('IsRageTargetReplacement'));
         $this->assertFalse($game->activeDieArrayArray[1][2]->has_flag('WasJustCaptured'));

--- a/test/src/engine/BMSkillTimeAndSpaceTest.php
+++ b/test/src/engine/BMSkillTimeAndSpaceTest.php
@@ -38,16 +38,16 @@ class BMSkillTimeAndSpaceTest extends PHPUnit_Framework_TestCase {
         $args = array('die' => $die);
         $this->object->post_roll($args);
 
-        $this->assertFalse(isset($game->nextPlayerIdx));
+        $this->assertTrue(is_null($game->nextPlayerIdx));
 
         $die->value = 2;
         $die->add_flag('IsAttacker');
-        $this->assertFalse(isset($game->nextPlayerIdx));
+        $this->assertTrue(is_null($game->nextPlayerIdx));
 
         $die->value = 3;
         $this->object->post_roll($args);
 
-        $this->assertTrue(isset($game->nextPlayerIdx));
+        $this->assertFalse(is_null($game->nextPlayerIdx));
         $this->assertEquals(1, $game->nextPlayerIdx);
     }
 }


### PR DESCRIPTION
Fixes #1167.

So, this pull request is intended to fix the calls to isset() and empty() in the code and test code that were broken by the upgrade from PHP 5.2 to PHP 7.0.

We already know from Chaos's replay testing that these changes break something with Dead Guy, so I'll mark this as incomplete until we have a responder test for that problem and the problem has been fixed.