### PR TITLE
Newer vagrant versions require additional AWS config

### DIFF
--- a/deploy/vagrant/setup_aws_vagrantfile
+++ b/deploy/vagrant/setup_aws_vagrantfile
@@ -38,6 +38,8 @@ sed -i.orig \
     -e "s,BUTTONMEN_SSH_KEYPAIR_NAME,$BUTTONMEN_SSH_KEYPAIR_NAME," \
     -e "s,BUTTONMEN_SSH_PRIVATE_KEY_PATH,$BUTTONMEN_SSH_PRIVATE_KEY_PATH," \
     -e "/:forwarded_port/s/^/#/" \
+    -e "/^  config.vm.synced_folder.*/a\ 
+  config.vm.allowed_synced_folder_types = [:rsync]" \
     $VAGRANTFILE
 if [ "$?" != "0" ]; then
   echo "sed failed - debug what went wrong"


### PR DESCRIPTION
* This forces folder sync to use rsync, rather than attempting SMB sync

See https://github.com/mitchellh/vagrant-aws/issues/365 for what happened when i tried running with a newer vagrant without this configuration.

I have no reason to believe this won't work for anyone else, but IMO this doesn't need any other testing or validation, because i think i'm the only person who's actively using `setup_aws_vagrantfile`