### PR TITLE
use ec2_placement_availability_zone fact, because ec2_placement_region is not always available

### DIFF
--- a/deploy/vagrant/modules/cloudwatch/manifests/init.pp
+++ b/deploy/vagrant/modules/cloudwatch/manifests/init.pp
@@ -14,7 +14,7 @@ class cloudwatch::buttonmen-site {
   # Record cloudwatch metrics from apache logs every five minutes
   cron {
     "record_buttonmen_cloudwatch_metrics":
-      command => "/usr/local/bin/record_buttonmen_cloudwatch_metrics ${ec2_instance_id} ${ec2_placement_region}",
+      command => "/usr/local/bin/record_buttonmen_cloudwatch_metrics ${ec2_instance_id} ${ec2_placement_availability_zone}",
       minute => '*/5';
   }
 }

--- a/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
+++ b/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
@@ -4,8 +4,14 @@
 import subprocess
 import sys
 
+def parse_arg_as_region(regionish):
+  # Argument may be an availability zone
+  if regionish[-1].isalpha():
+    return regionish[:-1]
+  return regionish
+
 INSTANCE_ID = sys.argv[1]
-REGION = sys.argv[2]
+REGION = parse_arg_as_region(sys.argv[2])
 
 ACCESS_LOG = '/var/log/apache2/access.log'
 LOGTAIL_LOG = '/var/spool/logtail/apache2_access_cloudwatch.log'


### PR DESCRIPTION
When i pushed the changes to staging, i started getting these cron failure e-mails:

```
Traceback (most recent call last):
  File "/usr/local/bin/record_buttonmen_cloudwatch_metrics", line 8, in <module>
    REGION = sys.argv[2]
IndexError: list index out of range
```

on bmstaging:

```
$ facter ec2_placement_region

$ facter ec2_placement_availability_zone
us-east-1a
```

(vs on the dev site where i tested this code initially:

```
$ facter ec2_placement_region
us-east-1
$ facter ec2_placement_availability_zone
us-east-1c
```

So... fine.  Hand the AZ to the script and have the script chop it off.