### PR TITLE
Fix truthiness check on auxiliary and reserve adds to work with buttons whose first die is +/r

### DIFF
--- a/tools/api-client/python/lib/bmapi.py
+++ b/tools/api-client/python/lib/bmapi.py
@@ -243,22 +243,22 @@ class BMClient():
     }
     return self._make_request(args)
 
-  def choose_reserve_dice(self, gameId, action, dieIdx):
+  def choose_reserve_dice(self, gameId, action, dieIdx=None):
     args = {
       'type': 'reactToReserve',
       'game': gameId,
       'action': action,
     }
-    if dieIdx:
+    if dieIdx is not None:
       args['dieIdx'] = dieIdx
     return self._make_request(args)
 
-  def choose_auxiliary_dice(self, gameId, action, dieIdx):
+  def choose_auxiliary_dice(self, gameId, action, dieIdx=None):
     args = {
       'type': 'reactToAuxiliary',
       'game': gameId,
       'action': action,
     }
-    if dieIdx:
+    if dieIdx is not None:
       args['dieIdx'] = dieIdx
     return self._make_request(args)


### PR DESCRIPTION
I think the branch name says it all.

Now that i've seen how easy it is to cast numbers at the API layer as part of addressing #712 i'm going to do it, but this PR addresses why my testing of #2389 keeps falling over.