### PR TITLE
Changed exception to error message when reactToNewGame receives a false input argument

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -452,7 +452,8 @@ class BMInterfaceGame extends BMInterface {
      */
     public function save_join_game_decision($playerId, $gameId, $decision) {
         if (('accept' != $decision) && ('reject' != $decision)) {
-            throw new InvalidArgumentException('decision must be either accept or reject');
+            $this->set_message('decision must be either accept or reject');
+            return;
         }
 
         $game = $this->load_game($gameId);


### PR DESCRIPTION
Fixes #2685.

I presume this is all that needs to happen to fix the issue, but it'll need testing from an API client.