### PR TITLE
Refactor BMUtilityHitTable to use less memory

### DIFF
--- a/src/engine/BMAttackSkill.php
+++ b/src/engine/BMAttackSkill.php
@@ -64,7 +64,7 @@ class BMAttackSkill extends BMAttack {
      *
      * @param bool $includeOptional
      */
-    protected function generate_hit_table($includeOptional = TRUE) {
+    protected function generate_hit_table($includeOptional = TRUE, $hitVals = NULL) {
         if ($includeOptional) {
             $validDice = $this->validDice;
         } else {
@@ -80,7 +80,7 @@ class BMAttackSkill extends BMAttack {
 
         self::strip_excess_plain_zeros($validDice);
 
-        $this->hitTable = new BMUtilityHitTable($validDice);
+        $this->hitTable = new BMUtilityHitTable($validDice, $hitVals=$hitVals);
     }
 
     /**
@@ -124,7 +124,12 @@ class BMAttackSkill extends BMAttack {
             return FALSE;
         }
 
-        $this->generate_hit_table($includeOptional);
+        $dvals = array();
+        foreach ($targets as $t) {
+            $dvals[] = $t->defense_value($this->type);
+        }
+
+        $this->generate_hit_table($includeOptional, $hitVals=$dvals);
         $hits = $this->hitTable->list_hits();
 
         foreach ($targets as $t) {
@@ -225,7 +230,7 @@ class BMAttackSkill extends BMAttack {
         $dval = $defenders[0]->defense_value($this->type);
 
         if (!($this->hitTable instanceof BMUtilityHitTable)) {
-            $this->generate_hit_table();
+            $this->generate_hit_table($hitVals = array($dval));
         }
 
         if ($this->is_direct_attack_valid($attackers, $dval)) {

--- a/src/engine/BMUtilityHitTable.php
+++ b/src/engine/BMUtilityHitTable.php
@@ -43,66 +43,120 @@ class BMUtilityHitTable {
     private $hits = array();
 
     /**
+     * $die_ids is an array of possible unique ids to use in constructing hits
+     *
+     * @var array
+     */
+    private $die_ids = array();
+
+    /**
+     * $hitVals is the array of target hit values used to construct this hit table
+     *
+     * @var array
+     */
+    private $hitVals = array();
+
+    /**
      * Constructor
      *
      * @param array $dice
      */
-    public function __construct($dice, $maxHitValue = PHP_INT_MAX) {
-        // For building hash keys, every die needs a unique
-        // identifier, no matter how many there are, but if there are
-        // more than 36 dice, something is very, very wrong.
-        $ids = str_split("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-        for ($i = 0; $i < count($dice); $i++) {
-            $die = $dice[$i];
-            $die_id = $ids[$i];
+    public function __construct($dice, $hitVals = NULL) {
+        $this->dice = $dice;
+        $this->hitVals = $hitVals;
+        $this->die_ids = str_split("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        $this->add_dice_to_hit_table($dice, array());
 
-            $this->dice[] = $die;
+        foreach ($this->dice as $dieIdx => $die) {
+            $die->run_hooks('hit_table', array('hits' => &$this->hits,
+                                               'dieLetter' => $this->die_ids[$dieIdx]));
+        }
+    }
 
-            foreach (array_keys($this->hits) as $target) {
-                foreach (array_keys($this->hits[$target]) as $key) {
-                    // We've already been used in this combo
-                    if (FALSE !== strpos($key, $die_id)) {
-                        continue;
-                    }
-
-                    foreach ($die->attack_values("Skill") as $val) {
-                        $newcombo = $this->hits[$target][$key];
-                        $newcombo[] = $die;
-                        // the new key will always be sorted, since we
-                        // process the dice in order
-                        $newkey = $key.$die_id;
-                        $newtarget = $target + $val;
-                        if ($newtarget > $maxHitValue) {
-                            continue;
-                        }
-                        if (array_key_exists($newtarget, $this->hits)) {
-                            // If the same die combo makes a number
-                            // two ways, we just overwrite the old
-                            // entry.
-                            $this->hits[$newtarget][$newkey] = $newcombo;
-                        } else {
-                            $this->hits[$newtarget] = array($newkey => $newcombo);
-                        }
-                    }
-                }
+    /**
+     * Recursively add attacking dice to the hit table
+     *
+     * Every time this function is called, it moves one die from $diceRemaining (the set of to-be-processed dice)
+     * to $prefixDieHits (the set of hits selected from dice).  When processing the die, the function looks at all
+     * possible values that die can contribute to an attack, either as an attacker or as a helper, and recursively
+     * calls itself once for each of those choices.
+     *
+     * When $diceRemaining is empty and all dice have had values selected for $prefixDieHits, the function
+     * determines the total target value of the hit represented by this combination of dice.  It then checks to
+     * see if that total is in $this->hitVals, the set of all target (defender) die values which this hit table
+     * instantiation is trying to hit.  If the target value is one of the ones this hit table is looking for,
+     * we save the combo of attacking die values participating in the attack (discarding helpers; they can and will
+     * be rediscovered later in the process of the actual attack) in $this->hits.  If the target value isn't one
+     * this hit table is looking for, we discard the combo to avoid using a huge amount of memory to store data
+     * about irrelevant attacks.
+     *
+     * @param int $target
+     * @return bool
+     */
+    protected function add_dice_to_hit_table($diceRemaining, $prefixDieHits) {
+        // There are dice remaining to process; process the next one, and recursively call this function
+        if (count($diceRemaining) > 0) {
+            $prefixDieHitsCopy = array();
+            foreach ($prefixDieHits as $prefixDieHit) {
+                $prefixDieHitsCopy[] = $prefixDieHit;
             }
-
-            // Add the unique values the die may provide
-            foreach ($die->attack_values("Skill") as $val) {
-                if ($val > $maxHitValue) {
-                    continue;
-                }
-                if (array_key_exists($val, $this->hits)) {
-                    $this->hits[$val][$die_id] = array($die);
+            $firstDie = NULL;
+            $diceRemainingCopy = array();
+            foreach ($diceRemaining as $dieRemaining) {
+                if (is_null($firstDie)) {
+                    $firstDie = $dieRemaining;
                 } else {
-                    $this->hits[$val] = array($die_id => array($die));
+                    $diceRemainingCopy[] = $dieRemaining;
                 }
             }
+            $prefixLength = count($prefixDieHitsCopy);
+            $prefixDieHitsCopy[] = NULL;
+            $possibleHits = $firstDie->attack_values("Skill");
+            // Values which can be contributed if this die participates in an attack
+            foreach ($possibleHits as $firstDieHit) {
+                $prefixDieHitsCopy[$prefixLength] = array($firstDieHit, TRUE);
+                $this->add_dice_to_hit_table($diceRemainingCopy, $prefixDieHitsCopy);
+            }
+            // Values which can be contributed if this die does not participate in an attack
+            $possibleAssists = $firstDie->assist_values("Skill", array(), array());
+            $possibleAssists[] = 0;
+            foreach ($possibleAssists as $firstDieAssist) {
+                $prefixDieHitsCopy[$prefixLength] = array($firstDieAssist, FALSE);
+                $this->add_dice_to_hit_table($diceRemainingCopy, $prefixDieHitsCopy);
+            }
+            return;
         }
 
-        foreach ($dice as $dieIdx => $die) {
-            $die->run_hooks('hit_table', array('hits' => &$this->hits,
-                                               'dieLetter' => $ids[$dieIdx]));
+        // There are no dice remaining to process; add this combo to the hit table
+        assert(count($prefixDieHits) == count($this->dice));
+        $target = 0;
+        foreach ($prefixDieHits as $dieHit) {
+            $target += $dieHit[0];
+        }
+        if (isset($this->hitVals) && !(in_array($target, $this->hitVals))) {
+            // This combo's target sum isn't needed for the hit table
+            return;
+        }
+
+        $newcombo = array();
+        $newkeyParts = array();
+        for ($i = 0; $i < count($prefixDieHits); $i++) {
+            if ($prefixDieHits[$i][1]) {
+                $newcombo[] = $this->dice[$i];
+                $newkeyParts[] = $this->die_ids[$i];
+            }
+        }
+        if (count($newcombo) == 0) {
+            // This attack contains zero dice
+            return;
+        }
+
+        // Actually add the combo to the hit table, either as a new key or a new combo for an existing one
+        $newkey = implode(".", $newkeyParts);
+        if (array_key_exists($target, $this->hits)) {
+            $this->hits[$target][$newkey] = $newcombo;
+        } else {
+            $this->hits[$target] = array($newkey => $newcombo);
         }
     }
 

--- a/src/engine/BMUtilityHitTable.php
+++ b/src/engine/BMUtilityHitTable.php
@@ -138,10 +138,16 @@ class BMUtilityHitTable {
             return;
         }
 
+        // The logic up to this point collected both direct and indirect die contributions,
+        // for the purpose of finding exactly those combinations which could under some circumstances
+        // hit a target of interest.  However, we want to install into the hit table the
+        // target sum from the direct contributions only, because that's what find_attack() will expect
         $newcombo = array();
         $newkeyParts = array();
+        $directTarget = 0;
         for ($i = 0; $i < count($prefixDieHits); $i++) {
             if ($prefixDieHits[$i][1]) {
+                $directTarget += $prefixDieHits[$i][0];
                 $newcombo[] = $this->dice[$i];
                 $newkeyParts[] = $this->die_ids[$i];
             }
@@ -153,10 +159,10 @@ class BMUtilityHitTable {
 
         // Actually add the combo to the hit table, either as a new key or a new combo for an existing one
         $newkey = implode(".", $newkeyParts);
-        if (array_key_exists($target, $this->hits)) {
-            $this->hits[$target][$newkey] = $newcombo;
+        if (array_key_exists($directTarget, $this->hits)) {
+            $this->hits[$directTarget][$newkey] = $newcombo;
         } else {
-            $this->hits[$target] = array($newkey => $newcombo);
+            $this->hits[$directTarget] = array($newkey => $newcombo);
         }
     }
 

--- a/test/src/engine/BMAttackSkillTest.php
+++ b/test/src/engine/BMAttackSkillTest.php
@@ -142,8 +142,8 @@ class BMAttackSkillTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue($sk->validate_attack($game, array($die1), $def));
 
         // test case where the amount of help is explicitly specified
-//        $this->assertFalse($sk->validate_attack($game, array($die1), $def, array('helpValue' => 3)));
-//        $this->assertTrue($sk->validate_attack($game, array($die1), $def, array('helpValue' => 1)));
+        $this->assertFalse($sk->validate_attack($game, array($die1), $def, array('helpValue' => 3)));
+        $this->assertTrue($sk->validate_attack($game, array($die1), $def, array('helpValue' => 1)));
 
         $target->value = 2;
         $this->assertTrue($sk->validate_attack($game, array($die1), $def));

--- a/test/src/engine/BMAttackSkillTest.php
+++ b/test/src/engine/BMAttackSkillTest.php
@@ -142,8 +142,8 @@ class BMAttackSkillTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue($sk->validate_attack($game, array($die1), $def));
 
         // test case where the amount of help is explicitly specified
-        $this->assertFalse($sk->validate_attack($game, array($die1), $def, array('helpValue' => 3)));
-        $this->assertTrue($sk->validate_attack($game, array($die1), $def, array('helpValue' => 1)));
+//        $this->assertFalse($sk->validate_attack($game, array($die1), $def, array('helpValue' => 3)));
+//        $this->assertTrue($sk->validate_attack($game, array($die1), $def, array('helpValue' => 1)));
 
         $target->value = 2;
         $this->assertTrue($sk->validate_attack($game, array($die1), $def));


### PR DESCRIPTION
Pass a list of target values at hit table creation time, and only
store combos which (either directly or with assistance) can hit one
of those targets