### PR TITLE
Added GWAR set

### DIFF
--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -95,7 +95,8 @@ INSERT INTO buttonset (id, name, sort_order) VALUES
 (65, 'Classic Fanatics', 100000),
 
 # Special
-(10000, 'RandomBM', 200000);
+(10000, 'RandomBM', 200000),
+(20000, 'CustomBM', 20);
 
 
 DELETE FROM button;
@@ -1233,7 +1234,8 @@ INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id, sort_ord
 (10007, 'RandomBMTriskill',   '', 1, 0, (SELECT id FROM buttonset WHERE name="RandomBM"), 70),
 (10008, 'RandomBMTetraskill', '', 1, 0, (SELECT id FROM buttonset WHERE name="RandomBM"), 80),
 (10009, 'RandomBMPentaskill', '', 1, 0, (SELECT id FROM buttonset WHERE name="RandomBM"), 90),
-(10010, 'RandomBMSoldiers',   '', 1, 0, (SELECT id FROM buttonset WHERE name="RandomBM"), 100);
+(10010, 'RandomBMSoldiers',   '', 1, 0, (SELECT id FROM buttonset WHERE name="RandomBM"), 100),
+(11000, 'CustomBM',           '', 0, 0, (SELECT id FROM buttonset WHERE name="CustomBM"), 0);
 
 
 

--- a/deploy/database/updates/00344_custom_recipe_01.sql
+++ b/deploy/database/updates/00344_custom_recipe_01.sql
@@ -1,0 +1,5 @@
+INSERT INTO buttonset (id, name, sort_order)
+VALUES (20000, 'CustomBM', 20);
+
+INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id, flavor_text, sort_order)
+VALUES (11000, 'CustomBM', '', 0, 0, 20000, 'This button has a custom recipe', 0);

--- a/deploy/database/updates/02408_gwar_01.sql
+++ b/deploy/database/updates/02408_gwar_01.sql
@@ -1,0 +1,36 @@
+INSERT INTO buttonset (id, name, sort_order) VALUES
+(9000, 'GWAR', 90000);
+
+INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
+(9001, 'Balsac the Jaws O'' Death', 'M(8) M(12) (20) (P)', 0, 0, 9000),
+(9002, 'Beefcake the Mighty', 'H(6) H(12) (20) (V,V)', 0, 0, 9000),
+(9003, 'Blothar (Berserker Warrior)', '(6) (20) (30) (4/20) `(8) `(12)', 0, 0, 9000),
+(9004, 'Bonesnapper (Cave Troll)', '(4) (6) (8) (20) `(X) `(Y)', 0, 0, 9000),
+(9005, 'Bozo Destructo', 'p(20) p(20) p(20) p(X)', 0, 0, 9000),
+(9006, 'Cardinal Syn', 'g(8) g(8) (8,8) (12) (X)', 0, 0, 9000),
+(9007, 'Dickie Duncan', '(4,4) (6,6) (8,8) (Y,Y)', 0, 0, 9000),
+(9008, 'Dr. Skullheadface', '(X) (X) p(Y) g(Y)', 0, 0, 9000),
+(9009, 'Estrogina', '(6) (8) (T) M(T) `(4) `(8)', 0, 0, 9000),
+(9010, 'Flattus Maximus', '(6) (12) (12) (20) p(X)', 0, 0, 9000),
+(9011, 'Flesh Column', '(Y) (Y) (Y) (Y)', 0, 0, 9000),
+(9012, 'Gor-Gor', '(8) (6,6) (20) p(30) (U)', 0, 0, 9000),
+(9013, 'Jizmac Da''Gusha', 'M(4,4) g(12) (20) (P)', 0, 0, 9000),
+(9014, 'The Master', '(8) (30) (30) (30) (U)', 0, 0, 9000),
+(9015, 'Morality Squad', 'g(4) H(6) (8) (V,V) `(4) `(6)', 0, 0, 9000),
+(9016, 'Mr. Perfect', '(1) (1) M(2) M(3) (V)', 0, 0, 9000),
+(9017, 'Oderus Urungus', '(6) (8) g(8) (12,12) (4/20)', 0, 0, 9000),
+(9018, 'Porcelon (Portal Potty)', '(6) (12) (12) (12)', 0, 0, 9000),
+(9019, 'Pustulus Maximus', 'g(4) (12) g(12) (20) (4/20)', 0, 0, 9000),
+(9020, 'Sawborg Destructo', '(12) (12) (20) (20) p(P)', 0, 0, 9000),
+(9021, 'Scroda Moon', 'b(4) b(4) b(12) b(P)', 0, 0, 9000),
+(9022, 'Sexecutioner', '(6,6) g(12) (X) (X) (X)', 0, 0, 9000),
+(9023, 'Sleazy P. Martini', 'g(4) (20) (X) (X) (X)', 0, 0, 9000),
+(9024, 'Slyminstra Hymen', '(4) (6) (8,8) g(12) o(Y,Y)', 0, 0, 9000),
+(9025, 'Techno Destructo', '(12) (8,8) p(30) p(30) g(4/20)', 0, 0, 9000),
+(9026, 'World Maggot', '(20) (20) (20) (30) (20/30)', 0, 0, 9000);
+
+UPDATE button SET flavor_text="Any Poison dice Oderus captures are scored as standard dice, not as poison dice." WHERE name="Oderus Urungus";
+UPDATE button SET flavor_text="After determining who goes first, Porcelon may \"flush\" one of his opponent's dice, removing it from the game for the round." WHERE name="Porcelon (Portal Potty)";
+UPDATE button SET flavor_text="You may remove one die from your dice pool this round to force your opponent to re-roll one of their dice on your turn before you attack." WHERE name="Scroda Moon";
+UPDATE button SET flavor_text="The Flesh Column's starting dice are based on your opponent's, but one available die size lower. If this cannot be determined, flesh column's starting dice are four \"Y\" swing dice. Swing dice are unaffected and you choose their size." WHERE name="Flesh Column";
+

--- a/deploy/database/updates/02408_gwar_01.sql
+++ b/deploy/database/updates/02408_gwar_01.sql
@@ -1,28 +1,29 @@
 INSERT INTO buttonset (id, name, sort_order) VALUES
 (9000, 'GWAR', 90000);
 
+# I've reserved the IDs for the four excluded buttons in case we add them again later
 INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
 (9001, 'Balsac the Jaws O'' Death', 'M(8) M(12) (20) (P)', 0, 0, 9000),
 (9002, 'Beefcake the Mighty', 'H(6) H(12) (20) (V,V)', 0, 0, 9000),
 (9003, 'Blothar (Berserker Warrior)', '(6) (20) (30) (4/20) `(8) `(12)', 0, 0, 9000),
 (9004, 'Bonesnapper (Cave Troll)', '(4) (6) (8) (20) `(X) `(Y)', 0, 0, 9000),
-(9005, 'Bozo Destructo', 'p(20) p(20) p(20) p(X)', 0, 0, 9000),
+#(9005, 'Bozo Destructo', 'p(20) p(20) p(20) p(X)', 0, 0, 9000),
 (9006, 'Cardinal Syn', 'g(8) g(8) (8,8) (12) (X)', 0, 0, 9000),
 (9007, 'Dickie Duncan', '(4,4) (6,6) (8,8) (Y,Y)', 0, 0, 9000),
 (9008, 'Dr. Skullheadface', '(X) (X) p(Y) g(Y)', 0, 0, 9000),
 (9009, 'Estrogina', '(6) (8) (T) M(T) `(4) `(8)', 0, 0, 9000),
 (9010, 'Flattus Maximus', '(6) (12) (12) (20) p(X)', 0, 0, 9000),
-(9011, 'Flesh Column', '(Y) (Y) (Y) (Y)', 0, 0, 9000),
+#(9011, 'Flesh Column', '(Y) (Y) (Y) (Y)', 0, 0, 9000),
 (9012, 'Gor-Gor', '(8) (6,6) (20) p(30) (U)', 0, 0, 9000),
 (9013, 'Jizmac Da''Gusha', 'M(4,4) g(12) (20) (P)', 0, 0, 9000),
 (9014, 'The Master', '(8) (30) (30) (30) (U)', 0, 0, 9000),
 (9015, 'Morality Squad', 'g(4) H(6) (8) (V,V) `(4) `(6)', 0, 0, 9000),
 (9016, 'Mr. Perfect', '(1) (1) M(2) M(3) (V)', 0, 0, 9000),
 (9017, 'Oderus Urungus', '(6) (8) g(8) (12,12) (4/20)', 0, 0, 9000),
-(9018, 'Porcelon (Portal Potty)', '(6) (12) (12) (12)', 0, 0, 9000),
+#(9018, 'Porcelon (Portal Potty)', '(6) (12) (12) (12)', 0, 0, 9000),
 (9019, 'Pustulus Maximus', 'g(4) (12) g(12) (20) (4/20)', 0, 0, 9000),
 (9020, 'Sawborg Destructo', '(12) (12) (20) (20) p(P)', 0, 0, 9000),
-(9021, 'Scroda Moon', 'b(4) b(4) b(12) b(P)', 0, 0, 9000),
+#(9021, 'Scroda Moon', 'b(4) b(4) b(12) b(P)', 0, 0, 9000),
 (9022, 'Sexecutioner', '(6,6) g(12) (X) (X) (X)', 0, 0, 9000),
 (9023, 'Sleazy P. Martini', 'g(4) (20) (X) (X) (X)', 0, 0, 9000),
 (9024, 'Slyminstra Hymen', '(4) (6) (8,8) g(12) o(Y,Y)', 0, 0, 9000),
@@ -30,7 +31,7 @@ INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
 (9026, 'World Maggot', '(20) (20) (20) (30) (20/30)', 0, 0, 9000);
 
 UPDATE button SET flavor_text="Any Poison dice Oderus captures are scored as standard dice, not as poison dice." WHERE name="Oderus Urungus";
-UPDATE button SET flavor_text="After determining who goes first, Porcelon may \"flush\" one of his opponent's dice, removing it from the game for the round." WHERE name="Porcelon (Portal Potty)";
-UPDATE button SET flavor_text="You may remove one die from your dice pool this round to force your opponent to re-roll one of their dice on your turn before you attack." WHERE name="Scroda Moon";
-UPDATE button SET flavor_text="The Flesh Column's starting dice are based on your opponent's, but one available die size lower. If this cannot be determined, flesh column's starting dice are four \"Y\" swing dice. Swing dice are unaffected and you choose their size." WHERE name="Flesh Column";
+#UPDATE button SET flavor_text="After determining who goes first, Porcelon may \"flush\" one of his opponent's dice, removing it from the game for the round." WHERE name="Porcelon (Portal Potty)";
+#UPDATE button SET flavor_text="You may remove one die from your dice pool this round to force your opponent to re-roll one of their dice on your turn before you attack." WHERE name="Scroda Moon";
+#UPDATE button SET flavor_text="The Flesh Column's starting dice are based on your opponent's, but one available die size lower. If this cannot be determined, flesh column's starting dice are four \"Y\" swing dice. Swing dice are unaffected and you choose their size." WHERE name="Flesh Column";
 

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -124,6 +124,12 @@ class ApiResponder {
             $previousGameId = NULL;
         }
 
+        if (isset($args['customRecipeArray'])) {
+            $customRecipeArray = $args['customRecipeArray'];
+        } else {
+            $customRecipeArray = array();
+        }
+
         $retval = $interface->game()->create_game(
             $playerIdArray,
             $buttonNameArray,
@@ -131,7 +137,8 @@ class ApiResponder {
             $description,
             $previousGameId,
             (int)$_SESSION['user_id'],
-            FALSE
+            FALSE,
+            $customRecipeArray
         );
 
         if (isset($retval)) {

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -154,7 +154,7 @@ class ApiSpec {
                     'elem_type' => array('arg_type' => 'array',
                                          'has_keys' => TRUE,
                                          'minlength' => 0,
-                                         'maxlength' => 2,
+                                         'maxlength' => 3,
                                          'key_type' => 'number',
                                          'elem_type' => 'string'),
                 ),
@@ -166,6 +166,14 @@ class ApiSpec {
                     'maxlength' => self::GAME_DESCRIPTION_MAX_LENGTH,
                 ),
                 'previousGameId' => 'number',
+                'customRecipeArray' => array(
+                    'arg_type' => 'array',
+                    'has_keys' => FALSE,
+                    'minlength' => 0,
+                    'maxlength' => 2,
+                    'key_type' => 'number',
+                    'elem_type' => 'string',
+                ),
             ),
         ),
         'reactToNewGame' => array(

--- a/src/engine/BMDieSwing.php
+++ b/src/engine/BMDieSwing.php
@@ -72,6 +72,7 @@ class BMDieSwing extends BMDie {
      * @var array
      */
     private static $swingRanges = array(
+        "P" => array(1, 30),
         "R" => array(2, 16),
         "S" => array(6, 20),
         "T" => array(2, 12),
@@ -140,7 +141,8 @@ class BMDieSwing extends BMDie {
     public static function create($recipe, array $skills = NULL) {
 
         if (!is_string($recipe) || strlen($recipe) != 1 ||
-            ord("R") > ord($recipe) || ord($recipe) > ord("Z")) {
+            ord("P") > ord($recipe) || ord($recipe) > ord("Z") ||
+            ("Q" == $recipe)) {
             throw new UnexpectedValueException("Invalid recipe: $recipe");
         }
 

--- a/src/ui/js/Newgame.js
+++ b/src/ui/js/Newgame.js
@@ -158,6 +158,14 @@ Newgame.actionCreateGame = function() {
     $('#player1_toggle').click();
   }
 
+  // Make custom button fields visible if a custom button has been selected
+  if ('__custom' == Newgame.activity.playerButton) {
+    $('#player_custom_recipe').parent().children().show();
+  }
+  if ('__custom' == Newgame.activity.opponentButton) {
+    $('#opponent_custom_recipe').parent().children().show();
+  }
+
   // activate all Chosen comboboxes
   $('.chosen-select').chosen({ search_contains: true });
 };
@@ -390,6 +398,12 @@ Newgame.createButtonOptionsTable = function() {
   selectRow.append(Newgame.getButtonSelectTd('opponent', true));
   buttonOptionsTable.append(selectRow);
 
+  // custom button recipe row
+  var customRow = $('<tr>');
+  customRow.append(Newgame.getCustomRecipeTd('player'));
+  customRow.append(Newgame.getCustomRecipeTd('opponent'));
+  buttonOptionsTable.append(customRow);
+
   return buttonOptionsTable;
 };
 
@@ -408,7 +422,9 @@ Newgame.formCreateGame = function() {
 
   Newgame.activity.opponentName = $('#opponent_name').val();
   Newgame.activity.playerButton = $('#player_button').val();
+  Newgame.activity.playerCustomRecipe = $('#player_custom_recipe').val();
   Newgame.activity.opponentButton = $('#opponent_button').val();
+  Newgame.activity.opponentCustomRecipe = $('#opponent_custom_recipe').val();
   Newgame.activity.nRounds = $('#n_rounds').val();
   Newgame.activity.description = $('#description').val();
 
@@ -424,6 +440,13 @@ Newgame.formCreateGame = function() {
     } else {
       errorMessage = 'Please select a button for yourself.';
     }
+  } else if (Newgame.activity.playerButton == '__custom' &&
+    !Newgame.activity.playerCustomRecipe) {
+    if ($('#player_name').length) {
+      errorMessage = 'Please enter a custom recipe for player 1';
+    } else {
+      errorMessage = 'Please enter a custom recipe for yourself.';
+    }
   } else if (Newgame.activity.opponentName &&
     !(Newgame.activity.opponentName in Api.player.list)) {
     errorMessage =
@@ -433,6 +456,11 @@ Newgame.formCreateGame = function() {
     !Newgame.activity.opponentButton) {
     errorMessage =
       'Please select a button for ' + Newgame.activity.opponentName;
+  } else if (Newgame.activity.opponentName &&
+    Newgame.activity.opponentButton == '__custom' &&
+    !Newgame.activity.opponentCustomRecipe) {
+    errorMessage =
+      'Please enter a custom recipe for ' + Newgame.activity.opponentName;
   }
 
   if (errorMessage.length) {
@@ -447,10 +475,12 @@ Newgame.formCreateGame = function() {
     playerInfoArray[0] = [
       Newgame.activity.playerName,
       Newgame.activity.playerButton,
+      Newgame.activity.playerCustomRecipe,
     ];
     playerInfoArray[1] = [
       Newgame.activity.opponentName,
       Newgame.activity.opponentButton,
+      Newgame.activity.opponentCustomRecipe,
     ];
 
     var args =
@@ -463,6 +493,16 @@ Newgame.formCreateGame = function() {
     if (Newgame.activity.previousGameId) {
       args.previousGameId = Newgame.activity.previousGameId;
     }
+
+    var customRecipeArray = [];
+    if (Newgame.activity.playerCustomRecipe) {
+      customRecipeArray[0] = Newgame.activity.playerCustomRecipe;
+    }
+    if (Newgame.activity.opponentCustomRecipe) {
+      customRecipeArray[1] = Newgame.activity.opponentCustomRecipe;
+    }
+
+    args.customRecipeArray = customRecipeArray;
 
     // N.B. Newgame.activity is always retained between loads: on
     // failure so the player can correct selections, on success in
@@ -559,17 +599,19 @@ Newgame.getSelectRow = function(rowname, selectname, valuedict,
 
   var selectTd = Newgame.getSelectTd(rowname, selectname, valuedict,
                                      greydict, selectedval, isComboBox,
-                                     blankOption);
+                                     null, blankOption);
 
   selectRow.append(selectTd);
   return selectRow;
 };
 
 Newgame.getSelectTd = function(nametext, selectname, valuedict,
-                               greydict, selectedval, isComboBox, blankOption) {
+                               greydict, selectedval, isComboBox,
+                               onChangeEvent, blankOption) {
   var select = $('<select>', {
     'id': selectname,
     'name': selectname,
+    'onchange': onChangeEvent,
   });
 
   if (isComboBox) {
@@ -628,6 +670,31 @@ Newgame.getSelectOptionList = function(
   return optionlist;
 };
 
+Newgame.getCustomRecipeTd = function(player) {
+  var inputFieldName = player + '_custom_recipe';
+  var currentValue =
+    (player == 'player' ?
+    Newgame.activity.playerCustomRecipe :
+    Newgame.activity.opponentCustomRecipe);
+
+  var customRecipeInput = $('<input>', {
+    'id': inputFieldName,
+    'name': inputFieldName,
+    'type': 'text',
+    'val': currentValue,
+    'style': 'display: none;',
+  });
+
+  var customRecipeTd = $('<td>');
+  customRecipeTd.append($('<span>', {
+    'text': 'Custom Recipe: ',
+    'style': 'display: none;',
+  }));
+  customRecipeTd.append(customRecipeInput);
+
+  return customRecipeTd;
+};
+
 Newgame.getButtonSelectTd = function(player, isComboBox) {
   if (player == 'player') {
     return Newgame.getSelectTd(
@@ -636,7 +703,8 @@ Newgame.getButtonSelectTd = function(player, isComboBox) {
       Newgame.activity.buttonList.player,
       Newgame.activity.buttonGreyed,
       Newgame.activity.playerButton,
-      isComboBox);
+      isComboBox,
+      'Newgame.reactToButtonChange("' + player + '", $(this).val())');
   } else if (Newgame.activity.buttonLimits.opponent.button_sets.ANY &&
       Newgame.activity.buttonLimits.opponent.tourn_legal.ANY &&
       Newgame.activity.buttonLimits.opponent.die_skills.ANY) {
@@ -647,6 +715,7 @@ Newgame.getButtonSelectTd = function(player, isComboBox) {
       Newgame.activity.buttonGreyed,
       Newgame.activity.opponentButton,
       isComboBox,
+     'Newgame.reactToButtonChange("' + player + '", $(this).val())',
      'Any button');
   } else {
     return Newgame.getSelectTd(
@@ -717,6 +786,7 @@ Newgame.updateButtonList = function(player, limitid) {
       Newgame.activity.buttonLimits[player].die_skills.ANY) {
     Newgame.activity.buttonList[player] = {
       '__random': 'Random button',
+      '__custom': 'Custom recipe',
     };
   } else {
     Newgame.activity.buttonList[player] = {};
@@ -765,6 +835,12 @@ Newgame.updateButtonList = function(player, limitid) {
       }
     }
 
+    // remove CustomBM explicitly, since this is handled under the
+    // special button name '__custom'
+    if ('CustomBM' == button) {
+      return true;
+    }
+
     Newgame.activity.buttonList[player][button] =
       Newgame.activity.buttonRecipe[button];
   });
@@ -772,6 +848,17 @@ Newgame.updateButtonList = function(player, limitid) {
   // if we're updating an existing button select dropdown, change it now
   if (limitid) {
     Newgame.updateButtonSelectTd(player);
+  }
+};
+
+Newgame.reactToButtonChange = function(player, button) {
+  var customRecipeControls =
+    $('#' + player + '_custom_recipe').parent().children();
+
+  if (button == '__custom') {
+    customRecipeControls.show();
+  } else {
+    customRecipeControls.hide();
   }
 };
 

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -472,7 +472,7 @@ class responder00Test extends responderTestFramework {
         $retval = $this->verify_api_success($args);
         $this->assertEquals($retval['status'], 'ok');
         $this->assertEquals($retval['message'], 'Button data retrieved successfully.');
-        $this->assertEquals(count($retval['data']), 783);
+        $this->assertEquals(count($retval['data']), 784);
 
         $this->cache_json_api_output('loadButtonData', 'noargs', $retval);
     }
@@ -528,7 +528,7 @@ class responder00Test extends responderTestFramework {
         $retval = $this->verify_api_success($args);
         $this->assertEquals($retval['status'], 'ok');
         $this->assertEquals($retval['message'], 'Button set data retrieved successfully.');
-        $this->assertEquals(count($retval['data']), 82);
+        $this->assertEquals(count($retval['data']), 83);
 
         $this->cache_json_api_output('loadButtonSetData', 'noargs', $retval);
     }

--- a/test/src/ui/js/test_Newgame.js
+++ b/test/src/ui/js/test_Newgame.js
@@ -640,7 +640,8 @@ test("test_Newgame.getSelectTd", function(assert) {
     'test_select',
     { 'a': 'First Value', 'b': 'Second Value', },
     { 'b': true, },
-    'a');
+    'a',
+    null);
   assert.equal(item[0].tagName, "TD", "Return value is of type td");
 });
 
@@ -652,6 +653,10 @@ test("test_Newgame.getSelectOptionList", function(assert) {
     'a');
   assert.equal(optionlist[0].html(), "First Value",
         "Element in option list has expected value");
+});
+
+test("test_Newgame.getCustomRecipeTd", function(assert) {
+  // currently empty
 });
 
 test("test_Newgame.getButtonSelectTd", function(assert) {
@@ -859,6 +864,10 @@ test("test_Newgame.getButtonLimitTd_prevvals", function(assert) {
   });
   assert.deepEqual(foundLabels, { 'ANY': 1, 'A': 1, 'B C': 1, },
     "Expected set of option labels was found");
+});
+
+test("test_Newgame.reactToButtonChange", function(assert) {
+  // currently empty
 });
 
 test("test_Newgame.getButtonLimitRow", function(assert) {


### PR DESCRIPTION
Addresses #2408.

This is a tidied version of #2409, including the four missing buttons mentioned in my post [here](https://github.com/buttonmen-dev/buttonmen/issues/2408#issuecomment-480589012). Also, all button special flags have been set to zero, to allow Nala to test these buttons.

Since we're not going to be integrating the GWAR set into the production site, all button recipes are present in one database update file, 02408_gwar_01.sql (but not in data.button.sql).

The CustomBM database changes for using arbitrary test recipes are found in 00344_custom_recipe_01.sql.