### PR TITLE
Removed "Forum thread: " text from forum links and updated help

### DIFF
--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -357,11 +357,9 @@ Env.applyBbCodeToHtml = function(htmlToParse) {
       'isAtomic': false,
       'isLink': true,
       'openingHtml':
-        '<a class="chatForumLink" href="forum.html#!threadId=###">' +
-        'Forum thread: ',
+        '<a class="chatForumLink" href="forum.html#!threadId=###">',
       'alternateOpeningHtml':
-        '<a class="chatForumLink" href="forum.html#!threadId=###&postId=$$$">' +
-        'Forum thread: ',
+        '<a class="chatForumLink" href="forum.html#!threadId=###&postId=$$$">',
       'closingHtml': '</a>',
       'escapeParameter': true,
       'multipleParameters': true,

--- a/src/ui/js/Faq.js
+++ b/src/ui/js/Faq.js
@@ -61,6 +61,7 @@ Faq.tableOfContents = function() {
 
   toc.append(Faq.gameplayLinks());
   toc.append(Faq.userprefsLinks());
+  toc.append(Faq.forumLinks());
   toc.append(Faq.unansweredLink());
 
   return toc;
@@ -124,6 +125,26 @@ Faq.userprefsLinks = function() {
   return links;
 };
 
+Faq.forumLinks = function() {
+  var links = $('<li>').append(
+    $('<a>').attr('href', '#Forum').text(
+      'Forum'
+    )
+  );
+
+  var sublinks = $('<ul>');
+
+  sublinks.append($('<li>').append(
+    $('<a>').attr('href', '#ForumLink').text(
+      'How do I link to another forum post?'
+    )
+  ));
+
+  links.append(sublinks);
+
+  return links;
+};
+
 Faq.unansweredLink = function() {
   var link = $('<li>').append(
     $('<a>').attr('href', '#Unanswered').text(
@@ -139,6 +160,7 @@ Faq.content = function() {
 
   content.append(Faq.gameplayContent());
   content.append(Faq.userprefsContent());
+  content.append(Faq.forumContent());
   content.append(Faq.unansweredContent());
 
   return content;
@@ -457,6 +479,52 @@ Faq.fireOvershootingContent = function() {
     'you with that choice any time you wish to perform a perfectly ' +
     'reasonable Power attack with a (20):19 against a (4):1 just because ' +
     'you happen to also have a Fire die.'
+  ));
+
+  return content;
+};
+
+Faq.forumContent = function() {
+  var content = $(document.createDocumentFragment());
+
+  content.append($('<a>').attr('name', 'Forum'));
+  content.append($('<h2>').text('Forum'));
+
+  content.append(Faq.forumLinkContent());
+
+  return content;
+};
+
+Faq.forumLinkContent = function() {
+  var content = $(document.createDocumentFragment());
+
+  content.append($('<a>').attr('name', 'ForumLink'));
+  content.append(
+    $('<h3>').text(
+      'How do I link to another forum post?'
+    )
+  );
+
+  content.append($('<p>').text(
+    'When you are posting in a forum, use the [forum] element to link to ' +
+    'another forum post. The syntax is [forum=t,p]text[/forum], where text ' +
+    'is the text that appears as the link. The number t is the thread id, ' +
+    'and the number p is the post id. The numbers appear at the bottom of ' +
+    'the post that you want to link to, in the footer of the post in a ' +
+    'very light color, to the left of the Quote button. '
+  ));
+
+  content.append($('<p>').html(
+    'For example, use the syntax [forum=93,1301]Learn about adopting a ' +
+    'button[/forum] to generate a link that looks like ' +
+    '<a href="forum.html#!threadid=93&postid=1301">Learn about adopting a ' +
+    'button</a>.'
+  ));
+
+  content.append($('<p>').text(
+    'If you want to refer to another post in the same thread, you can ' +
+    'either use the [forum] element or simply use the Quote ' +
+    'button instead.'
   ));
 
   return content;

--- a/src/ui/js/Forum.js
+++ b/src/ui/js/Forum.js
@@ -919,8 +919,7 @@ Forum.buildHelp = function() {
   helpDiv.append($('<div>', {
     'class': 'help',
     'html': '[forum=1,6]text[/forum]: ' +
-            '<a href="forum.html#!threadId=1&postId=6">' +
-            'Forum thread: text</a>',
+            '<a href="forum.html#!threadId=1&postId=6">text</a>',
   }));
   helpDiv.append($('<div>', {
     'class': 'help',

--- a/test/src/ui/js/test_Faq.js
+++ b/test/src/ui/js/test_Faq.js
@@ -93,10 +93,16 @@ test("test_Faq.gameplayLinks", function(assert) {
   assert.equal(node[0].childNodes[1].nodeName, "UL", "links contain a UL");
 });
 
-
 test("test_Faq.userprefsLinks", function(assert) {
   var node = Faq.userprefsLinks();
   assert.equal(node[0].nodeName, "LI", "userprefsLinks returns a LI");
+  assert.equal(node[0].childNodes[0].nodeName, "A", "links start with an A");
+  assert.equal(node[0].childNodes[1].nodeName, "UL", "links contain a UL");
+});
+
+test("test_Faq.forumLinks", function(assert) {
+  var node = Faq.forumLinks();
+  assert.equal(node[0].nodeName, "LI", "forumLinks returns a LI");
   assert.equal(node[0].childNodes[0].nodeName, "A", "links start with an A");
   assert.equal(node[0].childNodes[1].nodeName, "UL", "links contain a UL");
 });
@@ -170,6 +176,22 @@ test("test_Faq.monitorContent", function(assert) {
 
 test("test_Faq.fireOvershootingContent", function(assert) {
   var node = Faq.fireOvershootingContent();
+  assert.equal(node[0].nodeName, "#document-fragment",
+    "content contains a document fragment");
+  assert.equal(node[0].childNodes[0].nodeName, "A", "content starts with an A");
+  assert.equal(node[0].childNodes[1].nodeName, "H3", "content contains a H3");
+});
+
+test("test_Faq.forumContent", function(assert) {
+  var node = Faq.forumContent();
+  assert.equal(node[0].nodeName, "#document-fragment",
+    "content contains a document fragment");
+  assert.equal(node[0].childNodes[0].nodeName, "A", "content starts with an A");
+  assert.equal(node[0].childNodes[1].nodeName, "H2", "content contains a H2");
+});
+
+test("test_Faq.forumLinkContent", function(assert) {
+  var node = Faq.forumLinkContent();
   assert.equal(node[0].nodeName, "#document-fragment",
     "content contains a document fragment");
   assert.equal(node[0].childNodes[0].nodeName, "A", "content starts with an A");


### PR DESCRIPTION
Fixes #2460. Fixes #2461.

We'll need to test that the relative link I've used here actually works correctly on a deployed server.