### PR TITLE
On AWS instances, emit cloudwatch metric entries recording API call success

### DIFF
--- a/deploy/vagrant/manifests/init.pp
+++ b/deploy/vagrant/manifests/init.pp
@@ -59,4 +59,11 @@ node default {
   include "php::base"
   include "mysql::server"  
   include "buttonmen::server"
+
+  # location-specific configuration
+  case "${ec2_services_partition}" {
+    "aws": {
+      include "cloudwatch::buttonmen-site"
+    }
+  }
 }

--- a/deploy/vagrant/modules/cloudwatch/manifests/init.pp
+++ b/deploy/vagrant/modules/cloudwatch/manifests/init.pp
@@ -1,0 +1,20 @@
+class cloudwatch::buttonmen-site {
+  package {
+    "awscli": ensure => installed;
+  }
+
+  file {
+    # Install script to record cloudwatch metrics based on recent site API accesses
+    "/usr/local/bin/record_buttonmen_cloudwatch_metrics":
+      ensure => file,
+      content => template("cloudwatch/record_buttonmen_metrics.erb"),
+      mode => 0555;
+  }
+
+  # Record cloudwatch metrics from apache logs every five minutes
+  cron {
+    "record_buttonmen_cloudwatch_metrics":
+      command => "/usr/local/bin/record_buttonmen_cloudwatch_metrics ${ec2_instance_id} ${ec2_placement_region}",
+      minute => '*/5';
+  }
+}

--- a/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
+++ b/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+##### Script to record cloudwatch metrics for buttonmen site
+
+import subprocess
+import sys
+
+INSTANCE_ID = sys.argv[1]
+REGION = sys.argv[2]
+
+ACCESS_LOG = '/var/log/apache2/access.log'
+LOGTAIL_LOG = '/var/spool/logtail/apache2_access_cloudwatch.log'
+
+def parse_line_as_responder_post(line):
+  if not 'POST /api/responder ' in line:
+    return None, None
+  words = line.split()
+  assert words[-2].startswith('BMAPI=')
+  bmapi = words[-2].split('=')[1]
+  assert words[-1].startswith('BMStatus=')
+  bmsuccess = words[-1].split('=')[1] == 'ok'
+  return bmapi, bmsuccess
+
+def emit_cloudwatch_metric(bmapi, bmsuccess):
+  cmdargs = [
+    '/usr/bin/aws', 'cloudwatch', 'put-metric-data',
+    '--metric-name', 'bmapi_success',
+    '--dimensions', 'Instance=%s,BMAPI=%s' % (INSTANCE_ID, bmapi),
+    '--namespace', '"Custom"',
+    '--value', "1" if bmsuccess else "0",
+    '--region', REGION,
+  ]
+  print cmdargs
+  subprocess.check_call(cmdargs)
+
+def get_recent_access_log_entries():
+  output = subprocess.check_output([
+    '/usr/sbin/logtail',
+    '-o', LOGTAIL_LOG,
+    ACCESS_LOG,
+  ])
+  for line in output.split('\n'):
+    bmapi, bmsuccess = parse_line_as_responder_post(line)
+    if bmapi is None: continue
+    emit_cloudwatch_metric(bmapi, bmsuccess)
+
+get_recent_access_log_entries()


### PR DESCRIPTION
This is a very simple implementation of site health metrics using cloudwatch:
* On non-AWS sites, this does nothing
* On AWS sites, it installs aws-cli (used to record metrics)
* Every five minutes, it:
    * Uses logtail to find new entries in the apache access log
    * Looks for entries which are POSTs to /api/responder
    * Parses out from each entry what the API call was, and whether it succeeded
    * Emits a metric whose value is the success (1 on success, 0 on failure), and whose dimensions are the instance ID (which effectively tells us what buttonmen site it is) and the API call in use (just in case this is interesting)

This should be enough to allow us to alarm on whether a site hasn't seen any traffic in awhile, and on whether call success rate is low, whatever proves useful to us.
