### PR TITLE
Proof-of-concept: how would we remove casts from BMInterface.php?

### DIFF
--- a/src/engine/BMDB.php
+++ b/src/engine/BMDB.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * BMDB: database interface to standardize types 
+ *
+ * @author: Chaos
+ */
+
+/**
+ * This class contains all the logic to do with selecting from and updating
+ * the buttonmen database tables.
+ *
+ * It is not intended to be instantiated --- it's a set of public functions
+ * that callers will invoke using their own database connection.
+ *
+ *  */
+class BMDB {
+    // properties
+
+    /**
+     * Connection to database
+     *
+     * @var PDO
+     */
+    protected static $conn = NULL;
+
+    /**
+     * Constructor
+     *
+     * @param PDO $conn
+     */
+    public function __construct($conn) {
+        self::$conn = $conn;
+    }
+
+    /**
+     * Execute a query which fetches a single value from the DB
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $parameters
+     * @param array $returnType
+     * @return array
+     */
+    public function select_single_value($query, $parameters, $returnType) {
+        $statement = self::$conn->prepare($query);
+        $statement->execute($parameters);
+        $result = $statement->fetch(PDO::FETCH_NUM);
+        if (!$result) {
+            throw new BMDatabaseException("DB select_single_value found no result");
+        }
+        if (count($result) != 1) {
+            throw new BMDatabaseException("Expected 1 result from DB query, found " . count($result));
+        }
+        return ($this->cast_db_column($result[0], $returnType));
+    }
+
+    /**
+     * Execute a query which fetches an arbitrary number of rows from the database
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $parameters
+     * @param array $columnReturnTypes
+     * @return array
+     */
+    public function select_rows($query, $parameters, $columnReturnTypes) {
+        $statement = self::$conn->prepare($query);
+        $statement->execute($parameters);
+        $rows = array();
+        while ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
+            $row = array();
+            foreach ($columnReturnTypes as $column => $returnType) {
+                $row[$column] = $this->cast_db_column($result[$column], $returnType);
+            }
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    /**
+     * Cast a value fetched from a DB to the specified return type
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $returnType
+     * @return array
+     */
+    protected function cast_db_column($column, $returnType) {
+        if ($returnType == 'int') {
+            return (int)$column;
+        }
+        if ($returnType == 'bool') {
+            return (bool)$column;
+        }
+        if ($returnType == 'str') {
+            return $column;
+        }
+        if ($returnType == 'int_or_null') {
+            if (isset($column)) {
+                return (int)$column;
+            }
+            return NULL;
+        }
+        if ($returnType == 'str_or_null') {
+            if (isset($column)) {
+                return $column;
+            }
+            return NULL;
+        }
+        throw BMDatabaseException("Unknown column return type " . $returnType);
+    }
+}

--- a/src/engine/BMDatabaseException.php
+++ b/src/engine/BMDatabaseException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * BMDatabaseException: Custom exception for BM database operations
+ *
+ * @author chaos
+ */
+
+/**
+ * Indicates that something went wrong while accessing a BM database
+ */
+class BMDatabaseException extends Exception {
+}


### PR DESCRIPTION
Shadowshade, obviously don't merge this as written (among other things it definitely fails tests, though i think not any logic tests), i'm just putting it up to get your opinion about the approach.

This is an initial proposal for how we'd remove (int) and (bool) casts from BMInterface*.php.  The gist of it is:
* A new class, `BMDB`, that wraps database access and contains a small set of generic functions to do selects (and eventually also updates):
* A new exception class, so that if we want to be picky about the database select, e.g. "this query should return exactly one row", we have a way to communicate up "the database state wasn't what i expected"
* Within BMDB, the arguments to each function are the query to run, the parameters to pass, and the set of column names and *types* to expect in each row.  The types tell us how to cast the value we select, and they let us do the set of slightly-complicated-but-not-that-complicated things we do with DB types, of which the most interesting common example afaict is "this column contains either NULL or an int, and if it's an int i want to cast it to an int, but if it's NULL it should stay NULL"

* Within BMInterface and other classes that make database calls, we replace direct database connection executions with calls to these BMDB functions.

These are the advantages i see for BMInterface and friends:
* Because we're passing a parameter that says what type we expect each column to be, this provides inline documentation of what we expect the return values to look like, so when we return to code for later development, we don't have to guess.
* Because we know every parameter has always been cast to whatever type it's supposed to be cast to, we can vastly simplify the logic that brings these parameters into PHP game variables:
    * If something is a bool, we can just assign it to a parameter that's supposed to be a bool rather than futzing with select statements.
    * If something is int_or_null, the code does still have to care about those two cases to differentiate NULL and 0, because that's the way our codebase works so there's no easy out.  But what we don't have to do is stamp the if-not-NULL-cast-to-int pattern all over the codebase and worry about whether we got one wrong, because that's handled on select.  And we can know that if we got a value from a database and it fails isset(), it's precisely NULL and not some other non-set value.

To me, this seems like it would be more elegant and easier to deal with, in addition to giving us a path to resolving #712.  But you're the one who would mostly have to live with it, so i want to know what you think.

(And i'm also totally aware that you don't want me ripping out and rewriting a bunch of BMInterface before tournaments are merged.  I'm not going to do that.  I just wanted to put up a PR with the approach so you can tell me whether you like it.)
