### PR TITLE
Fixed PHP warning caused by incorrect bracketing

### DIFF
--- a/src/engine/BMUtilityXCYIterator.php
+++ b/src/engine/BMUtilityXCYIterator.php
@@ -98,7 +98,7 @@ class BMUtilityXCYIterator implements Iterator {
         $this->tail = NULL;
 
         $this->head = array_pop($this->list);
-        if (count($this->list > 0) && $this->depth > 1) {
+        if ((count($this->list) > 0) && ($this->depth > 1)) {
             $this->tail = new BMUtilityXCYIterator($this->list, $this->depth - 1);
         }
         if ($this->tail) {


### PR DESCRIPTION
Fixes #2591.

I *think* I understand why this hasn't caused any trouble, but I'm not entirely sure. My thinking is the following:

The bad code is

    if (count(array > 0) && ...) {...}

and the fixed code is

    if ((count(array) > 0) && ...) {...}

If you think about it,

    array > 0

produces an array of logicals, so

    count(array > 0)

is just the same as

    count(array)

and since this is in an 'if' statement, it gets converted to a logical, meaning that it's equivalent to

    count(array) > 0


However, if I could have this wrong.

Anyway, I'll let the unit tests have the last word. 