### PR TITLE
Upgrade various modules so that jshint can run/pass

### DIFF
--- a/src/ui/js/Env.js
+++ b/src/ui/js/Env.js
@@ -1,6 +1,7 @@
 // namespace for this "module"
-if (!(Env)) {
-  var Env = {};
+var Env;
+if (!Env) {
+  Env = {};
 }
 
 // Keycodes for use when handling keyboard events

--- a/util/grunt/package.json
+++ b/util/grunt/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.4.3",
+    "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-concat": "~0.3.0",
-    "jshint": "~1.1.0",
-    "grunt-lint-inline": "~0.1.1"
+    "jshint": "~2.13.0",
+    "grunt-lint-inline": "~1.0.0"
   }
 }


### PR DESCRIPTION
* Fixes #2728 

Simply upgrading various package versions addresses the 404 errors, but yields:
```
Running "jshint:all" (jshint) task

   ../../src/ui/js/Env.js
      3 |  var Env = {};
               ^ 'Env' was used before it was defined.

>> 1 error in 25 files
Warning: Task "jshint:all" failed. Use --force to continue.
```

Setting `"latedef": false` in our preferences would make that error go away, so we could always fall back to that if this doesn't work.

But looking at it, the *only* problem is `Env`, and the only reason we have to check whether `Env` is defined before defining it, is that the JS unit tests use an `Env` property to define the fact that they are running under unit test.  That's kludgy in itself and we could probably do better, but it doesn't really matter --- as far as i can tell, we can initialize `Env` unconditionally, then only define it if it's undefined, and that makes everyone happy:
* jshint passes
* I can still browse to the UI when i bring up a vagrant site
* QUnit tests still pass interactively on my vagrant site and via CircleCI

So afaict this solves the problem, and gets us back into a state where builds can pass.
