### PR TITLE
Remove remaining unnecessary int casts from game/recipe/die code

### DIFF
--- a/deploy/circleci/audit_php_files.php
+++ b/deploy/circleci/audit_php_files.php
@@ -41,17 +41,8 @@
     "src/api/ApiSpec.php" => 2,
     // exceptions for the three int types BMDB supports on select
     "src/engine/BMDB.php" => 3,
-
-    // arbitrarily high exceptions because we are not yet limiting casts in these files (#712)
-    "src/engine/BMAttack.php" => 1000,
-    "src/engine/BMDie.php" => 1000,
-    "src/engine/BMDieSwing.php" => 1000,
-    "src/engine/BMGame.php" => 1000,
-    "src/engine/BMPlayer.php" => 1000,
-    // This file is converted to BMDB, but we haven't yet done the exercise of ensuring that
-    // subdie values reconstructed from flags are always ints.
-    // Leave those casts in place until we do
-    "src/engine/BMInterface.php" => 2,
+    // exceptions for validate_die_size(), which parses string die recipe into int sides
+    "src/engine/BMDie.php" => 2,
   );
 
   // In these directories, we limit explicit references to $_SESSION variables

--- a/src/engine/BMAttack.php
+++ b/src/engine/BMAttack.php
@@ -86,8 +86,8 @@ abstract class BMAttack {
             $attacker->run_hooks(
                 'attack_list',
                 array('attackTypeArray' => &$attackTypeArray,
-                      'value' => (int)$attacker->value,
-                      'nAttDice' => (int)count($attackers))
+                      'value' => $attacker->value,
+                      'nAttDice' => count($attackers))
             );
 
             foreach ($attackTypeArray as $attackType) {

--- a/src/engine/BMDie.php
+++ b/src/engine/BMDie.php
@@ -138,7 +138,7 @@ class BMDie extends BMCanHaveSkill {
             $this->max = 0;
         } else {
             $this->min = 1;
-            $this->max = (int)$sides;
+            $this->max = $sides;
         }
 
         $this->add_multiple_skills($skills);
@@ -301,20 +301,30 @@ class BMDie extends BMCanHaveSkill {
      * Create an appropriate BMDie with a specified number of sides, then
      * add skills to the die.
      *
-     * @param int $size
+     * @param string|int $size
      * @param array $skills
      * @return BMDie
      */
     public static function create($size, array $skills = NULL) {
-        self::validate_die_size($size);
+        $int_size = self::validate_die_size($size);
 
         $die = new BMDie;
 
-        $die->init($size, $skills);
+        $die->init($int_size, $skills);
 
         return $die;
     }
 
+    /**
+     * Validate and sanitize a die size parsed from a string recipe.
+     *
+     * If the size is valid, return it as an integer, so that all subsequent
+     * code can assume it is an integer.
+     * If the size is not valid, throw InvalidArgumentException.
+     *
+     * @param string|int $size
+     * @return int
+     */
     protected static function validate_die_size($size, $isOptionSubDie = FALSE) {
         if (!is_numeric($size)) {
             if ($isOptionSubDie) {
@@ -349,6 +359,8 @@ class BMDie extends BMCanHaveSkill {
                 'but you chose a size of ' . $size . '.'
             );
         }
+
+        return (int)$size;
     }
 
 
@@ -1132,7 +1144,7 @@ class BMDie extends BMCanHaveSkill {
                 throw new LogicException('Invalid option value for turbo die');
             }
         } else {
-            if ((int)$size !== $this->max) {
+            if ($size !== $this->max) {
                 throw new LogicException('Cannot change die size for a non-swing, non-option turbo die');
             }
         }

--- a/src/engine/BMDieOption.php
+++ b/src/engine/BMDieOption.php
@@ -56,6 +56,7 @@ class BMDieOption extends BMDie {
             throw new InvalidArgumentException('optionArray must have exactly two elements.');
         }
 
+        $int_optionArray = array();
         foreach ($optionArray as $option) {
             if ($option === '0') {
                 // see Issue #2614
@@ -64,7 +65,7 @@ class BMDieOption extends BMDie {
                 );
             }
 
-            self::validate_die_size($option, TRUE);
+            $int_optionArray[] = self::validate_die_size($option, TRUE);
         }
 
         $this->min = 1;
@@ -72,7 +73,7 @@ class BMDieOption extends BMDie {
         $this->divisor = 1;
         $this->remainder = 0;
 
-        $this->optionValueArray = $optionArray;
+        $this->optionValueArray = $int_optionArray;
         $this->needsOptionValue = TRUE;
         $this->valueRequested = FALSE;
 

--- a/src/engine/BMDieSwing.php
+++ b/src/engine/BMDieSwing.php
@@ -273,7 +273,7 @@ class BMDieSwing extends BMDie {
             return FALSE;
         }
 
-        $sides = (int)$swingList[$this->swingType];
+        $sides = $swingList[$this->swingType];
 
         if ($sides < $this->swingMin || $sides > $this->swingMax) {
             return FALSE;

--- a/src/engine/BMGame.php
+++ b/src/engine/BMGame.php
@@ -3342,7 +3342,7 @@ class BMGame {
                 'Invalid game ID.'
             );
         }
-        $this->gameId = (int)$value;
+        $this->gameId = $value;
     }
 
     /**
@@ -3387,7 +3387,7 @@ class BMGame {
                 'Invalid player index.'
             );
         }
-        $this->activePlayerIdx = (int)$value;
+        $this->activePlayerIdx = $value;
     }
 
     /**
@@ -3409,7 +3409,7 @@ class BMGame {
                 'Invalid player index.'
             );
         }
-        $this->playerWithInitiativeIdx = (int)$value;
+        $this->playerWithInitiativeIdx = $value;
     }
 
     /**
@@ -3555,7 +3555,7 @@ class BMGame {
                 'maxWins must be a positive integer.'
             );
         }
-        $this->maxWins = (int)$value;
+        $this->maxWins = $value;
     }
 
     /**
@@ -3565,7 +3565,7 @@ class BMGame {
      */
     protected function set__gameState($value) {
         BMGameState::validate_game_state($value);
-        $this->gameState = (int)$value;
+        $this->gameState = $value;
     }
 
     /**

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -247,10 +247,10 @@ class BMInterface {
                 $playerName = $this->get_player_name_from_id($gamePlayer->playerId);
                 $playerNameArray[] = $playerName;
                 $data['playerDataArray'][$gamePlayerIdx]['playerName'] = $playerName;
-                $isOnVacation = (bool) $game->playerArray[$gamePlayerIdx]->isOnVacation;
+                $isOnVacation = $game->playerArray[$gamePlayerIdx]->isOnVacation;
                 $data['playerDataArray'][$gamePlayerIdx]['isOnVacation'] = $isOnVacation;
 
-                $isChatPrivate = (bool) $game->playerArray[$gamePlayerIdx]->isChatPrivate;
+                $isChatPrivate = $game->playerArray[$gamePlayerIdx]->isChatPrivate;
                 $data['playerDataArray'][$gamePlayerIdx]['isChatPrivate'] = $isChatPrivate;
             }
 
@@ -867,11 +867,11 @@ class BMInterface {
                 $subdiePropertyArray = $die->flagList['Twin']->value();
                 $max = $subdiePropertyArray['sides'][$subdieIdx];
                 if (isset($max)) {
-                    $subdie->max = (int)$max;
+                    $subdie->max = $max;
                 }
                 $value = $subdiePropertyArray['values'][$subdieIdx];
                 if (isset($value)) {
-                    $subdie->value = (int)$value;
+                    $subdie->value = $value;
                 }
             } else {
                 // continue to handle the old case where there was no BMFlagTwin information

--- a/src/engine/BMInterfaceGameChat.php
+++ b/src/engine/BMInterfaceGameChat.php
@@ -126,7 +126,7 @@ class BMInterfaceGameChat extends BMInterface {
             $this->db_set_chat_visibility($playerId, $gameId, $private);
 
             // Now return a message based on the new and opponent states
-            $opponentIsChatPrivate = (bool) $game->playerArray[1 - $currentPlayerIdx]->isChatPrivate;
+            $opponentIsChatPrivate = $game->playerArray[1 - $currentPlayerIdx]->isChatPrivate;
             if ($private) {
                 $this->set_message("Set game chat to private");
                 return TRUE;

--- a/src/engine/BMPlayer.php
+++ b/src/engine/BMPlayer.php
@@ -399,13 +399,13 @@ class BMPlayer {
         if (array_key_exists('W', $value) &&
             array_key_exists('L', $value) &&
             array_key_exists('D', $value)) {
-            $this->gameScoreArray = array('W' => (int)$value['W'],
-                                          'L' => (int)$value['L'],
-                                          'D' => (int)$value['D']);
+            $this->gameScoreArray = array('W' => $value['W'],
+                                          'L' => $value['L'],
+                                          'D' => $value['D']);
         } else {
-            $this->gameScoreArray = array('W' => (int)$value[0],
-                                          'L' => (int)$value[1],
-                                          'D' => (int)$value[2]);
+            $this->gameScoreArray = array('W' => $value[0],
+                                          'L' => $value[1],
+                                          'D' => $value[2]);
         }
     }
 

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -1089,7 +1089,7 @@ class responder00Test extends responderTestFramework {
 
         $args = array(
             'type' => 'editForumPost',
-            'postId' => (int)$thread['data']['posts'][0]['postId'],
+            'postId' => $thread['data']['posts'][0]['postId'],
             'body' => 'Cat!',
         );
         $retval = $this->verify_api_success($args);

--- a/test/src/ui/js/test_Api.js
+++ b/test/src/ui/js/test_Api.js
@@ -461,7 +461,7 @@ test("test_Api.parseGamePlayerData", function(assert) {
               "array of captured dice should be parsed");
     assert.deepEqual(
       Api.game.player.optRequestArray[4],
-      ['2', '20'],
+      [2, 20],
       "option request array should contain entry for (2/20)");
     delete Game.game;
     start();
@@ -474,7 +474,7 @@ test("test_Api.parseGamePlayerData_option", function(assert) {
   Api.getGameData(gameId, 10, function() {
     assert.deepEqual(Api.game.player.swingRequestArray, {});
     assert.deepEqual(Api.game.player.optRequestArray, {
-      4: ["2", "20"],
+      4: [2, 20],
     });
     start();
   });


### PR DESCRIPTION
* Refactor die parsing slightly so that validate_die_size() does all interaction with the die size as a string, including casting it to an int
* Also remove some bool casts which are not necessary under BMDB

* Fixes #712 (finally!  i think!)