### PR TITLE
Clean up how puppet variables are referenced in templates

### DIFF
--- a/deploy/vagrant/modules/apache/templates/site_default.erb
+++ b/deploy/vagrant/modules/apache/templates/site_default.erb
@@ -9,7 +9,7 @@
     ## Set environment variables for buttonmen database access
 
     # Database 1 (primary)
-    SetEnv DB1_HOST <%= database_fqdn %>
+    SetEnv DB1_HOST <%= @database_fqdn %>
     SetEnv DB1_PORT 3306
     SetEnv DB1_NAME buttonmen
     SetEnv DB1_USER bmuser1

--- a/deploy/vagrant/modules/buttonmen/templates/apache.conf.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/apache.conf.erb
@@ -3,16 +3,16 @@
   ## Set environment variables for buttonmen database access
 
   # Database 1 (primary)
-  SetEnv DB1_HOST <%= database_fqdn %>
+  SetEnv DB1_HOST <%= @database_fqdn %>
   SetEnv DB1_PORT 3306
-  SetEnv DB1_NAME <%= buttonmen_db1_name %>
-  SetEnv DB1_USER <%= buttonmen_db1_user %>
-  SetEnv DB1_PASS <%= buttonmen_db1_pass %>
+  SetEnv DB1_NAME <%= @buttonmen_db1_name %>
+  SetEnv DB1_USER <%= @buttonmen_db1_user %>
+  SetEnv DB1_PASS <%= @buttonmen_db1_pass %>
   
   # Database 2 (test)
   SetEnv DB2_HOST 127.0.0.1
   SetEnv DB2_PORT 3306
-  SetEnv DB2_NAME <%= buttonmen_db2_name %>
-  SetEnv DB2_USER <%= buttonmen_db2_user %>
-  SetEnv DB2_PASS <%= buttonmen_db2_pass %>
+  SetEnv DB2_NAME <%= @buttonmen_db2_name %>
+  SetEnv DB2_USER <%= @buttonmen_db2_user %>
+  SetEnv DB2_PASS <%= @buttonmen_db2_pass %>
 </Directory>

--- a/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
@@ -18,7 +18,7 @@ fi
 if [ -f "${CREDS_FILE}" ]; then
   . ${CREDS_FILE}
   # Need to disable GTID restores to backup/restore a remote RDS MySQL DB with default args
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= database_fqdn %> --set-gtid-purged=OFF"
+  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %> --set-gtid-purged=OFF"
 else
   MYSQL_ARGS="-u root"
 fi

--- a/deploy/vagrant/modules/buttonmen/templates/create_databases.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/create_databases.erb
@@ -1,26 +1,26 @@
 #!/bin/sh
 
-mysqlshow -u root <%= buttonmen_db1_name %> | grep -q "^Database: buttonmen"
+mysqlshow -u root <%= @buttonmen_db1_name %> | grep -q "^Database: buttonmen"
 if [ "$?" = "0" ]; then
-  echo "<%= buttonmen_db1_name %> already exists"
+  echo "<%= @buttonmen_db1_name %> already exists"
 else 
-  echo "Creating <%= buttonmen_db1_name %>"
-  echo "CREATE DATABASE <%= buttonmen_db1_name %>" | mysql -u root
-  echo "GRANT ALL ON <%= buttonmen_db1_name %>.* TO <%= buttonmen_db1_user %>@localhost IDENTIFIED BY '<%= buttonmen_db1_pass %>'" | mysql -u root
+  echo "Creating <%= @buttonmen_db1_name %>"
+  echo "CREATE DATABASE <%= @buttonmen_db1_name %>" | mysql -u root
+  echo "GRANT ALL ON <%= @buttonmen_db1_name %>.* TO <%= @buttonmen_db1_user %>@localhost IDENTIFIED BY '<%= @buttonmen_db1_pass %>'" | mysql -u root
 
-  echo "Populating <%= buttonmen_db1_name %>"
+  echo "Populating <%= @buttonmen_db1_name %>"
   cd /buttonmen/deploy/database
-  mysql -u root <%= buttonmen_db1_name %> < initialize_all.sql
+  mysql -u root <%= @buttonmen_db1_name %> < initialize_all.sql
 fi
 
-mysqlshow -u root <%= buttonmen_db2_name %> | grep -q "^Database: buttonmen_test"
+mysqlshow -u root <%= @buttonmen_db2_name %> | grep -q "^Database: buttonmen_test"
 if [ "$?" = "0" ]; then
-  echo "<%= buttonmen_db2_name %> already exists - recreating it"
+  echo "<%= @buttonmen_db2_name %> already exists - recreating it"
   echo "DROP DATABASE buttonmen_test" | mysql -u root
 fi
-echo "Creating <%= buttonmen_db2_name %>"
-echo "CREATE DATABASE <%= buttonmen_db2_name %>" | mysql -u root
-echo "GRANT ALL ON <%= buttonmen_db2_name %>.* TO <%= buttonmen_db2_user %>@localhost IDENTIFIED BY '<%= buttonmen_db2_pass %>'" | mysql -u root
-echo "Populating <%= buttonmen_db2_name %>"
+echo "Creating <%= @buttonmen_db2_name %>"
+echo "CREATE DATABASE <%= @buttonmen_db2_name %>" | mysql -u root
+echo "GRANT ALL ON <%= @buttonmen_db2_name %>.* TO <%= @buttonmen_db2_user %>@localhost IDENTIFIED BY '<%= @buttonmen_db2_pass %>'" | mysql -u root
+echo "Populating <%= @buttonmen_db2_name %>"
 cd /buttonmen/deploy/database
-mysql -u <%= buttonmen_db2_user%> -p<%= buttonmen_db2_pass %> <%= buttonmen_db2_name %> < initialize_all.sql
+mysql -u <%= @buttonmen_db2_user%> -p<%= @buttonmen_db2_pass %> <%= @buttonmen_db2_name %> < initialize_all.sql

--- a/deploy/vagrant/modules/buttonmen/templates/create_rds_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/create_rds_database.erb
@@ -7,17 +7,17 @@ if [ ! -f ${CREDS_FILE} ]; then
 fi
 . ${CREDS_FILE}
 
-MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= database_fqdn %>" 
+MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>" 
 
-mysqlshow ${MYSQL_ARGS} <%= buttonmen_db1_name %> | grep -q "^Database: buttonmen"
+mysqlshow ${MYSQL_ARGS} <%= @buttonmen_db1_name %> | grep -q "^Database: buttonmen"
 if [ "$?" = "0" ]; then
-  echo "<%= buttonmen_db1_name %> already exists"
+  echo "<%= @buttonmen_db1_name %> already exists"
 else 
-  echo "Creating <%= buttonmen_db1_name %>"
-  echo "CREATE DATABASE <%= buttonmen_db1_name %>" | mysql ${MYSQL_ARGS}
-  echo "GRANT ALL ON <%= buttonmen_db1_name %>.* TO <%= buttonmen_db1_user %>@'<%= puppet_hostname %>' IDENTIFIED BY '<%= buttonmen_db1_pass %>'" | mysql ${MYSQL_ARGS}
+  echo "Creating <%= @buttonmen_db1_name %>"
+  echo "CREATE DATABASE <%= @buttonmen_db1_name %>" | mysql ${MYSQL_ARGS}
+  echo "GRANT ALL ON <%= @buttonmen_db1_name %>.* TO <%= @buttonmen_db1_user %>@'<%= @puppet_hostname %>' IDENTIFIED BY '<%= @buttonmen_db1_pass %>'" | mysql ${MYSQL_ARGS}
 
-  echo "Populating <%= buttonmen_db1_name %>"
+  echo "Populating <%= @buttonmen_db1_name %>"
   cd /buttonmen/deploy/database
-  mysql ${MYSQL_ARGS} <%= buttonmen_db1_name %> < initialize_all.sql
+  mysql ${MYSQL_ARGS} <%= @buttonmen_db1_name %> < initialize_all.sql
 fi

--- a/deploy/vagrant/modules/buttonmen/templates/mysql_root_cli.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/mysql_root_cli.erb
@@ -9,7 +9,7 @@ DBNAME=buttonmen
 # database, and in particular an admin password
 if [ -f "${CREDS_FILE}" ]; then
   . ${CREDS_FILE}
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= database_fqdn %>"
+  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>"
 else
   MYSQL_ARGS="-u root"
 fi

--- a/deploy/vagrant/modules/buttonmen/templates/test_config.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/test_config.erb
@@ -9,7 +9,7 @@ CONFIGFILE=/var/www/ui/js/Config.js
 # database, and in particular an admin password
 if [ -f "${CREDS_FILE}" ]; then
   . ${CREDS_FILE}
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= database_fqdn %> --set-gtid-purged=OFF"
+  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %> --set-gtid-purged=OFF"
 else
   MYSQL_ARGS="-u root"
 fi

--- a/deploy/vagrant/modules/fqdn/templates/from_ec2_tags.erb
+++ b/deploy/vagrant/modules/fqdn/templates/from_ec2_tags.erb
@@ -7,8 +7,8 @@ OUTPUT_FILE=$1
 
 FQDN=""
 <% if @ec2_services_partition == "aws" -%>
-REGION=$(echo <%= ec2_placement_availability_zone %> | sed -e 's/[a-z]$//')
-FQDN=$(aws ec2 describe-tags --region ${REGION} --filters "Name=resource-id,Values=<%= ec2_instance_id %>" "Name=key,Values=fqdn" | grep Value | awk -F\" '{print $4}')
+REGION=$(echo <%= @ec2_placement_availability_zone %> | sed -e 's/[a-z]$//')
+FQDN=$(aws ec2 describe-tags --region ${REGION} --filters "Name=resource-id,Values=<%= @ec2_instance_id %>" "Name=key,Values=fqdn" | grep Value | awk -F\" '{print $4}')
 <% end -%>
 
 # Use a static fake site name for both non-AWS instances and instances that failed the above check

--- a/deploy/vagrant/modules/postfix/templates/main.cf.erb
+++ b/deploy/vagrant/modules/postfix/templates/main.cf.erb
@@ -19,13 +19,13 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-myhostname = <%= puppet_hostname %>
+myhostname = <%= @puppet_hostname %>
 mydomain = buttonweavers.com
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-myorigin = <%= puppet_hostname %>
+myorigin = <%= @puppet_hostname %>
 masquerade_domains = $mydomain
-mydestination = <%= puppet_hostname %>, localhost.buttonweavers.com, localhost
+mydestination = <%= @puppet_hostname %>, localhost.buttonweavers.com, localhost
 relayhost = 
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0


### PR DESCRIPTION
This one isn't *so* critical, but it's a noop which cleans up an annoying warning that shows up when i run vagrant provision:

```
==> default: Running provisioner: puppet...
==> default: Running Puppet with init.pp...
==> default: Warning: Variable access via 'puppet_hostname' is deprecated. Use '@puppet_hostname' instead. template[/tmp/vagrant-puppet/modules-71904193657bd9e6560c6f15cd46d302/postfix/templates/main.cf.erb]:22
==> default:    (at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:77:in `method_missing')
==> default: Notice: Compiled catalog for ip-10-153-208-25.ec2.internal in environment production in 1.03 seconds
```

(The warning shows up in the circleci output too, so we should be able to use circleci to verify that we got all the relevant ones.  It only shows the warning once, for the first occurrence it parses, but it will show it if there are any occurrences in any templates.)