### PR TITLE
Migrate BMInterfacePlayer and BMInterfaceGameChat to use BMDB

### DIFF
--- a/deploy/circleci/audit_php_files.php
+++ b/deploy/circleci/audit_php_files.php
@@ -31,6 +31,7 @@
   // In these directories, we limit the use of explicit (int) casts
   $php_limit_int_cast_dirs = array(
     "src/api",
+    "src/engine",
   );
   $php_limit_int_cast_exceptions = array(
     // exceptions for $_SESSION variables
@@ -38,6 +39,19 @@
     "src/api/api_core.php" => 1,
     // exception for the API-spec-level validate and cast of all numeric args to int
     "src/api/ApiSpec.php" => 2,
+    // exceptions for the three int types BMDB supports on select
+    "src/engine/BMDB.php" => 3,
+
+    // arbitrarily high exceptions because we are not yet limiting casts in these files (#712)
+    "src/engine/BMAttack.php" => 1000,
+    "src/engine/BMDie.php" => 1000,
+    "src/engine/BMDieSwing.php" => 1000,
+    "src/engine/BMGame.php" => 1000,
+    "src/engine/BMInterface.php" => 1000,
+    "src/engine/BMInterfaceForum.php" => 1000,
+    "src/engine/BMInterfaceGame.php" => 1000,
+    "src/engine/BMInterfaceGameAction.php" => 1000,
+    "src/engine/BMPlayer.php" => 1000,
   );
 
   // In these directories, we limit explicit references to $_SESSION variables

--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -534,7 +534,7 @@ class ApiResponder {
         return $interface->game_chat()->set_chat_visibility(
             $this->session_user_id(),
             $args['game'],
-            'true' == $args['private']
+            $args['private']
         );
     }
 

--- a/src/engine/BMDB.php
+++ b/src/engine/BMDB.php
@@ -77,6 +77,19 @@ class BMDB {
     }
 
     /**
+     * Execute a query which performs a database update
+     *
+     * @param $conn
+     * @param string $query
+     * @param array $parameters
+     * @return void
+     */
+    public function update($query, $parameters) {
+        $statement = self::$conn->prepare($query);
+        $statement->execute($parameters);
+    }
+
+    /**
      * Cast a value fetched from a DB to the specified return type
      *
      * @param $conn

--- a/src/engine/BMInterfaceGameChat.php
+++ b/src/engine/BMInterfaceGameChat.php
@@ -176,9 +176,13 @@ class BMInterfaceGameChat extends BMInterface {
                 'FROM game_chat_log ';
 
             $query .= $this->build_game_log_query_restrictions($game, $doQueryPreviousGame, FALSE, $sqlParameters);
+            $columnReturnTypes = array(
+              'chat_timestamp' => 'int',
+              'chatting_player' => 'int',
+              'message' => 'str',
+            );
 
-            $statement = self::$conn->prepare($query);
-            $statement->execute($sqlParameters);
+            $rows = self::$db->select_rows($query, $sqlParameters, $columnReturnTypes);
 
             $chatEntries = array();
 
@@ -192,12 +196,12 @@ class BMInterfaceGameChat extends BMInterface {
                 );
             }
 
-            while ($row = $statement->fetch()) {
+            foreach ($rows as $row) {
                 // Even a player who can't view chat messages should be able to see non-chat entries
                 // like continuation messages which are stored in the chat stream
                 if ($canViewChat || $row['chatting_player'] == 0) {
                     $chatEntries[] = array(
-                        'timestamp' => (int)$row['chat_timestamp'],
+                        'timestamp' => $row['chat_timestamp'],
                         'player' => $this->get_player_name_from_id($row['chatting_player']),
                         'message' => $row['message'],
                     );
@@ -381,12 +385,10 @@ class BMInterfaceGameChat extends BMInterface {
                  '(game_id, chatting_player, message) ' .
                  'VALUES ' .
                  '(:game_id, :chatting_player, :message)';
-        $statement = self::$conn->prepare($query);
-        $statement->execute(
-            array(':game_id'         => $gameId,
-                  ':chatting_player' => $playerId,
-                  ':message'         => $chat)
-        );
+        $parameters = array(':game_id'         => $gameId,
+                            ':chatting_player' => $playerId,
+                            ':message'         => $chat);
+        self::$db->update($query, $parameters);
     }
 
     /**
@@ -406,11 +408,11 @@ class BMInterfaceGameChat extends BMInterface {
                  'AND UNIX_TIMESTAMP(chat_time) = :timestamp ' .
                  'ORDER BY id DESC ' .
                  'LIMIT 1';
-        $statement = self::$conn->prepare($query);
-        $statement->execute(array(':message' => $chat,
-                                  ':game_id' => $gameId,
-                                  ':player_id' => $playerId,
-                                  ':timestamp' => $editTimestamp));
+        $parameters = array(':message' => $chat,
+                            ':game_id' => $gameId,
+                            ':player_id' => $playerId,
+                            ':timestamp' => $editTimestamp);
+        self::$db->update($query, $parameters);
     }
 
     /**
@@ -428,10 +430,10 @@ class BMInterfaceGameChat extends BMInterface {
                  'AND UNIX_TIMESTAMP(chat_time) = :timestamp ' .
                  'ORDER BY id DESC ' .
                  'LIMIT 1';
-        $statement = self::$conn->prepare($query);
-        $statement->execute(array(':game_id' => $gameId,
-                                  ':player_id' => $playerId,
-                                  ':timestamp' => $editTimestamp));
+        $parameters = array(':game_id' => $gameId,
+                            ':player_id' => $playerId,
+                            ':timestamp' => $editTimestamp);
+        self::$db->update($query, $parameters);
     }
 
     /**
@@ -446,9 +448,9 @@ class BMInterfaceGameChat extends BMInterface {
                  'SET is_chat_private = :is_chat_private ' .
                  'WHERE game_id = :game_id ' .
                  'AND player_id = :player_id ';
-        $statement = self::$conn->prepare($query);
-        $statement->execute(array(':game_id' => $gameId,
-                                  ':player_id' => $playerId,
-                                  ':is_chat_private' => (int)$private));
+        $parameters = array(':game_id' => $gameId,
+                            ':player_id' => $playerId,
+                            ':is_chat_private' => $private);
+        self::$db->update($query, $parameters);
     }
 }

--- a/src/engine/BMInterfacePlayer.php
+++ b/src/engine/BMInterfacePlayer.php
@@ -22,84 +22,77 @@ class BMInterfacePlayer extends BMInterface {
         try {
             $query =
                 'SELECT p.*, b.name AS favorite_button, bs.name AS favorite_buttonset, ' .
-                    'UNIX_TIMESTAMP(p.last_access_time) AS last_access_timestamp, ' .
-                    'UNIX_TIMESTAMP(p.last_action_time) AS last_action_timestamp, ' .
-                    'UNIX_TIMESTAMP(p.creation_time) AS creation_timestamp ' .
+                    'UNIX_TIMESTAMP(p.last_access_time) AS last_access_time, ' .
+                    'UNIX_TIMESTAMP(p.last_action_time) AS last_action_time, ' .
+                    'UNIX_TIMESTAMP(p.creation_time) AS creation_time ' .
                 'FROM player_view p ' .
                     'LEFT JOIN button b ON b.id = p.favorite_button_id ' .
                     'LEFT JOIN buttonset bs ON bs.id = p.favorite_buttonset_id ' .
                 'WHERE p.id = :id';
-            $statement = self::$conn->prepare($query);
-            $statement->execute(array(':id' => $playerId));
-            $result = $statement->fetchAll();
-
-            if (0 == count($result)) {
+            $columnReturnTypes = array(
+                'id' => 'int',
+                'name_ingame' => 'str',
+                'name_irl' => 'str_or_null',
+                'email' => 'str',
+                'is_email_public' => 'bool',
+                'status' => 'str',
+                'dob_month' => 'int',
+                'dob_day' => 'int',
+                'gender' => 'str_or_null',
+                'image_size' => 'int_or_null',
+                'autoaccept' => 'bool',
+                'autopass' => 'bool',
+                'fire_overshooting' => 'bool',
+                'uses_gravatar' => 'bool',
+                'monitor_redirects_to_game' => 'bool',
+                'monitor_redirects_to_forum' => 'bool',
+                'automatically_monitor' => 'bool',
+                'die_background' => 'str',
+                'comment' => 'str_or_null',
+                'vacation_message' => 'str_or_null',
+                'player_color' => 'str_or_null',
+                'opponent_color' => 'str_or_null',
+                'neutral_color_a' => 'str_or_null',
+                'neutral_color_b' => 'str_or_null',
+                'homepage' => 'str_or_null',
+                'favorite_button' => 'str_or_null',
+                'favorite_buttonset' => 'str_or_null',
+                'last_action_time' => 'int_or_null',
+                'last_access_time' => 'int_or_null',
+                'creation_time' => 'int_or_null',
+                'fanatic_button_id' => 'int_or_null',
+                'n_games_won' => 'int',
+                'n_games_lost' => 'int',
+            );
+            $parameters = array(':id' => $playerId);
+            $rows = self::$db->select_rows($query, $parameters, $columnReturnTypes);
+            if (0 == count($rows)) {
                 return NULL;
             }
+            $playerInfoArray = $rows[0];
         } catch (Exception $e) {
-            if (isset($statement)) {
-                $errorData = $statement->errorInfo();
-                $this->set_message('Player info get failed: ' . $errorData[2]);
-            } else {
-                $this->set_message('Player info get failed: ' . $e->getMessage());
-            }
+            $this->set_message('Player info get failed: ' . $e->getMessage());
             error_log($this->message);
             return NULL;
         }
 
-        $infoArray = $result[0];
 
-        $last_action_time = (int)$infoArray['last_action_timestamp'];
-        if ($last_action_time == 0) {
-            $last_action_time = NULL;
+        // Some values have defaults
+        if ($playerInfoArray['name_irl'] == NULL) {
+            $playerInfoArray['name_irl'] = $playerInfoArray['name_ingame'];
         }
-
-        $last_access_time = (int)$infoArray['last_access_timestamp'];
-        if ($last_access_time == 0) {
-            $last_access_time = NULL;
+        if ($playerInfoArray['player_color'] == NULL) {
+            $playerInfoArray['player_color'] = self::DEFAULT_PLAYER_COLOR;
         }
-
-        $image_size = NULL;
-        if ($infoArray['image_size'] != NULL) {
-            $image_size = (int)$infoArray['image_size'];
+        if ($playerInfoArray['opponent_color'] == NULL) {
+            $playerInfoArray['opponent_color'] = self::DEFAULT_OPPONENT_COLOR;
         }
-
-        // set the values we want to actually return
-        $playerInfoArray = array(
-            'id' => (int)$infoArray['id'],
-            'name_ingame' => $infoArray['name_ingame'],
-            'name_irl' => $infoArray['name_irl'] ?: $infoArray['name_ingame'],
-            'email' => $infoArray['email'],
-            'is_email_public' => (bool)$infoArray['is_email_public'],
-            'status' => $infoArray['status'],
-            'dob_month' => (int)$infoArray['dob_month'],
-            'dob_day' => (int)$infoArray['dob_day'],
-            'gender' => $infoArray['gender'],
-            'image_size' => $image_size,
-            'autoaccept' => (bool)$infoArray['autoaccept'],
-            'autopass' => (bool)$infoArray['autopass'],
-            'fire_overshooting' => (bool)$infoArray['fire_overshooting'],
-            'uses_gravatar' => (bool)$infoArray['uses_gravatar'],
-            'monitor_redirects_to_game' => (bool)$infoArray['monitor_redirects_to_game'],
-            'monitor_redirects_to_forum' => (bool)$infoArray['monitor_redirects_to_forum'],
-            'automatically_monitor' => (bool)$infoArray['automatically_monitor'],
-            'die_background' => $infoArray['die_background'],
-            'comment' => $infoArray['comment'],
-            'vacation_message' => $infoArray['vacation_message'],
-            'player_color' => $infoArray['player_color'] ?: self::DEFAULT_PLAYER_COLOR,
-            'opponent_color' => $infoArray['opponent_color'] ?: self::DEFAULT_OPPONENT_COLOR,
-            'neutral_color_a' => $infoArray['neutral_color_a'] ?: self::DEFAULT_NEUTRAL_COLOR_A,
-            'neutral_color_b' => $infoArray['neutral_color_b'] ?: self::DEFAULT_NEUTRAL_COLOR_B,
-            'homepage' => $infoArray['homepage'],
-            'favorite_button' => $infoArray['favorite_button'],
-            'favorite_buttonset' => $infoArray['favorite_buttonset'],
-            'last_action_time' => $last_action_time,
-            'last_access_time' => $last_access_time,
-            'creation_time' => (int)$infoArray['creation_timestamp'],
-            'fanatic_button_id' => (int)$infoArray['fanatic_button_id'],
-            'n_games_won' => (int)$infoArray['n_games_won'],
-            'n_games_lost' => (int)$infoArray['n_games_lost'],
-        );
+        if ($playerInfoArray['neutral_color_a'] == NULL) {
+            $playerInfoArray['neutral_color_a'] = self::DEFAULT_NEUTRAL_COLOR_A;
+        }
+        if ($playerInfoArray['neutral_color_b'] == NULL) {
+            $playerInfoArray['neutral_color_b'] = self::DEFAULT_NEUTRAL_COLOR_B;
+        }
 
         return array('user_prefs' => $playerInfoArray);
     }
@@ -113,13 +106,6 @@ class BMInterfacePlayer extends BMInterface {
      * @return mixed
      */
     public function set_player_info($playerId, array $infoArray, array $addlInfo) {
-        // mysql treats bools as one-bit integers
-        $infoArray['autopass'] = (int)($infoArray['autopass']);
-        $infoArray['fire_overshooting'] = (int)($infoArray['fire_overshooting']);
-        $infoArray['monitor_redirects_to_game'] = (int)($infoArray['monitor_redirects_to_game']);
-        $infoArray['monitor_redirects_to_forum'] = (int)($infoArray['monitor_redirects_to_forum']);
-        $infoArray['automatically_monitor'] = (int)($infoArray['automatically_monitor']);
-
         $isValidData =
             ($this->validate_player_dob($infoArray) &&
             $this->validate_player_password_and_email($addlInfo, $playerId) &&
@@ -159,10 +145,9 @@ class BMInterfacePlayer extends BMInterface {
                 $query = 'UPDATE player '.
                          "SET $infoType = :info ".
                          'WHERE id = :player_id;';
-
-                $statement = self::$conn->prepare($query);
-                $statement->execute(array(':info' => $info,
-                                          ':player_id' => $playerId));
+                $parameters = array(':info' => $info,
+                                    ':player_id' => $playerId);
+                self::$db->update($query, $parameters);
             } catch (Exception $e) {
                 $this->set_message('Player info update failed: '.$e->getMessage());
             }
@@ -224,10 +209,8 @@ class BMInterfacePlayer extends BMInterface {
         if (isset($addlInfo['current_password'])) {
             try {
                 $passwordQuery = 'SELECT password_hashed FROM player WHERE id = :playerId';
-                $passwordQuery = self::$conn->prepare($passwordQuery);
-                $passwordQuery->execute(array(':playerId' => $playerId));
-
-                $passwordResults = $passwordQuery->fetchAll();
+                $parameters = array(':playerId' => $playerId);
+                $password_hashed = self::$db->select_single_value($passwordQuery, $parameters, 'str');
             } catch (Exception $e) {
                 error_log(
                     'Caught exception in BMInterface::validate_player_password_and_email: ' .
@@ -235,11 +218,6 @@ class BMInterfacePlayer extends BMInterface {
                 );
                 return NULL;
             }
-            if (count($passwordResults) != 1) {
-                $this->set_message('An error occurred in BMInterface::validate_player_password_and_email().');
-                return FALSE;
-            }
-            $password_hashed = $passwordResults[0]['password_hashed'];
 
             // support versions of PHP older than 5.5.0
             if (version_compare(phpversion(), "5.5.0", "<")) {
@@ -284,9 +262,12 @@ class BMInterfacePlayer extends BMInterface {
                         'ON v.game_id = g.id AND v.player_id = :player_id ' .
                 'WHERE s.name = "COMPLETE" ' .
                 'GROUP BY v.n_rounds_won >= g.n_target_wins;';
-
-            $statement = self::$conn->prepare($query);
-            $statement->execute(array(':player_id' => $profilePlayerId));
+            $parameters = array(':player_id' => $profilePlayerId);
+            $columnReturnTypes = array(
+                'number_of_games' => 'int',
+                'win_or_loss' => 'int',
+            );
+            $rows = self::$db->select_rows($query, $parameters, $columnReturnTypes);
         } catch (Exception $e) {
             error_log(
                 'Caught exception in BMInterface::get_profile_info: ' .
@@ -298,12 +279,12 @@ class BMInterfacePlayer extends BMInterface {
         $nWins = 0;
         $nLosses = 0;
 
-        while ($row = $statement->fetch()) {
-            if ((int)$row['win_or_loss'] == 1) {
-                $nWins = (int)$row['number_of_games'];
+        foreach ($rows as $row) {
+            if ($row['win_or_loss'] == 1) {
+                $nWins = $row['number_of_games'];
             }
-            if ((int)$row['win_or_loss'] == 0) {
-                $nLosses = (int)$row['number_of_games'];
+            if ($row['win_or_loss'] == 0) {
+                $nLosses = $row['number_of_games'];
             }
         }
 
@@ -312,10 +293,10 @@ class BMInterfacePlayer extends BMInterface {
             'id' => $playerInfo['id'],
             'name_ingame' => $playerInfo['name_ingame'],
             'name_irl' => $playerInfo['name_irl'],
-            'email' => ($playerInfo['is_email_public'] == 1 ? $playerInfo['email'] : NULL),
+            'email' => ($playerInfo['is_email_public'] ? $playerInfo['email'] : NULL),
             'email_hash' => md5(strtolower(trim($playerInfo['email']))),
-            'dob_month' => (int)$playerInfo['dob_month'],
-            'dob_day' => (int)$playerInfo['dob_day'],
+            'dob_month' => $playerInfo['dob_month'],
+            'dob_day' => $playerInfo['dob_day'],
             'gender' => $playerInfo['gender'],
             'image_size' => $playerInfo['image_size'],
             'uses_gravatar' => $playerInfo['uses_gravatar'],
@@ -343,8 +324,8 @@ class BMInterfacePlayer extends BMInterface {
     public function update_last_action_time($playerId, $gameId = NULL) {
         try {
             $query = 'UPDATE player SET last_action_time = now() WHERE id = :id';
-            $statement = self::$conn->prepare($query);
-            $statement->execute(array(':id' => $playerId));
+            $parameters = array(':id' => $playerId);
+            self::$db->update($query, $parameters);
 
             if (is_null($gameId)) {
                 return;
@@ -353,9 +334,8 @@ class BMInterfacePlayer extends BMInterface {
             $query = 'UPDATE game_player_map SET last_action_time = now() '.
                      'WHERE player_id = :player_id '.
                      'AND game_id = :game_id';
-            $statement = self::$conn->prepare($query);
-            $statement->execute(array(':player_id' => $playerId,
-                                      ':game_id' => $gameId));
+            $parameters = array(':player_id' => $playerId, ':game_id' => $gameId);
+            self::$db->update($query, $parameters);
         } catch (Exception $e) {
             error_log(
                 'Caught exception in BMInterface::update_last_action_time: ' .
@@ -373,8 +353,8 @@ class BMInterfacePlayer extends BMInterface {
     public function update_last_access_time($playerId) {
         try {
             $query = 'UPDATE player SET last_access_time = now() WHERE id = :id';
-            $statement = self::$conn->prepare($query);
-            $statement->execute(array(':id' => $playerId));
+            $parameters = array(':id' => $playerId);
+            self::$db->update($query, $parameters);
         } catch (Exception $e) {
             error_log(
                 'Caught exception in BMInterface::update_last_access_time: ' .

--- a/test/src/api/responder01Test.php
+++ b/test/src/api/responder01Test.php
@@ -1275,7 +1275,7 @@ class responder01Test extends responderTestFramework {
         // now can't see current game chat either
         $this->verify_api_setChatVisibility(
             'Set game chat to private',
-            $gameId, 'true');
+            $gameId, TRUE);
         $expData['playerDataArray'][0]['isChatPrivate'] = TRUE;
         $expData['gameChatLogCount'] = 2;
         array_splice($expData['gameChatLog'], 0, 1);

--- a/test/src/engine/BMInterfacePlayerTest.php
+++ b/test/src/engine/BMInterfacePlayerTest.php
@@ -56,8 +56,7 @@ class BMInterfacePlayerTest extends BMInterfaceTestAbstract {
         $this->assertTrue(is_bool($resultArray['monitor_redirects_to_forum']));
         $this->assertTrue(is_bool($resultArray['automatically_monitor']));
 
-        $this->assertTrue(is_int($resultArray['fanatic_button_id']));
-        $this->assertEquals(0, $resultArray['fanatic_button_id']);
+        $this->assertEquals(NULL, $resultArray['fanatic_button_id']);
         $this->assertTrue(is_int($resultArray['n_games_won']));
         $this->assertTrue(is_int($resultArray['n_games_lost']));
     }


### PR DESCRIPTION
* Partially addresses #712
* This change is effectively a noop --- it does select `player_fanatic_id` as NULL rather than 0 (which required a unit test change), but that field is not used by anything and is never set (it is NULL for 100% of players on the prod and staging sites) and IMO it's fine for us to select it as NULL if it's NULL
* It also fixes the setChatVisibility handling in ApiResponder to expect a bool rather than a string.  I'm surprised the string handling was even working, given that the ApiSpec configuration definitely means it's getting a bool.  PHP is very weird.  Anyway, by my testing it works just fine with a bool.
* I added update functionality to BMDB for this change --- nothing in BMInterfacePlayer.php required that functionality to do anything special, so i just made it minimal.  I can expand it later if needed for other classes.
* I tested this a bunch in virtualbox, loading and modifying preferences, and i believe it's just fine --- i know i removed some code that claimed we needed to explicitly cast booleans to 1-character ints so the right thing would happen in the DB, but that doesn't seem to be true.  It definitely looks to me like if we update a mysql int field by handing it a bool value, the right thing will happen.  I suspect that's vestigial code from some past time when the values might have internally been a string representation of an int, which indeed might not have done the right thing.  But that's the world we're moving away from --- with this codebase we can be sure that whatever got past the API is a bool, so we shouldn't need to cast it.
