### PR TITLE
Cast all number arguments to int in ApiSpec, rather than one-off in ApiResponder

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -195,7 +195,7 @@ class ApiResponder {
         if ($success && isset($args['buttonName'])) {
             $success = $interface->game()->select_button(
                 $_SESSION['user_id'],
-                (int)$args['gameId'],
+                $args['gameId'],
                 $args['buttonName']
             );
         }
@@ -228,7 +228,7 @@ class ApiResponder {
     protected function get_interface_response_selectButton($interface, $args) {
         return $interface->game()->select_button(
             $_SESSION['user_id'],
-            (int)$args['gameId'],
+            $args['gameId'],
             $args['buttonName']
         );
     }
@@ -327,7 +327,7 @@ class ApiResponder {
      * @return NULL|array
      */
     protected function get_interface_response_loadActivePlayers($interface, $args) {
-        return $interface->get_active_players((int)$args['numberOfPlayers']);
+        return $interface->get_active_players($args['numberOfPlayers']);
     }
 
     /**
@@ -435,8 +435,8 @@ class ApiResponder {
         $infoArray = array();
         $infoArray['name_irl'] = $args['name_irl'];
         $infoArray['is_email_public'] = ('true' == $args['is_email_public']);
-        $infoArray['dob_month'] = (int)$args['dob_month'];
-        $infoArray['dob_day'] = (int)$args['dob_day'];
+        $infoArray['dob_month'] = $args['dob_month'];
+        $infoArray['dob_day'] = $args['dob_day'];
         $infoArray['comment'] = $args['comment'];
         $infoArray['vacation_message'] = $args['vacation_message'];
         $infoArray['gender'] = $args['gender'];
@@ -459,8 +459,8 @@ class ApiResponder {
         $infoArray['uses_gravatar'] = ('true' == $args['uses_gravatar']);
 
         $addlInfo = array();
-        $addlInfo['dob_month'] = (int)$args['dob_month'];
-        $addlInfo['dob_day'] = (int)$args['dob_day'];
+        $addlInfo['dob_month'] = $args['dob_month'];
+        $addlInfo['dob_day'] = $args['dob_day'];
         $addlInfo['homepage'] = $args['homepage'];
 
         if (isset($args['favorite_button'])) {
@@ -718,8 +718,8 @@ class ApiResponder {
         }
 
         $args['playerId'] = $_SESSION['user_id'];
-        $args['attackerIdx'] = (int)$args['attackerIdx'];
-        $args['defenderIdx'] = (int)$args['defenderIdx'];
+        $args['attackerIdx'] = $args['attackerIdx'];
+        $args['defenderIdx'] = $args['defenderIdx'];
 
         $retval = $interface->game()->submit_turn($args);
 
@@ -789,7 +789,7 @@ class ApiResponder {
      * @return NULL|array
      */
     protected function get_interface_response_loadForumBoard($interface, $args) {
-        return $interface->forum()->load_forum_board($_SESSION['user_id'], (int)$args['boardId']);
+        return $interface->forum()->load_forum_board($_SESSION['user_id'], $args['boardId']);
     }
 
     /**
@@ -801,13 +801,13 @@ class ApiResponder {
      */
     protected function get_interface_response_loadForumThread($interface, $args) {
         if (isset($args['currentPostId'])) {
-            $currentPostId = (int)$args['currentPostId'];
+            $currentPostId = $args['currentPostId'];
         } else {
             $currentPostId = NULL;
         }
         return $interface->forum()->load_forum_thread(
             $_SESSION['user_id'],
-            (int)$args['threadId'],
+            $args['threadId'],
             $currentPostId
         );
     }
@@ -833,7 +833,7 @@ class ApiResponder {
     protected function get_interface_response_markForumRead($interface, $args) {
         return $interface->forum()->mark_forum_read(
             $_SESSION['user_id'],
-            (int)$args['timestamp']
+            $args['timestamp']
         );
     }
 
@@ -847,8 +847,8 @@ class ApiResponder {
     protected function get_interface_response_markForumBoardRead($interface, $args) {
         return $interface->forum()->mark_forum_board_read(
             $_SESSION['user_id'],
-            (int)$args['boardId'],
-            (int)$args['timestamp']
+            $args['boardId'],
+            $args['timestamp']
         );
     }
 
@@ -862,9 +862,9 @@ class ApiResponder {
     protected function get_interface_response_markForumThreadRead($interface, $args) {
         return $interface->forum()->mark_forum_thread_read(
             $_SESSION['user_id'],
-            (int)$args['threadId'],
-            (int)$args['boardId'],
-            (int)$args['timestamp']
+            $args['threadId'],
+            $args['boardId'],
+            $args['timestamp']
         );
     }
 
@@ -878,7 +878,7 @@ class ApiResponder {
     protected function get_interface_response_createForumThread($interface, $args) {
         return $interface->forum()->create_forum_thread(
             $_SESSION['user_id'],
-            (int)$args['boardId'],
+            $args['boardId'],
             $args['title'],
             $args['body']
         );
@@ -894,7 +894,7 @@ class ApiResponder {
     protected function get_interface_response_createForumPost($interface, $args) {
         return $interface->forum()->create_forum_post(
             $_SESSION['user_id'],
-            (int)$args['threadId'],
+            $args['threadId'],
             $args['body']
         );
     }
@@ -909,7 +909,7 @@ class ApiResponder {
     protected function get_interface_response_editForumPost($interface, $args) {
         return $interface->forum()->edit_forum_post(
             $_SESSION['user_id'],
-            (int)$args['postId'],
+            $args['postId'],
             $args['body']
         );
     }

--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -840,6 +840,19 @@ class ApiSpec {
     }
 
     /**
+     * sanitize an number argument by casting it to an int
+     *
+     * @param array $arg
+     * @return array
+     */
+    protected function sanitize_argument_of_type_number($arg) {
+        if (is_string($arg)) {
+            return (int)$arg;
+        }
+        return $arg;
+    }
+
+    /**
      * verify that the argument is an array, and verify the types
      * of each of its elements
      *


### PR DESCRIPTION
So this isn't all the work that's needed for #712 but i was wondering whether it would be easier to put up smaller PRs that touched smaller pieces of the codebase.  This particular piece touches only `src/api`, and does:
* Move all casts of elements in `$args` to numbers into `ApiSpec.php` (and in particular into one generic method within `ApiSpec.php` that casts all API arguments of type `number`)
* Make it so the only `(int)` casts remaining within `ApiResponder.php` are casts of elements of `$_SESSION`
* Add a regression test so that as we start stripping `(int)` casts from the codebase, we can't backslide

Future pieces will traverse `src/engine` and make that so that all `(int)` casts occur when pulling things from the database.
