### PR TITLE
publishing game event notifications to SNS

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -46,6 +46,13 @@ class BMInterface {
     protected static $conn = NULL;
 
     /**
+     * Communication to notification service
+     *
+     * @var SnsClient
+     */
+    protected static $snsClient = NULL;
+
+    /**
      * Owning BMInterface, allows back navigation
      *
      * @var BMInterface
@@ -73,10 +80,13 @@ class BMInterface {
 
         if ($isTest) {
             require_once __DIR__.'/../../test/src/database/mysql.test.inc.php';
+            require_once __DIR__.'/../../test/src/notify/sns.test.php';
         } else {
             require_once __DIR__.'/../database/mysql.inc.php';
+            require_once __DIR__.'/../notify/sns.php';
         }
         self::$conn = conn();
+        self::$snsClient = snsClient();
     }
 
     /**
@@ -98,6 +108,7 @@ class BMInterface {
         $result->message = $this->message;
         $result->timestamp = $this->timestamp;
         $result::$conn = self::$conn;
+        $result::$snsClient = self::$snsClient;
         return $result;
     }
 

--- a/src/notify/sns.php
+++ b/src/notify/sns.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * sns : definition of communication to notification service
+ *
+ * @author danlangford
+ */
+
+// TODO: consider the requirements and recommendations
+// https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/getting-started_requirements.html
+
+// TODO: consider installing dependency via Composer, phar, or zip file
+// TODO: determine the proper way, in this project, to get the libs i need
+require '/path/to/aws.phar'; // OOR require '/path/to/vendor/autoload.php'; OR require '/path/to/aws-autoloader.php';
+use Aws\Sns\SnsClient;
+use Aws\Exception\AwsException;
+
+/**
+ * build a client
+ *
+ * @return SnSclient
+ */
+function snsClient() {
+
+    // credentials can be obtained from ENV vars like AWS_ACCESS_KEY_ID
+    // or credentials can be obtained from a single file on the host like $HOME/.aws/credentials
+    // for now ill assume a credentials file with profile: buttonweavers
+    // https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html
+
+    $SnSclient = new SnsClient([
+        'profile' => 'buttonweavers',
+        'region' => 'us-east-1',
+        'version' => 'latest'
+    ]);
+
+    return $SnSclient;
+}

--- a/test/src/notify/sns.test.php
+++ b/test/src/notify/sns.test.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * sns : definition of communication to notification service
+ */
+
+// TODO: consider the appropriate test setup.
+// connect to different SNS Topic? or stub out calls so they no-op? or provide choice?
+
+// TODO: determine the proper way, in this project, to get the libs i need
+require 'vendor/autoload.php';
+use Aws\Sns\SnsClient;
+use Aws\Exception\AwsException;
+
+/**
+ * build a client
+ *
+ * @return SnSclient
+ */
+function snsClient() {
+
+    // credentials can be obtained from ENV vars like AWS_ACCESS_KEY_ID
+    // or credentials can be obtained from a single file on the host like $HOME/.aws/credentials
+    // for now ill assume a credentials file with profile: buttonweavers
+    // https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html
+
+    $SnSclient = new SnsClient([
+        'profile' => 'buttonweavers',
+        'region' => 'us-east-1',
+        'version' => '2010-03-31'
+    ]);
+
+    return $SnSclient;
+}


### PR DESCRIPTION
I would like to discuss the possibility to publishing some game actions to a notification service like a SNS topic. 

If this has already been discussed please advise. 

The code here is the beginning of an idea and a demonstration that I may be able to find my way around the PHP enough to help implement this. 

VALUE

by publishing some game actions to a SNS topic that would allow other apps/systems to subscribe to the topics and react accordingly. Subscriptions could be HTTP, SQS, or Lambda all of which would be managed outside of the buttonweavers code base.
 - MAINLY scripts would not have to call/poll the api as frequently while still providing quick responses
 - the community could possibly create more supporting functionality without imposing much more traffic or code demands on the development team
 - some site feature requests may be able to be easily solved outside of the current codebase. for example if somebody wanted to create a simple Lambda that emailed you when a UBFC match was waiting for your turn that would be possible. 
 - this also opens the doors to emitting more events of various kinds to lend towards various automation. 

This mainly started as an idea while working on BMAI. I want BMAI to be able to respond to matches quickly but i dont want to be polling all day long if there is nobody needing engagement with BMAI. Mainly to save traffic and resources on the webserver. If notifications get out to SNS then i could actually move BMAI to run on demand as needed as a Lambda and the not be running when not needed. 

What is required from an AWS point of view? Well there are 2 - 3 primary resources. 
 - **Topic** <- could be owned by non-buttonmen-dev but the site would then be dependent on an outside entity. i would suggest at least this is owned by buttonmen-dev group. 1st million messages a month are free. 50 cents per mission after that. 
 - **Topic Subscription** <- this could be owned by the Topic Owner (if you want control) or the message consumer (if you want freedom to make adjustments).
 - **Destination** like an HTTP Endpoint, SQS Queue, Lambda <- this you want owned and paid for by the consumer. Me in the case of BMAI

Imagine a future scenario where all the button stats are updated in real time without taxing the current systems or current DB because enough information is published over SNS for that to be cataloged separately. 

Imagine somebody wanting to make a deeper integration with Challonge brackets or a ranked leaderboard that could respond to events in near real time without increasing traffic to your site. 

Is there any appetite to continue this conversation? 

MARKED AS DRAFT PR BECAUSE THIS IS NOT READY TO MERGE, JUST READY TO DISCUSS. 