### PR TITLE
Exclude some common unimportant error log messages

### DIFF
--- a/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
+++ b/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
@@ -10,4 +10,6 @@
   | grep -v " not found or unable to stat" \
   | grep -v " Graceful restart requested, doing restart" \
   | grep -v " resuming normal operations" \
-  | grep -v "client denied by server configuration: /var/www/database/"
+  | grep -v "client denied by server configuration: " \
+  | grep -v "AH00094: Command line: '/usr/sbin/apache2'" \
+  | grep -v "client sent HTTP/1.1 request without hostname"


### PR DESCRIPTION
This is to reverse some bitrot in the amount of noise e-mail i've been getting from buttonmen apache error logs, to make scanning them for real errors less time-consuming.

I tested the recipe on some live dev sites that have been spamming me, and verified that the greps work to remove the messages they're targeting.