### PR TITLE
Python client should sort keys when JSON-encoding them for API submission

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -944,10 +944,12 @@ class ApiResponder {
             if ($argcheck['ok']) {
                 // As far as we can easily tell, it's safe to call
                 // the function.  Go ahead and create an interface
-                // object, invoke the function, and return the result
-                $interface = $this->create_interface($args, $check);
-                apache_note('BMAPIMethod', $args['type']);
-                $data = $this->{$check['funcname']}($interface, $args);
+                // object, invoke the function on sanitized args,
+                // and return the result
+                $sanitizedArgs = $this->spec->sanitize_function_args($args);
+                $interface = $this->create_interface($sanitizedArgs, $check);
+                apache_note('BMAPIMethod', $sanitizedArgs['type']);
+                $data = $this->{$check['funcname']}($interface, $sanitizedArgs);
 
                 $output = array(
                     'data' => $data,

--- a/test/src/api/responder01Test.php
+++ b/test/src/api/responder01Test.php
@@ -3549,7 +3549,7 @@ class responder01Test extends responderTestFramework {
      * 14. responder003 performed Power attack using [(X=20):7] against [q(T=2):2]; Defender q(T=2) was captured; Attacker (X=20) rerolled 7 => 20
      * 15. End of round: responder003 won round 2 (80 vs. 18)
      * 16. responder004 added a reserve die: rz(S)
-     * 17. responder004 set swing values: T=2, W=4, X=4, Z=4, S=20
+     * 17. responder004 set swing values: S=20, T=2, W=4, X=4, Z=4
      *     responder004 won initiative for round 3. Initial die values: responder003 rolled [(4):2, (6):5, (12):1, (X=20):12, (20):8], responder004 rolled [q(T=2):2, q(W=4):4, q(X=4):1, q(Z=4):1, z(S=20):4].
      * 18. responder004 performed Skill attack using [q(T=2):2,q(W=4):4,q(X=4):1,q(Z=4):1,z(S=20):4] against [(X=20):12]; Defender (X=20) was captured; Attacker q(T=2) rerolled 2 => 1; Attacker q(W=4) rerolled 4 => 4; Attacker q(X=4) rerolled 1 => 3; Attacker q(Z=4) rerolled 1 => 1; Attacker z(S=20) rerolled 4 => 10
      * 19. responder003 performed Power attack using [(12):1] against [q(Z=4):1]; Defender q(Z=4) was captured; Attacker (12) rerolled 1 => 12
@@ -4170,7 +4170,7 @@ class responder01Test extends responderTestFramework {
 
 
         ////////////////////
-        // Move 16 - responder004 set swing values: T=2, W=4, X=4, Z=4, S=20
+        // Move 16 - responder004 set swing values: S=20, T=2, W=4, X=4, Z=4
         $_SESSION = $this->mock_test_user_login('responder004');
         $this->verify_api_submitDieValues(
             array(2, 4, 1, 1, 4),
@@ -4211,7 +4211,7 @@ class responder01Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][4]['description'] .= ' (with 20 sides)';
         $expData['playerDataArray'][0]['swingRequestArray'] = array();
         $expData['playerDataArray'][1]['swingRequestArray'] = array();
-        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder004', 'message' => 'responder004 set swing values: T=2, W=4, X=4, Z=4, S=20'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder004', 'message' => 'responder004 set swing values: S=20, T=2, W=4, X=4, Z=4'));
         $cachedActionLog[] = array_pop($expData['gameActionLog']);
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => '', 'message' => 'responder004 won initiative for round 3. Initial die values: responder003 rolled [(4):2, (6):5, (12):1, (X=20):12, (20):8], responder004 rolled [q(T=2):2, q(W=4):4, q(X=4):1, q(Z=4):1, z(S=20):4].'));
         $cachedActionLog[] = array_pop($expData['gameActionLog']);

--- a/test/src/api/responder02Test.php
+++ b/test/src/api/responder02Test.php
@@ -1627,7 +1627,7 @@ class responder02Test extends responderTestFramework {
      *
      * This game reproduces a bug in which time and space is not triggered on a twin die
      * 0. Start a game with responder003 playing LadyJ and responder004 playing Giant
-     * 1. responder003 set swing values: W=4, X=4, T=3
+     * 1. responder003 set swing values: T=3, W=4, X=4
      *    responder003 won initiative for round 1. Initial die values: responder003 rolled [d(17):2, Ho(W=4)?:2, q(X=4):3, ^B(T=3,T=3):4, (5):5], responder004 rolled [(20):4, (20):1, (20):15, (20):14, (20):19, (20):11]. responder004's button has the "slow" button special, and cannot win initiative normally.
      * 2. responder003 performed Power attack using [^B(T=3,T=3):4] against [(20):4]; Defender (20) was captured; Attacker ^B(T=3,T=3) rerolled 4 => 3
      *    responder003's idle ornery dice rerolled at end of turn: Ho(W=4)? changed size from 4 to 12 sides, recipe changed from Ho(W=4)? to Ho(W=12)?, rerolled 2 => 8
@@ -1674,7 +1674,7 @@ class responder02Test extends responderTestFramework {
 
 
         ////////////////////
-        // Move 01 - responder003 set swing values: W=4, X=4, T=3
+        // Move 01 - responder003 set swing values: T=3, W=4, X=4
         // responder003 won initiative for round 1. Initial die values: responder003 rolled [d(17):2, Ho(W=4)?:2, q(X=4):3, ^B(T=3,T=3):4, (5):5], responder004 rolled [(20):4, (20):1, (20):15, (20):14, (20):19, (20):11]. responder004's button has the "slow" button special, and cannot win initiative normally.
 
         // this should cause four die rolls (for 3 dice)
@@ -1710,7 +1710,7 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][5]['value'] = 11;
         $expData['playerDataArray'][0]['swingRequestArray'] = array();
         $expData['playerDataArray'][1]['swingRequestArray'] = array();
-        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 set swing values: W=4, X=4, T=3'));
+        array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 set swing values: T=3, W=4, X=4'));
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => '', 'message' => 'responder003 won initiative for round 1. Initial die values: responder003 rolled [dG(17):2, Ho(W=4)?:2, q(X=4):3, ^B(T=3,T=3):4, (5):5], responder004 rolled [(20):4, (20):1, (20):15, (20):14, (20):19, (20):11]. responder004\'s button has the "slow" button special, and cannot win initiative normally.'));
         $expData['gameActionLogCount'] += 2;
 

--- a/tools/api-client/python/replay_loop
+++ b/tools/api-client/python/replay_loop
@@ -165,6 +165,7 @@ def test_new_games():
 def log(message):
   LOGF.write('%s: %s\n' % (
     datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message))
+  LOGF.flush()
 
 ########################################################################
 setup()


### PR DESCRIPTION
* Fixes #2433

The `LOGF.flush()` is unrelated --- it's something i want to get my log updated faster, and have been too lazy to submit a separate pull for it.