### PR TITLE
Don't use the ec2_placement_availability_zone variable unless we're on an EC2 instance

### DIFF
--- a/deploy/vagrant/modules/fqdn/templates/from_ec2_tags.erb
+++ b/deploy/vagrant/modules/fqdn/templates/from_ec2_tags.erb
@@ -5,9 +5,9 @@
 # Optionally put the FQDN in a file, otherwise just print it to STDOUT
 OUTPUT_FILE=$1
 
-REGION=$(echo <%= ec2_placement_availability_zone %> | sed -e 's/[a-z]$//')
 FQDN=""
 <% if @ec2_services_partition == "aws" -%>
+REGION=$(echo <%= ec2_placement_availability_zone %> | sed -e 's/[a-z]$//')
 FQDN=$(aws ec2 describe-tags --region ${REGION} --filters "Name=resource-id,Values=<%= ec2_instance_id %>" "Name=key,Values=fqdn" | grep Value | awk -F\" '{print $4}')
 <% end -%>
 


### PR DESCRIPTION
I thought i implemented the FQDN stuff in a way that would keep working on virtualbox, but i got my wires crossed and accidentally broke it.  This one-liner fixes it (so virtualbox sites come up, which is the important part, and define the default/fake FQDN `sandbox.buttonweavers.com` and thus don't try to configure HTTPS).