### PR TITLE
Remove debugging statements from cron jobs

### DIFF
--- a/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
+++ b/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
@@ -35,7 +35,6 @@ def emit_cloudwatch_metric(bmapi, bmsuccess):
     '--value', "1" if bmsuccess else "0",
     '--region', REGION,
   ]
-  print cmdargs
   subprocess.check_call(cmdargs)
 
 def get_recent_access_log_entries():


### PR DESCRIPTION
I just made this change by hand on staging and prod because to do otherwise would be ridiculous, but here it is in the codebase.