### PR TITLE
Added flag HasJustBeenMoody to mood dice that have just attacked

### DIFF
--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -839,6 +839,11 @@ class BMDie extends BMCanHaveSkill {
             $actionLogInfo['hasJustTurboed'] = $this->flagList['HasJustTurboed']->value();
         }
 
+        if ($this->has_flag('HasJustBeenMoody')) {
+            $actionLogInfo['hasJustBeenMoody'] =
+                $this->flagList['HasJustBeenMoody']->value();
+        }
+
         if ($this->has_flag('HasJustRerolledOrnery')) {
             $actionLogInfo['hasJustRerolledOrnery'] = TRUE;
         }

--- a/src/engine/BMFlagHasJustBeenMoody.php
+++ b/src/engine/BMFlagHasJustBeenMoody.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * BMFlagHasJustBeenMoody: Used to signal that a die has been subject to mood/mad
+ *
+ * @author: james
+ */
+
+/**
+ * This class is a flag that signals that a die has potentially changed size
+ * due to mood or mad.
+ * It stores the initial die recipe for logging purposes.
+ */
+class BMFlagHasJustBeenMoody extends BMFlag {
+    /**
+     * Initial die recipe before changing size, stored in flag
+     *
+     * @var string
+     */
+    protected $preChangeRecipe;
+
+    /**
+     * Value stored in flag
+     *
+     * @return mixed
+     */
+    public function value() {
+        return $this->preChangeRecipe;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param string $recipe
+     */
+    public function __construct($recipe) {
+        $this->preChangeRecipe = NULL;
+        if (isset($recipe)) {
+            $this->preChangeRecipe = $recipe;
+        }
+    }
+
+    /**
+     * Convert to string.
+     *
+     * @return string
+     */
+    public function __toString() {
+        $string = $this->type();
+        if (!empty($this->preChangeRecipe)) {
+            $string .= '__' . $this->preChangeRecipe;
+        }
+
+        return $string;
+    }
+}

--- a/src/engine/BMSkillMood.php
+++ b/src/engine/BMSkillMood.php
@@ -36,8 +36,10 @@ class BMSkillMood extends BMSkill {
         $newSwingValue = $validSwingValueArray[$randIdx];
 
         if ($die instanceof BMDieSwing) {
+            $die->add_flag('HasJustBeenMoody', $die->get_recipe(TRUE));
             $die->max = $newSwingValue;
         } elseif ($die instanceof BMDieTwin) {
+            $die->add_flag('HasJustBeenMoody', $die->get_recipe(TRUE));
             foreach ($die->dice as $subdie) {
                 if ($subdie instanceof BMDieSwing) {
                     $subdie->max = $newSwingValue;

--- a/test/src/api/responder01Test.php
+++ b/test/src/api/responder01Test.php
@@ -1805,8 +1805,11 @@ class responder01Test extends responderTestFramework {
         $expData['playerDataArray'][0]['activeDieArray'][2]['value'] = 10;
         $expData['playerDataArray'][0]['activeDieArray'][3]['value'] = 3;
         $expData['playerDataArray'][0]['activeDieArray'][4]['value'] = 10;
-        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array('HasJustRerolledOrnery');
-        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array('HasJustRerolledOrnery');
+        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array('HasJustBeenMoody', 'HasJustRerolledOrnery');
+        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array('HasJustBeenMoody', 'HasJustRerolledOrnery');
+        $expData['playerDataArray'][0]['activeDieArray'][2]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][0]['activeDieArray'][3]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][0]['activeDieArray'][4]['properties'] = array('HasJustBeenMoody');
         $expData['playerDataArray'][0]['capturedDieArray'][] =
             array('value' => 9, 'sides' => '10', 'recipe' => 'o(X)?', 'properties' => array('WasJustCaptured'));
         array_splice($expData['playerDataArray'][1]['activeDieArray'], 2, 1);
@@ -1855,8 +1858,15 @@ class responder01Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][1]['value'] = 5;
         $expData['playerDataArray'][1]['activeDieArray'][2]['value'] = 3;
         $expData['playerDataArray'][1]['activeDieArray'][3]['value'] = 18;
-        $expData['playerDataArray'][1]['activeDieArray'][1]['properties'] = array('HasJustRerolledOrnery');
-        $expData['playerDataArray'][1]['activeDieArray'][2]['properties'] = array('HasJustRerolledOrnery');
+        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array();
+        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array();
+        $expData['playerDataArray'][0]['activeDieArray'][2]['properties'] = array();
+        $expData['playerDataArray'][0]['activeDieArray'][3]['properties'] = array();
+        $expData['playerDataArray'][0]['activeDieArray'][4]['properties'] = array();
+        $expData['playerDataArray'][1]['activeDieArray'][0]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][1]['activeDieArray'][1]['properties'] = array('HasJustBeenMoody', 'HasJustRerolledOrnery');
+        $expData['playerDataArray'][1]['activeDieArray'][2]['properties'] = array('HasJustBeenMoody', 'HasJustRerolledOrnery');
+        $expData['playerDataArray'][1]['activeDieArray'][3]['properties'] = array('HasJustBeenMoody');
         array_splice($expData['playerDataArray'][0]['activeDieArray'], 2, 1);
         $expData['playerDataArray'][1]['capturedDieArray'][] =
             array('value' => 10, 'sides' => '20', 'recipe' => 'o(X)?', 'properties' => array('WasJustCaptured'));
@@ -1889,8 +1899,14 @@ class responder01Test extends responderTestFramework {
         $expData['playerDataArray'][1]['roundScore'] = 35;
         $expData['playerDataArray'][0]['sideScore'] = 16.7;
         $expData['playerDataArray'][1]['sideScore'] = -16.7;
+        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][0]['activeDieArray'][2]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][0]['activeDieArray'][3]['properties'] = array('HasJustBeenMoody');
+        $expData['playerDataArray'][1]['activeDieArray'][0]['properties'] = array();
         $expData['playerDataArray'][1]['activeDieArray'][1]['properties'] = array();
         $expData['playerDataArray'][1]['activeDieArray'][2]['properties'] = array();
+        $expData['playerDataArray'][1]['activeDieArray'][3]['properties'] = array();
         $expData['playerDataArray'][1]['capturedDieArray'][0]['properties'] = array();
         $expData['playerDataArray'][0]['activeDieArray'][0]['sides'] = 10;
         $expData['playerDataArray'][0]['activeDieArray'][1]['sides'] = 12;

--- a/test/src/api/responder02Test.php
+++ b/test/src/api/responder02Test.php
@@ -418,7 +418,7 @@ class responder02Test extends responderTestFramework {
         $this->update_expected_data_after_normal_attack(
             $expData, 0, array('Power', 'Skill', 'Speed', 'Trip'),
             array(17, 35, -12.0, 12.0),
-            array(array(1, 4, array('value' => 4, 'sides' => 16, 'properties' => array('Twin'), 'description' => 'Shadow Twin R Mood Swing Die (both with 8 sides)', 'subdieArray' => array(array('sides' => 8, 'value' => 1), array('sides' => 8, 'value' => 3))))),
+            array(array(1, 4, array('value' => 4, 'sides' => 16, 'properties' => array('HasJustBeenMoody', 'Twin'), 'description' => 'Shadow Twin R Mood Swing Die (both with 8 sides)', 'subdieArray' => array(array('sides' => 8, 'value' => 1), array('sides' => 8, 'value' => 3))))),
             array(array(0, 4)),
             array(),
             array(array(1, array('value' => 3, 'sides' => 20, 'recipe' => 'sF(20)')))
@@ -1541,7 +1541,7 @@ class responder02Test extends responderTestFramework {
         $this->update_expected_data_after_normal_attack(
             $expData, 1, array('Power', 'Skill', 'Trip'),
             array(7.5, 31.5, -16.0, 16.0),
-            array(array(0, 1, array('value' => 9, 'sides' => '10', 'description' => 'Poison X Mood Swing Die (with 10 sides)')),
+            array(array(0, 1, array('value' => 9, 'properties' => array('HasJustBeenMoody'), 'sides' => '10', 'description' => 'Poison X Mood Swing Die (with 10 sides)')),
                   array(0, 2, array('value' => 1, 'properties' => array('HasJustRerolledOrnery')))),
             array(array(1, 3)),
             array(array(1, 0)),
@@ -1574,6 +1574,7 @@ class responder02Test extends responderTestFramework {
             $expData, 0, array('Power', 'Skill'),
             array(5, 36.5, -21.0, 21.0),
             array(array(1, 0, array('value' => 5)),
+                  array(0, 1, array('properties' => array())),
                   array(0, 2, array('properties' => array()))),
             array(array(0, 4)),
             array(array(0, 0)),
@@ -1730,7 +1731,7 @@ class responder02Test extends responderTestFramework {
         $this->update_expected_data_after_normal_attack(
             $expData, 1, array('Power', 'Skill'),
             array(42, 50, -5.3, 5.3),
-            array(array(0, 1, array('value' => 8, 'sides' => 12, 'description' => 'Mighty Ornery W Mood Swing Die (with 12 sides)', 'properties' => array('HasJustGrown', 'HasJustRerolledOrnery'))),
+            array(array(0, 1, array('value' => 8, 'sides' => 12, 'description' => 'Mighty Ornery W Mood Swing Die (with 12 sides)', 'properties' => array('HasJustBeenMoody', 'HasJustGrown', 'HasJustRerolledOrnery'))),
                   array(0, 3, array('value' => 3))),
             array(array(1, 0)),
             array(),
@@ -2905,6 +2906,7 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][0]['waitingOnAction'] = false;
         $expData['playerDataArray'][1]['activeDieArray'][4]['description'] = "Y Mad Swing Die (with 6 sides)";
         $expData['playerDataArray'][1]['activeDieArray'][4]['sides'] = 6;
+        $expData['playerDataArray'][1]['activeDieArray'][4]['properties'] = array('HasJustBeenMoody');
         $expData['playerDataArray'][1]['roundScore'] = 18;
         $expData['playerDataArray'][1]['sideScore'] = 0.3;
         $expData['playerDataArray'][1]['waitingOnAction'] = true;
@@ -2930,6 +2932,7 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][0]['sideScore'] = -10.3;
         $expData['playerDataArray'][0]['waitingOnAction'] = true;
         $expData['playerDataArray'][1]['activeDieArray'][1]['value'] = 4;
+        $expData['playerDataArray'][1]['activeDieArray'][4]['properties'] = array();
         $expData['playerDataArray'][1]['capturedDieArray'][0]['properties'] = array("WasJustCaptured");
         $expData['playerDataArray'][1]['capturedDieArray'][0]['recipe'] = "(10)";
         $expData['playerDataArray'][1]['capturedDieArray'][0]['sides'] = 10;

--- a/test/src/api/responder03Test.php
+++ b/test/src/api/responder03Test.php
@@ -480,7 +480,7 @@ class responder03Test extends responderTestFramework {
         $expData['playerDataArray'][0]['activeDieArray'][1]['sides'] = 20;
         $expData['playerDataArray'][0]['activeDieArray'][1]['value'] = 15;
         $expData['playerDataArray'][0]['activeDieArray'][1]['skills'] = array('Shadow', 'Trip', 'Mood');
-        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array('JustPerformedTripAttack');
+        $expData['playerDataArray'][0]['activeDieArray'][1]['properties'] = array('HasJustBeenMoody', 'JustPerformedTripAttack');
         $expData['playerDataArray'][0]['activeDieArray'][1]['recipe'] = 'st(S)?';
         $expData['playerDataArray'][0]['activeDieArray'][1]['description'] = 'Shadow Trip S Mood Swing Die (with 20 sides)';
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 performed Trip attack using [Gst(S=6)?:1] against [(20):20]; Attacker Gst(S=6)? remained the same size, recipe changed from Gst(S=6)? to Gst(S=20)?, rerolled 1 => 15; Defender (20) rerolled 20 => 4, was captured'));

--- a/test/src/engine/BMFlagHasJustBeenMoodyTest.php
+++ b/test/src/engine/BMFlagHasJustBeenMoodyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+class BMFlagHasJustBeenMoodyTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * @covers BMFlagHasJustBeenMoody::__construct
+     * @covers BMFlagHasJustBeenMoody::value
+     */
+    public function testConstruct() {
+        $flag = BMFlag::create_from_string('HasJustBeenMoody__p(X=6)?');
+        $this->assertInstanceOf('BMFlagHasJustBeenMoody', $flag);
+        $this->assertEquals('p(X=6)?', $flag->value());
+    }
+
+    /**
+     * @covers BMFlagHasJustBeenMoody::__toString
+     * @covers BMFlagHasJustBeenMoody::__toString
+     */
+    public function testToString() {
+        $flag = BMFlag::create_from_string('HasJustBeenMoody__p(X=6)?');
+        $this->assertEquals('HasJustBeenMoody__p(X=6)?', strval($flag));
+    }
+}


### PR DESCRIPTION
This is the first component extracted from pull request #1675. It simply adds the flag HasJustBeenMoody, which will be used for correctly logging mood die size changes.