### PR TITLE
Fixed incorrect interaction between warrior and stinger

### DIFF
--- a/src/engine/BMSkillWarrior.php
+++ b/src/engine/BMSkillWarrior.php
@@ -17,7 +17,6 @@ class BMSkillWarrior extends BMSkill {
      */
     public static $hooked_methods = array('initiative_value',
                                           'attack_list',
-                                          'attack_values',
                                           'capture',
                                           'post_roll',
                                           'score_value',
@@ -57,21 +56,6 @@ class BMSkillWarrior extends BMSkill {
                 unset($attackTypeArray[$attackType]);
             }
         }
-    }
-
-    /**
-     * Hooked method applied when determining possible attack values
-     *
-     * @param array $args
-     */
-    public static function attack_values($args) {
-        if (!is_array($args) ||
-            !array_key_exists('attackValues', $args) ||
-            !array_key_exists('value', $args)) {
-            return;
-        }
-
-        $args['attackValues'] = array($args['value']);
     }
 
     /**

--- a/test/src/engine/BMSkillWarriorTest.php
+++ b/test/src/engine/BMSkillWarriorTest.php
@@ -77,21 +77,6 @@ class BMSkillWarriorTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @covers BMSkillWarrior::attack_values
-     */
-    public function testAttack_values() {
-        $attackValues = array(-3, -2, -1, 1, 2, 3);
-
-        $args = array('attackType' => 'Skill',
-                      'attackValues' => &$attackValues,
-                      'minValue' => 1,
-                      'value' => 6);
-
-        $this->object->attack_values($args);
-        $this->assertEquals(array(6), $args['attackValues']);
-    }
-
-    /**
      * @covers BMSkillWarrior::capture
      */
     public function testCapture_invalid_args() {


### PR DESCRIPTION
In #2408, @TheOrgg notes that Warrior Stinger dice don't seem to be able to use partial values as part of their initial multidie skill attack.

This pull request fixes that problem.