### PR TITLE
Re-enabled button recipes with zero-option dice

### DIFF
--- a/deploy/database/data.button.sql
+++ b/deploy/database/data.button.sql
@@ -1254,7 +1254,7 @@ INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
 
 INSERT INTO button (id, name, recipe, btn_special, tourn_legal, set_id) VALUES
 (788, 'AnnoDomini',       '(W) (4) (R) s(4) (W)',                          0, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),
-(789, 'blackshadowshade', 'mkht(T)! Bt(T)& `fg(4) bHt^(0/10) F%(1,10) rbHt^(0/10) rnDt^(1,8)', 1, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),
+(789, 'blackshadowshade', 'mkht(T)! Bt(T)& `fg(4) bHt^(0/10) F%(1,10) rbHt^(0/10) rnDt^(1,8)', 0, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),
 (790, 'Blargh',           'Hop(4) hop(10) Mh(8) Mf(8) MF(13)',             0, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),
 (791, 'devious',          'dv(S) (16) (16) pqr(S,S) Jm`(0) Jm`(0) Jm`(0)', 0, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),
 (792, 'jimmosk',          '(4) %(8) g(12) JIMmo(S) k(2)',                  0, 0, (SELECT id FROM buttonset WHERE name="2020 Fanatics")),

--- a/deploy/database/updates/02772_reenable_zero_option_01.sql
+++ b/deploy/database/updates/02772_reenable_zero_option_01.sql
@@ -1,0 +1,1 @@
+UPDATE button SET btn_special = 0 WHERE name = 'blackshadowshade';

--- a/src/engine/BMDieOption.php
+++ b/src/engine/BMDieOption.php
@@ -58,13 +58,6 @@ class BMDieOption extends BMDie {
 
         $int_optionArray = array();
         foreach ($optionArray as $option) {
-            if ($option === '0') {
-                // see Issue #2614
-                throw new BMExceptionUnimplementedDie(
-                    'Option die size of 0 is currently not supported.'
-                );
-            }
-
             $int_optionArray[] = self::validate_die_size($option, TRUE);
         }
 

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -560,7 +560,7 @@ class responder00Test extends responderTestFramework {
         $retval = $this->verify_api_success($args);
         $this->assertEquals($retval['status'], 'ok');
         $this->assertEquals($retval['message'], 'Button data retrieved successfully.');
-        $this->assertEquals(count($retval['data']), 697);
+        $this->assertEquals(count($retval['data']), 698);
 
         $this->cache_json_api_output('loadButtonData', 'noargs', $retval);
     }


### PR DESCRIPTION
Fixes #2772.

This pull request will need a responder test or two to lock in the behaviour of zero-option dice.

Naturally, this pull request will conflict with any other that changes the number of active buttons.