### PR TITLE
Add simple BMDB layer which casts selected values to consistent types

### DIFF
--- a/src/engine/BMDB.php
+++ b/src/engine/BMDB.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * BMDB: database interface to standardize types
+ *
+ * @author: Chaos
+ */
+
+/**
+ * This class contains all the logic to do with selecting from and updating
+ * the buttonmen database tables.
+ *
+ * It should be instantiated with a PDO database connection created by the caller
+ * (which will be a TestDummyPDOConn in the case that the caller is unit testing).
+ */
+class BMDB {
+    // properties
+
+    /**
+     * Connection to database
+     *
+     * @var PDO
+     */
+    protected static $conn = NULL;
+
+    /**
+     * Constructor
+     *
+     * @param PDO $conn
+     */
+    public function __construct($conn) {
+        self::$conn = $conn;
+    }
+
+    /**
+     * Execute a query which fetches a single value from the DB
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $parameters
+     * @param array $returnType
+     * @return array
+     */
+    public function select_single_value($query, $parameters, $returnType) {
+        $statement = self::$conn->prepare($query);
+        $statement->execute($parameters);
+        $result = $statement->fetch(PDO::FETCH_NUM);
+        if (!$result) {
+            throw new BMExceptionDatabase("DB select_single_value found no result");
+        }
+        if (count($result) != 1) {
+            throw new BMExceptionDatabase("Expected 1 result from DB query, found " . count($result));
+        }
+        return ($this->cast_db_column($result[0], $returnType));
+    }
+
+    /**
+     * Execute a query which fetches an arbitrary number of rows from the database
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $parameters
+     * @param array $columnReturnTypes
+     * @return array
+     */
+    public function select_rows($query, $parameters, $columnReturnTypes) {
+        $statement = self::$conn->prepare($query);
+        $statement->execute($parameters);
+        $rows = array();
+        while ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
+            $row = array();
+            foreach ($columnReturnTypes as $column => $returnType) {
+                $row[$column] = $this->cast_db_column($result[$column], $returnType);
+            }
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    /**
+     * Cast a value fetched from a DB to the specified return type
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $returnType
+     * @return array
+     */
+    protected function cast_db_column($column, $returnType) {
+        if ($returnType == 'int') {
+            if (!isset($column)) {
+                throw new BMExceptionDatabase("Found non-set value in DB when expecting integer");
+            }
+            return (int)$column;
+        }
+        // Cast all values to int, including unset values - this returns 0 if the DB contains NULL
+        if ($returnType == 'int_null_becomes_zero') {
+            return (int)$column;
+        }
+        if ($returnType == 'bool') {
+            return (bool)$column;
+        }
+        if ($returnType == 'str') {
+            if (!isset($column)) {
+                throw new BMExceptionDatabase("Found non-set value in DB when expecting string");
+            }
+            return (string)$column;
+        }
+        if ($returnType == 'int_or_null') {
+            if (isset($column)) {
+                return (int)$column;
+            }
+            return NULL;
+        }
+        if ($returnType == 'str_or_null') {
+            if (isset($column)) {
+                return (string)$column;
+            }
+            return NULL;
+        }
+        throw BMExceptionDatabase("Unknown column return type " . $returnType);
+    }
+}

--- a/src/engine/BMExceptionDatabase.php
+++ b/src/engine/BMExceptionDatabase.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * BMExceptionDatabase: Custom exception for BM database operations
+ *
+ * @author chaos
+ */
+
+/**
+ * Indicates that something went wrong while accessing a BM database
+ */
+class BMExceptionDatabase extends Exception {
+}

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -46,6 +46,13 @@ class BMInterface {
     protected static $conn = NULL;
 
     /**
+     * Modelled connection to database
+     *
+     * @var BMDB
+     */
+    protected static $db = NULL;
+
+    /**
      * Owning BMInterface, allows back navigation
      *
      * @var BMInterface
@@ -77,6 +84,7 @@ class BMInterface {
             require_once __DIR__.'/../database/mysql.inc.php';
         }
         self::$conn = conn();
+        self::$db = new BMDB(self::$conn);
     }
 
     /**

--- a/test/src/engine/BMDBTest.php
+++ b/test/src/engine/BMDBTest.php
@@ -1,0 +1,166 @@
+<?php
+
+require_once __DIR__.'/TestDummyPDOConn.php';
+
+class BMDBTest extends PHPUnit_Framework_TestCase {
+    /**
+     * @var BMDB
+     */
+    protected $object;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp() {
+        $this->conn = new TestDummyPDOConn;
+        $this->object = new BMDB($this->conn);
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown() {
+    }
+
+    /**
+     * @covers BMDB::select_single_value
+     */
+    public function testSelect_single_value()
+    {
+        $parameters = array(':player_id' => 3);
+        $query =
+            'SELECT COUNT(*) '.
+            'FROM game_player_map AS gpm '.
+               'LEFT JOIN game AS g ON g.id = gpm.game_id '.
+            'WHERE gpm.player_id = :player_id '.
+               'AND gpm.is_awaiting_action = 1 '.
+               'AND g.status_id IN '.
+                   '(SELECT id FROM game_status WHERE name IN (\'NEW\', \'ACTIVE\'))';
+
+        $this->conn->setNextExpectedReturnValue(array(array(18)));
+        $this->assertEquals($this->object->select_single_value($query, $parameters, 'int'), 18);
+    }
+
+    /**
+     * @covers BMDB::select_rows
+     */
+    public function testSelect_rows()
+    {
+        $parameters = array(':game_id' => 3);
+        $query =
+            'SELECT s.name AS status_name,' .
+            'v.player_id'.
+            'v.autopass '.
+            'FROM game AS g '.
+            'LEFT JOIN game_status AS s '.
+            'ON s.id = g.status_id '.
+            'LEFT JOIN game_player_view AS v '.
+            'ON g.id = v.game_id '.
+            'WHERE g.id = :game_id '.
+            'ORDER BY g.id;';
+        $columnReturnTypes = array(
+            'status_name' => 'str',
+            'player_id' => 'int_or_null',
+            'autopass' => 'bool',
+        );
+
+        // Fake value for the database query to return to PDO::fetch()
+        $this->conn->setNextExpectedReturnValue(array(
+            array('status_name' => 'OPEN', 'player_id' => '0', 'autopass' => TRUE),
+            array('status_name' => 'OPEN', 'player_id' => NULL, 'autopass' => FALSE)));
+
+        $rows = $this->object->select_rows($query, $parameters, $columnReturnTypes);
+        $this->assertEquals(2, count($rows));
+        $this->assertEquals(array('status_name' => 'OPEN', 'player_id' => 0, 'autopass' => TRUE), $rows[0]);
+        $this->assertEquals(array('status_name' => 'OPEN', 'player_id' => NULL, 'autopass' => FALSE), $rows[1]);
+    }
+
+    /**
+     * @covers BMDB::cast_db_column
+     */
+    public function testCast_db_column()
+    {
+        // Get an accessible copy of the protected cast_db_column method so we can test it
+        $class = new ReflectionClass('BMDB');
+        $method = $class->getMethod('cast_db_column');
+        $method->setAccessible(true);
+
+        // use ReflectionClass::invokeArgs() to call cast_db_column with various args
+
+        // 'int' column type
+        foreach (array('3', 3) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'int'));
+            $this->assertEquals(3, $retval);
+            $this->assertEquals('integer', gettype($retval));
+        }
+        try {
+            $retval = $method->invokeArgs($this->object, array(NULL, 'int'));
+            $this->fail("Exception should have been thrown");
+        } catch (BMExceptionDatabase $e) {
+            $this->assertEquals('Found non-set value in DB when expecting integer', $e->getMessage());
+        }
+
+        // 'int_null_becomes_zero' column type
+        foreach (array('3', 3) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'int_null_becomes_zero'));
+            $this->assertEquals(3, $retval);
+            $this->assertEquals('integer', gettype($retval));
+        }
+        foreach (array(NULL) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'int_null_becomes_zero'));
+            $this->assertEquals(0, $retval);
+            $this->assertEquals('integer', gettype($retval));
+        }
+
+        // 'int_or_null' column type
+        foreach (array('3', 3) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'int_or_null'));
+            $this->assertEquals(3, $retval);
+            $this->assertEquals('integer', gettype($retval));
+        }
+        foreach (array(NULL) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'int_or_null'));
+            $this->assertEquals(NULL, $retval);
+            $this->assertEquals('NULL', gettype($retval));
+        }
+
+        // 'bool' column type
+        foreach (array(TRUE, '1', 1) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'bool'));
+            $this->assertEquals(TRUE, $retval);
+            $this->assertEquals('boolean', gettype($retval));
+        }
+        foreach (array(FALSE, '0', 0, NULL) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'bool'));
+            $this->assertEquals(FALSE, $retval);
+            $this->assertEquals('boolean', gettype($retval));
+        }
+
+        // 'str' column type
+        foreach (array('1', 1, TRUE) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'str'));
+            $this->assertEquals('1', $retval);
+            $this->assertEquals('string', gettype($retval));
+        }
+        try {
+            $retval = $method->invokeArgs($this->object, array(NULL, 'str'));
+            $this->fail("Exception should have been thrown");
+        } catch (BMExceptionDatabase $e) {
+            $this->assertEquals('Found non-set value in DB when expecting string', $e->getMessage());
+        }
+
+        // 'str_or_null' column type
+        foreach (array('1', 1, TRUE) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'str_or_null'));
+            $this->assertEquals('1', $retval);
+            $this->assertEquals('string', gettype($retval));
+        }
+        foreach (array(NULL) as $input) {
+            $retval = $method->invokeArgs($this->object, array($input, 'str_or_null'));
+            $this->assertEquals(NULL, $retval);
+            $this->assertEquals('NULL', gettype($retval));
+        }
+    }
+}

--- a/test/src/engine/BMExceptionDatabaseTest.php
+++ b/test/src/engine/BMExceptionDatabaseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+class BMExceptionDatabaseTest extends PHPUnit_Framework_TestCase  {
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers BMExceptionDatabase
+     */
+    public function testBMExceptionDatabase()
+    {
+        try {
+            throw new BMExceptionDatabase("Received unexpected response to database query");
+        } catch (BMExceptionDatabase $e) {
+            $this->assertTrue(TRUE);
+        } catch (Exception $e) {
+            $this->assertTrue(FALSE);
+        }
+    }
+}

--- a/test/src/engine/TestDummyPDOConn.php
+++ b/test/src/engine/TestDummyPDOConn.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once __DIR__.'/TestDummyPDOStatement.php';
+
+class TestDummyPDOConn {
+    public function __construct() {
+        $this->nextExpectedReturnValue = NULL;
+    }
+
+    public function setNextExpectedReturnValue($value) {
+        $this->nextExpectedReturnValue = $value;
+    }
+
+    public function prepare($stmt) {
+        return new TestDummyPDOStatement($this->nextExpectedReturnValue);
+    }
+}

--- a/test/src/engine/TestDummyPDOStatement.php
+++ b/test/src/engine/TestDummyPDOStatement.php
@@ -1,0 +1,25 @@
+<?php
+
+class TestDummyPDOStatement {
+    public function __construct($dummyReturnValue) {
+        $this->returnValue = $dummyReturnValue;
+        $this->hasExecuted = FALSE;
+        $this->cursorOffset = 0;
+    }
+
+    public function execute($parameters) {
+        $this->hasExecuted = TRUE;
+    }
+
+    public function fetch() {
+        if (!$this->hasExecuted) {
+            throw new Exception("Attempted to fetch from a DB statement before executing it");
+        }
+        if ($this->cursorOffset < count($this->returnValue)) {
+            $retval = $this->returnValue[$this->cursorOffset];
+            $this->cursorOffset++;
+            return $retval;
+        }
+        return NULL;
+    }
+}


### PR DESCRIPTION
Don't merge this yet, because it'll need a rebase.

This is intended to be a version of #2628 which can be merged without interfering with tournaments, and will give me a framework to build on driving down (int) casts across the codebase.

------------------------------------------------------------------------
First commit, just implement BMDB:

* BMDB implements a couple of types of select
* No callers invoke BMDB yet --- that will happen in future PRs
* Functions are fully tested using dummy DB connector objects

------------------------------------------------------------------------
Second commit, use BMDB to model all database accesses in BMInterfaceHistory.php

* All `(int)` casts are removed, because the database row selects now take care of them
* All direct accesses to `self::$conn` are now replaced with `self::$db` calls (note that this was possible to do with the existing infrastructure because BMInterfaceHistory.php doesn't do any DB updates --- i may have to add a new BMDB function when i go to migrate a class which does DB updates, but one thing at a time)
* I had to add a third int type --- at this point, i think this handles all the ways NULL might be treated when we look for an int in the database:
    * `int`: raise an exception if NULL is received --- this is what we *want* the default to be, because if the caller hasn't thought about the possibility that their select might get a NULL, that probably means there's a bug if their select *does* get a NULL, and we want to draw attention to it (by failing), not paper over it
    * `int_or_null`: return an int type if the DB entry is set; if it's unset, return NULL.  In this case, the calling function has to be aware that it might wind up with an int or a NULL, and has to be able to do the right thing.  We have a lot of code that works that way, but we explicitly flag it because the caller has to know that they might have a NULL
    * `int_null_becomes_zero`: it's not clear to me that this behavior is desirable, but it's the way some of the BMInterfaceHistory.php code works, and it's not very harmful in that case (the situation is that the SQL is doing some sums to get some of the fields that are returned, and if there's nothing to sum, apparently `SUM()` returns NULL, but we want zero), so let's support it with a funny name that makes it clear it's funny behavior
