### PR TITLE
Get phploc from apt rather than downloading the phar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           command: php /etc/php/7.0/deploy-includes/phpmd.phar ./src xml ./deploy/circleci/pmd/buttonmen.xml --reportfile ./build/logs/pmd.xml
       - run:
           name: Generate phploc.csv
-          command: php /etc/php/7.0/deploy-includes/phploc.phar --log-csv ./build/logs/phploc.csv ./src
+          command: /usr/bin/phploc --log-csv ./build/logs/phploc.csv ./src
       - run:
           name: Aggregate tool output with PHP_CodeBrowser
           command: php /etc/php/7.0/deploy-includes/phpcb.phar --log ./build/logs --source ./src --output ./build/code-browser

--- a/deploy/vagrant/modules/php/manifests/init.pp
+++ b/deploy/vagrant/modules/php/manifests/init.pp
@@ -36,6 +36,7 @@ class php::type::circleci {
     "php-pear": ensure => installed;
     "php-xdebug": ensure => installed;
     "php-xsl": ensure => installed;
+    "phploc": ensure => installed;
   }
 
   exec {
@@ -56,11 +57,6 @@ class php::type::circleci {
     "php_wget_install_phpcpd":
       command => "/usr/bin/wget --no-verbose -O /etc/php/7.0/deploy-includes/phpcpd.phar https://phar.phpunit.de/phpcpd.phar",
       creates => "/etc/php/7.0/deploy-includes/phpcpd.phar",
-      require => File["/etc/php/7.0/deploy-includes"];
-
-    "php_wget_install_phploc":
-      command => "/usr/bin/wget --no-verbose -O /etc/php/7.0/deploy-includes/phploc.phar https://phar.phpunit.de/phploc.phar",
-      creates => "/etc/php/7.0/deploy-includes/phploc.phar",
       require => File["/etc/php/7.0/deploy-includes"];
 
     "php_wget_install_phpcb":


### PR DESCRIPTION
* Fixes #2444 (if it passes circleci)

I could probably safely migrate more of the PHP checking stuff from downloading phar files to apt-get, but i wanted to start with the thing which is actually broken to get a PR in today.