### PR TITLE
Run most responderTests on a production site_type

### DIFF
--- a/test/src/api/responder03Test.php
+++ b/test/src/api/responder03Test.php
@@ -4487,6 +4487,9 @@ class responder03Test extends responderTestFramework {
      * having the CustomBM player perform at least one game action.
      */
     public function test_interface_game_060() {
+        // This test uses CustomBM, which can't be used on a production site
+        $this->update_config_site_type('development');
+
         // responder003 is the POV player, so if you need to fake
         // login as a different player e.g. to submit an attack, always
         // return to responder003 as soon as you've done so
@@ -4553,5 +4556,7 @@ class responder03Test extends responderTestFramework {
         $expData['validAttackTypeArray'] = array("Power", "Skill");
 
         $retval = $this->verify_api_loadGameData($expData, $gameId, 10);
+
+        $this->update_config_site_type('production');
     }
 }

--- a/test/src/api/responderTestFramework.php
+++ b/test/src/api/responderTestFramework.php
@@ -556,6 +556,24 @@ class responderTestFramework extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Utility function to update config.site_type in the test database
+     *
+     * Our goal is to test the behavior of a production type site as often as possible.
+     * Only fall back to behaving like a non-production site when there's a specific
+     * reason the test can't run on production (e.g. test uses an unimplemented button).
+     */
+    protected function update_config_site_type($site_type) {
+        // N.B. it's generally undesirable to invoke database operations directly in responderTest.
+        // Do NOT take this functionality as precedent that this is a good way to run tests, and
+        // specifically NEVER modify database state in the middle of a responder test
+        $conn = conn();
+        $query = 'UPDATE config SET conf_value = :site_type WHERE conf_key = "site_type"';
+        $parameters = array(':site_type' => $site_type);
+        $statement = $conn->prepare($query);
+        $statement->execute($parameters);
+    }
+
+    /**
      * Utility function to suppress non-zero timestamps in a game data option.
      * This function shouldn't do any assertions itself; that's the caller's job.
      */


### PR DESCRIPTION
This is my proposed fix for the fact that no tests alerted us to #2762

Had we had this change in place when i introduced the initial syntax for the CustomBM change, responder tests would have lit up:

```
$ sudo /usr/local/bin/create_buttonmen_databases && sudo -u vagrant phpunit --bootstrap /usr/local/etc/buttonmen_phpunit.php /buttonmen/test/src/api/
...
FAILURES!
Tests: 107, Assertions: 625, Failures: 71, Skipped: 5, Incomplete: 3.
```