### PR TITLE
Check whether site allows CustomBM as the first step of are_custom_recipes_valid()

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -246,11 +246,6 @@ class BMInterfaceGame extends BMInterface {
             return TRUE;
         }
 
-        if ($this->get_config('site_type') != 'development') {
-            $this->set_message('Custom recipes can only be used on development sites.');
-            return FALSE;
-        }
-
         if (empty($customRecipeArray)) {
             return FALSE;
         }
@@ -283,6 +278,11 @@ class BMInterfaceGame extends BMInterface {
         array $buttonNameArray,
         array $customRecipeArray
     ) {
+        if ($this->get_config('site_type') != 'development') {
+            $this->set_message('Custom recipes can only be used on development sites.');
+            return FALSE;
+        }
+
         foreach ($buttonNameArray as $position => $buttonName) {
             if ('CustomBM' == $buttonName) {
                 if (empty($customRecipeArray)) {


### PR DESCRIPTION
* This way we'll error out on site type before inspecting the recipes


* Fixes #2757 

I'm going to go ahead and setup a dev site for this, and we can check it out there.