### PR TITLE
Fixed bug with game creation being blocked by CustomBM checking

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -278,13 +278,13 @@ class BMInterfaceGame extends BMInterface {
         array $buttonNameArray,
         array $customRecipeArray
     ) {
-        if ($this->get_config('site_type') != 'development') {
-            $this->set_message('Custom recipes can only be used on development sites.');
-            return FALSE;
-        }
-
         foreach ($buttonNameArray as $position => $buttonName) {
             if ('CustomBM' == $buttonName) {
+                if ($this->get_config('site_type') != 'development') {
+                    $this->set_message('Custom recipes can only be used on development sites.');
+                    return FALSE;
+                }
+                
                 if (empty($customRecipeArray)) {
                     $this->set_message('customRecipeArray must be supplied');
                     return FALSE;


### PR DESCRIPTION
Fixes #2762.

This unblocks game creation, and still maintains a restriction on creating games with CustomBM if the site is not a development site.

@cgolubi1, I think this needs to be approved urgently, assuming you're happy with it and your tests of CustomBM still pass.