### PR TITLE
Make bmsite cloudwatch metrics more user-friendly for production use

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -63,6 +63,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # firewall settings
     aws.security_groups = ["buttonmen-dev"]
+    aws.iam_instance_profile_name = "ec2_instance_perms"
 
     aws.instance_type = "t1.micro"
     aws.ami = "ami-0735ea082a1534cac"

--- a/deploy/vagrant/modules/cloudwatch/manifests/init.pp
+++ b/deploy/vagrant/modules/cloudwatch/manifests/init.pp
@@ -1,6 +1,7 @@
 class cloudwatch::buttonmen-site {
   package {
     "awscli": ensure => installed;
+    "python-boto": ensure => installed;
   }
 
   file {
@@ -14,7 +15,7 @@ class cloudwatch::buttonmen-site {
   # Record cloudwatch metrics from apache logs every five minutes
   cron {
     "record_buttonmen_cloudwatch_metrics":
-      command => "/usr/local/bin/record_buttonmen_cloudwatch_metrics ${ec2_instance_id} ${ec2_placement_availability_zone}",
+      command => "/usr/bin/timeout 15s /usr/local/bin/record_buttonmen_cloudwatch_metrics ${ec2_instance_id} ${ec2_placement_availability_zone}",
       minute => '*/5';
   }
 }

--- a/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
+++ b/deploy/vagrant/modules/cloudwatch/templates/record_buttonmen_metrics.erb
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 ##### Script to record cloudwatch metrics for buttonmen site
 
+import boto.ec2.cloudwatch
 import subprocess
 import sys
 
@@ -16,6 +17,8 @@ REGION = parse_arg_as_region(sys.argv[2])
 ACCESS_LOG = '/var/log/apache2/access.log'
 LOGTAIL_LOG = '/var/spool/logtail/apache2_access_cloudwatch.log'
 
+NAMESPACE = 'BMSite'
+
 def parse_line_as_responder_post(line):
   if not 'POST /api/responder ' in line:
     return None, None
@@ -26,18 +29,22 @@ def parse_line_as_responder_post(line):
   bmsuccess = words[-1].split('=')[1] == 'ok'
   return bmapi, bmsuccess
 
-def emit_cloudwatch_metric(bmapi, bmsuccess):
-  cmdargs = [
-    '/usr/bin/aws', 'cloudwatch', 'put-metric-data',
-    '--metric-name', 'bmapi_success',
-    '--dimensions', 'Instance=%s,BMAPI=%s' % (INSTANCE_ID, bmapi),
-    '--namespace', '"Custom"',
-    '--value', "1" if bmsuccess else "0",
-    '--region', REGION,
-  ]
-  subprocess.check_call(cmdargs)
+def emit_cloudwatch_metrics(conn, name, api_counts):
+  for api, count in sorted(api_counts.items()):
+    conn.put_metric_data(
+      NAMESPACE, name,
+      value=count,
+      dimensions={'Instance': INSTANCE_ID, 'BMAPI': api})
+  # Emit a non-dimensional metric for the sum, with a different
+  # name to avoid double-counting
+  conn.put_metric_data(
+    NAMESPACE, 'total_' + name,
+    value=sum(api_counts.values()),
+    dimensions={'Instance': INSTANCE_ID})
 
 def get_recent_access_log_entries():
+  api_calls = {}
+  api_failures = {}
   output = subprocess.check_output([
     '/usr/sbin/logtail',
     '-o', LOGTAIL_LOG,
@@ -46,6 +53,14 @@ def get_recent_access_log_entries():
   for line in output.split('\n'):
     bmapi, bmsuccess = parse_line_as_responder_post(line)
     if bmapi is None: continue
-    emit_cloudwatch_metric(bmapi, bmsuccess)
+    api_calls.setdefault(bmapi, 0)
+    api_calls[bmapi] += 1
+    if not bmsuccess:
+      api_failures.setdefault(bmapi, 0)
+      api_failures[bmapi] += 1
+  return api_calls, api_failures
 
-get_recent_access_log_entries()
+conn = boto.ec2.cloudwatch.connect_to_region(REGION)
+api_calls, api_failures = get_recent_access_log_entries()
+emit_cloudwatch_metrics(conn, 'api_calls', api_calls)
+emit_cloudwatch_metrics(conn, 'api_failures', api_failures)


### PR DESCRIPTION
* Use boto instead of awscli so we're not spawning a process per metric
* Emit a sum per API call type, rather than one metric per individual call
* Emit a total metric and a failure metric, so we can look at load and at failures
* Emit a total, which will be zero if there are no calls in that interval
* Timeout the entire cron job if it's not done in 15 seconds
* Actually set the IAM role for new AWS instances (so dev/replay instances can emit cloudwatch metrics at all)

This partially addresses #2536 and is the same change as #2605 (so you can see the graphs there for what the behavior looks like), just in a clean branch for git merge laziness reasons.