### PR TITLE
Undo accidental removal of FQDN config

### DIFF
--- a/deploy/vagrant/manifests/init.pp
+++ b/deploy/vagrant/manifests/init.pp
@@ -53,6 +53,7 @@ node default {
   include "postfix::base"
   include "user::buttonmen-devs"
   include "sudo::buttonmen-devs"
+  include "fqdn::base"
 
   # Node configuration needed for the buttonmen server
   include "apache::server::vagrant"


### PR DESCRIPTION
Testing done: without this change, a build of a fresh AWS site fails with:

```
==> default: Error: Could not find dependency Exec[fqdn_populate_etc_file] for Exec[apache_certbot_setup] at /tmp/vagrant-puppet/modules-01f9aab119b6a4b76e30e7c1575836eb/apache/manifests/init.pp:96
```

With this change, it succeeds.  Sorry again!