### PR TITLE
Fixed zero-sided option die min value

### DIFF
--- a/src/engine/BMDieOption.php
+++ b/src/engine/BMDieOption.php
@@ -197,6 +197,11 @@ class BMDieOption extends BMDie {
         $this->needsOptionValue = FALSE;
         $this->valueRequested = FALSE;
         $this->max = $optionValue;
+        if (0 === $optionValue) {
+            $this->min = 0;
+        } else {
+            $this->min = 1;
+        }
         $this->scoreValue = $optionValue;
 
         return TRUE;

--- a/test/src/engine/BMDieOptionTest.php
+++ b/test/src/engine/BMDieOptionTest.php
@@ -223,6 +223,25 @@ class BMDieOptionTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @depends testInit
+     * @covers BMDieOption::set_optionValue
+     */
+    public function testSet_optionValue_including_zero() {
+        $this->object->init(array(0,7));
+
+        $this->assertFalse($this->object->set_optionValue(5), 'Invalid option value set should fail.');
+
+        $this->assertTrue($this->object->set_optionValue(7), 'Valid nonzero option value set should pass.');
+        $this->assertEquals(7, $this->object->max);
+        $this->assertEquals(1, $this->object->min);
+
+        $this->assertTrue($this->object->set_optionValue(0), 'Valid zero option value set should pass.');
+
+        $this->assertEquals(0, $this->object->max);
+        $this->assertEquals(0, $this->object->min);
+    }
+
+    /**
+     * @depends testInit
      * @depends testActivate
      * @depends testSet_optionValue
      * @covers BMDieOption::roll


### PR DESCRIPTION
Fixes #2486. Fixes #2614.

~~The proposed fix in this pull request uses a non-typed comparison for the option die value. This will need to be strengthened once we are a bit further down the road with ensuring correct typing in the BMInterface* classes (cf. #2628).~~

This pull request was designed to fix the underlying bug with zero-sided option dice without conflicting with the custom recipe pull request (#2389), which disables 0-sided option dice explicitly.

Once both this pull request and #2389 have been accepted, the plan would be to submit another pull request that removes the explicit rule banning 0-sided option dice, and simultaneously removes the special skill flag for my fanatic, which has a (0/4) die.