### PR TITLE
save_game should throw an exception when it fails to save the game

### DIFF
--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -965,6 +965,7 @@ class BMInterface {
             );
             $this->set_message("Game save failed: $e");
             self::$conn->rollBack();
+            throw new BMExceptionDatabase("Game save failed");
         }
     }
 


### PR DESCRIPTION
* Fixes #2769 

This isn't a very exciting fix, but it should solve the general problem of preventing the backend from reporting success to players when game save fails (or at least push it one layer up the stack; the calling function could catch and ignore exceptions, but i believe most API functions should return failure when they catch an exception.  Definitely `submit_die_values()` does the right thing, and that's the case for which i filed the issue.