### PR TITLE
Add --follow-symlinks flag to sed commands for staging site (and deprecated dev site)

### DIFF
--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -98,7 +98,7 @@ class buttonmen::server {
       exec {
         "buttonmen_update_config_sitetype":
           command =>
-            "/bin/sed -i -e '/^Config.siteType =/s/production/development/' /var/www/ui/js/Config.js",
+            "/bin/sed --follow-symlinks -i -e '/^Config.siteType =/s/production/development/' /var/www/ui/js/Config.js",
           require => Exec["buttonmen_src_rsync"];
       }
     }
@@ -106,7 +106,7 @@ class buttonmen::server {
       exec {
         "buttonmen_update_config_sitetype":
           command =>
-            "/bin/sed -i -e '/^Config.siteType =/s/production/staging/' /var/www/ui/js/Config.js",
+            "/bin/sed --follow-symlinks -i -e '/^Config.siteType =/s/production/staging/' /var/www/ui/js/Config.js",
           require => Exec["buttonmen_src_rsync"];
       }
     }


### PR DESCRIPTION
This is the change that should mean i won't have to manually update the site type in Config.js for staging on the next BM release.