### PR TITLE
Visually indicate that die is irrelevant for initiative

### DIFF
--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -353,7 +353,6 @@ class BMDie extends BMCanHaveSkill {
         return $val;
     }
 
-//
     /**
      * Returns ten times the "real" scoring value
      *
@@ -391,8 +390,6 @@ class BMDie extends BMCanHaveSkill {
         }
     }
 
-    //
-
     /**
      * Return die's initiative value.
      * Negative means it doesn't count for initiative.
@@ -405,6 +402,17 @@ class BMDie extends BMCanHaveSkill {
         $this->run_hooks(__FUNCTION__, array('initiativeValue' => &$val));
 
         return $val;
+    }
+
+    /**
+     * Add flag to signal whether the die is considered by initiative
+     */
+    public function add_initiative_flag() {
+        $initiativeValue = $this->initiative_value();
+
+        if ($initiativeValue && ($initiativeValue < 0)) {
+            $this->add_flag('IrrelevantForInitiative');
+        }
     }
 
     /**

--- a/src/engine/BMFlagIrrelevantForInitiative.php
+++ b/src/engine/BMFlagIrrelevantForInitiative.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * BMFlagIrrelevantForInitiative: Used to signal that a die is irrelevant for initiative
+ *
+ * @author: james
+ */
+
+/**
+ * This class is a flag that signals that a die is irrelevant for initiative
+ */
+class BMFlagIrrelevantForInitiative extends BMFlag {
+
+}

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -4075,6 +4075,10 @@ class BMGame {
             }
 
             foreach ($player->activeDieArray as $dieIdx => $die) {
+                if (BMGameState::REACT_TO_INITIATIVE == $this->gameState) {
+                    $die->add_initiative_flag();
+                }
+
                 if (!empty($die->flagList)) {
                     foreach (array_keys($die->flagList) as $flag) {
                         // actively lie about auxiliary choices to avoid leaking info

--- a/src/ui/gui.css
+++ b/src/ui/gui.css
@@ -375,6 +375,10 @@ select.center {
     background-color: #ffa500;
 }
 
+.recipe_irrelevant_for_initiative {
+    color: #cccccc;
+}
+
 .die_overlay {
     position:relative;
     font-size: 21px;

--- a/src/ui/js/Game.js
+++ b/src/ui/js/Game.js
@@ -2432,16 +2432,10 @@ Game.dieRecipeTable = function(table_action, active) {
             Game.dieValueSelectTd('init_react_' + i, initopts,
               Api.game.player.activeDieArray[i].value, defaultval));
         } else {
-          dieLRow.append($('<td>', {
-            'text': Game.activeDieFieldString(
-              i, 'value', Api.game.player.activeDieArray),
-          }));
+          dieLRow.append(Game.valueCell(i, true));
         }
         dieRRow.append(opponentEnt);
-        dieRRow.append($('<td>', {
-          'text': Game.activeDieFieldString(
-            i, 'value', Api.game.opponent.activeDieArray),
-        }));
+        dieRRow.append(Game.valueCell(i, false));
       } else if (table_action == 'adjust_fire_dice') {
         dieLRow.append(playerEnt);
         var fireopts = [];
@@ -2520,6 +2514,30 @@ Game.dieRecipeTable = function(table_action, active) {
   }
 
   return dietable;
+};
+
+Game.valueCell = function(dieIdx, isPlayer) {
+  var activeDieArray;
+  if (isPlayer) {
+    activeDieArray = Api.game.player.activeDieArray;
+  } else {
+    activeDieArray = Api.game.opponent.activeDieArray;
+  }
+
+  var cellText = Game.activeDieFieldString(dieIdx, 'value', activeDieArray);
+  var valueCell = $('<td>', {
+    'text': cellText,
+  });
+
+  if ('' !== cellText) {
+    var die = activeDieArray[dieIdx];
+    if (('properties' in die) &&
+        (die.properties.indexOf('IrrelevantForInitiative') >= 0)) {
+      valueCell.addClass('recipe_irrelevant_for_initiative');
+    }
+  }
+
+  return valueCell;
 };
 
 Game.playerWLTText = function(player) {
@@ -2616,6 +2634,16 @@ Game.dieTableEntry = function(i, activeDieArray) {
       dieopts['class'] = 'recipe_inuse';
       dieopts.title += '. (This die is a target of the attack which ' +
         'is currently in progress.)';
+    }
+
+    if (die.properties.indexOf('IrrelevantForInitiative') >= 0) {
+      if (typeof dieopts['class'] == 'undefined') {
+        dieopts['class'] = '';
+      } else {
+        dieopts['class'] += ' ';
+      }
+
+      dieopts['class'] += 'recipe_irrelevant_for_initiative';
     }
     return $('<td>', dieopts);
   }

--- a/test/src/api/responder02Test.php
+++ b/test/src/api/responder02Test.php
@@ -363,8 +363,10 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][0]['waitingOnAction'] = TRUE;
         $expData['playerDataArray'][1]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][0]['activeDieArray'][0]['value'] = 3;
+        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][0]['activeDieArray'][1]['value'] = 8;
         $expData['playerDataArray'][0]['activeDieArray'][2]['value'] = 7;
+        $expData['playerDataArray'][0]['activeDieArray'][2]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][0]['activeDieArray'][3]['value'] = 1;
         $expData['playerDataArray'][0]['activeDieArray'][4]['value'] = 3;
         $expData['playerDataArray'][1]['activeDieArray'][0]['value'] = 2;
@@ -395,6 +397,8 @@ class responder02Test extends responderTestFramework {
         $expData['activePlayerIdx'] = 1;
         $expData['playerDataArray'][0]['waitingOnAction'] = FALSE;
         $expData['playerDataArray'][1]['waitingOnAction'] = TRUE;
+        $expData['playerDataArray'][0]['activeDieArray'][0]['properties'] = array();
+        $expData['playerDataArray'][0]['activeDieArray'][2]['properties'] = array();
         $expData['validAttackTypeArray'] = array('Power', 'Skill', 'Shadow');
         array_unshift($expData['gameActionLog'], array('timestamp' => 'TIMESTAMP', 'player' => 'responder003', 'message' => 'responder003 chose not to try to gain initiative using chance or focus dice'));
         $expData['gameActionLogCount'] += 1;
@@ -1847,6 +1851,7 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][0]['subdieArray'][0]['value'] = 4;
         $expData['playerDataArray'][1]['activeDieArray'][0]['subdieArray'][1]['value'] = 2;
         $expData['playerDataArray'][1]['activeDieArray'][1]['value'] = 6;
+        $expData['playerDataArray'][1]['activeDieArray'][1]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][1]['activeDieArray'][2]['value'] = 4;
         $expData['playerDataArray'][1]['activeDieArray'][2]['sides'] = 5;
         $expData['playerDataArray'][1]['activeDieArray'][2]['description'] = 'Null Y Swing Die (with 5 sides)';
@@ -1854,7 +1859,9 @@ class responder02Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][3]['sides'] = 20;
         $expData['playerDataArray'][1]['activeDieArray'][3]['description'] = 'Focus Option Die (with 20 sides)';
         $expData['playerDataArray'][1]['activeDieArray'][4]['value'] = 6;
+        $expData['playerDataArray'][1]['activeDieArray'][4]['properties'][] = 'IrrelevantForInitiative';
         $expData['playerDataArray'][1]['activeDieArray'][5]['value'] = 1;
+        $expData['playerDataArray'][1]['activeDieArray'][5]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][0]['swingRequestArray'] = array();
         $expData['playerDataArray'][1]['swingRequestArray'] = array();
 

--- a/test/src/api/responder03Test.php
+++ b/test/src/api/responder03Test.php
@@ -3196,7 +3196,9 @@ class responder03Test extends responderTestFramework {
         $expData['playerDataArray'][1]['activeDieArray'][0]['value'] = 5;
         $expData['playerDataArray'][1]['activeDieArray'][1]['value'] = 3;
         $expData['playerDataArray'][1]['activeDieArray'][2]['value'] = 10;
+        $expData['playerDataArray'][1]['activeDieArray'][2]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][1]['activeDieArray'][3]['value'] = 9;
+        $expData['playerDataArray'][1]['activeDieArray'][3]['properties'] = array('IrrelevantForInitiative');
         $expData['playerDataArray'][1]['activeDieArray'][4]['description'] = "Z Swing Die (with 27 sides)";
         $expData['playerDataArray'][1]['activeDieArray'][4]['sides'] = 27;
         $expData['playerDataArray'][1]['activeDieArray'][4]['value'] = 24;
@@ -3220,6 +3222,8 @@ class responder03Test extends responderTestFramework {
         $expData['gameState'] = "START_TURN";
         $expData['playerDataArray'][0]['waitingOnAction'] = true;
         $expData['playerDataArray'][1]['waitingOnAction'] = false;
+        $expData['playerDataArray'][1]['activeDieArray'][2]['properties'] = array();
+        $expData['playerDataArray'][1]['activeDieArray'][3]['properties'] = array();
         $expData['validAttackTypeArray'] = array("Power", "Skill");
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);

--- a/test/src/engine/BMFlagIrrelevantForInitiativeTest.php
+++ b/test/src/engine/BMFlagIrrelevantForInitiativeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class BMFlagIrrelevantForInitiativeTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * @covers BMFlag::create_from_string
+     * @covers BMFlag::value
+     */
+    public function testConstruct() {
+        $flag = BMFlag::create_from_string('IrrelevantForInitiative');
+        $this->assertInstanceOf('BMFlagIrrelevantForInitiative', $flag);
+    }
+
+    /**
+     * @covers BMFlag::__toString
+     */
+    public function testToString() {
+        $flag = BMFlag::create_from_string('IrrelevantForInitiative');
+        $this->assertEquals('IrrelevantForInitiative', strval($flag));
+    }
+}

--- a/test/src/ui/js/test_Game.js
+++ b/test/src/ui/js/test_Game.js
@@ -1304,6 +1304,50 @@ test("test_Game.dieRecipeTable", function(assert) {
   });
 });
 
+test("test_Game.valueCell", function(assert) {
+  stop();
+  BMTestUtils.GameType = 'blackomega_thefool_reacttoinitiative';
+  Game.getCurrentGame(function() {
+    Game.page = $('<div>');
+    var table = $('<table>');
+    var tr = $('<tr>');
+    var valueCell1 = Game.valueCell(0, true);
+    valueCell1.attr('id', 'cell1');
+    var valueCell2 = Game.valueCell(3, true);
+    valueCell2.attr('id', 'cell2');
+
+    tr.append(valueCell1);
+    tr.append(valueCell2);
+    table.append(tr);
+    Game.page.append(table);
+    Login.arrangePage(Game.page, null, null);
+
+    var retrievedCell1 = document.getElementById('cell1');
+    assert.ok(retrievedCell1, "Document should contain cell 1");
+    assert.equal(retrievedCell1.nodeName, "TD",
+      "Cell should be the correct type");
+    assert.ok(retrievedCell1.innerHTML.match('3'),
+      "Cell should contain correct value");
+    assert.ok(
+      retrievedCell1.classList.contains('recipe_irrelevant_for_initiative'),
+      "Cell should indicate that it is irrelevant for initiative"
+    );
+
+    var retrievedCell2 = document.getElementById('cell2');
+    assert.ok(retrievedCell2, "Document should contain cell 2");
+    assert.equal(retrievedCell2.nodeName, "TD",
+      "Cell should be the correct type");
+    assert.ok(retrievedCell2.innerHTML.match('1'),
+      "Cell should contain correct value");
+    assert.ok(
+      !retrievedCell2.classList.contains('recipe_irrelevant_for_initiative'),
+      "Cell should not indicate that it is irrelevant for initiative"
+    );
+
+    start();
+  });
+});
+
 test("test_Game.playerWLTText", function(assert) {
   stop();
   var gameId = BMTestUtils.testGameId('washu_hooloovoo_game_over');


### PR DESCRIPTION
Fixes #835.

On my system, the updated display looks like this:

![irrelevant_for_initiative](https://user-images.githubusercontent.com/2898401/97977418-4cba5a00-1e20-11eb-9a10-41294b5c0fd0.png)

Let me know what you think about how this looks.