### PR TITLE
Made selected button persistent on filter change

### DIFF
--- a/src/ui/js/Newgame.js
+++ b/src/ui/js/Newgame.js
@@ -608,8 +608,9 @@ Newgame.getSelectOptionList = function(
       'text': blankOption,
     }));
   } else {
-    // If there's no default, put an invalid default value first
-    if (selectedval === null) {
+    // If there's no default or the selected value doesn't exist
+    // in the dropdown, put an invalid default value first
+    if ((selectedval === null) || !(selectedval in valuedict)) {
       optionlist.push($('<option>', {
         'value': '',
         'class': 'yellowed',
@@ -710,6 +711,12 @@ Newgame.updateButtonSelectTd = function(player) {
 
 Newgame.updateButtonList = function(player, limitid) {
   if (limitid) {
+    var buttonText = $('#' + player + '_button_chosen > a > span').text();
+    var delimiterIdx = buttonText.indexOf(':');
+    if (delimiterIdx >= 0) {
+      Newgame.activity[player + 'Button'] = buttonText.substr(0, delimiterIdx);
+    }
+
     var optsTag = '#' + Newgame.getLimitSelectid(player, limitid) + ' option';
     $.each($(optsTag), function() {
       Newgame.activity.buttonLimits[player][limitid][$(this).val()] = false;


### PR DESCRIPTION
Fixes #1010.

I've tested this with Limax: (W) om(34) (T). The selection remains there if I filter according to die skill = ornery or morphing or ANY, but not if I select some other skill.