### PR TITLE
Don't use --set-gtid-purged flag when querying remote BM database for config

### DIFF
--- a/deploy/vagrant/modules/buttonmen/templates/test_config.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/test_config.erb
@@ -9,7 +9,7 @@ CONFIGFILE=/var/www/ui/js/Config.js
 # database, and in particular an admin password
 if [ -f "${CREDS_FILE}" ]; then
   . ${CREDS_FILE}
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %> --set-gtid-purged=OFF"
+  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>"
 else
   MYSQL_ARGS="-u root"
 fi


### PR DESCRIPTION
I was a little hasty in writing up the config check to detect site-type misconfigurations between DB and JS.  For an RDS database like staging, the cron job fails with:

```
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [ERROR] unknown variable 'set-gtid-purged=OFF'
site_type configuration mismatch between database and config file
* database contains:
* /var/www/ui/js/Config.js contains: staging
```

and that blank entry is because the select is failing:

```bash
$ MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h ${BM_STAGING_RDS_HOST} --set-gtid-purged=OFF"
$ echo "select conf_value from config where conf_key='site_type'" | mysql -N ${MYSQL_ARGS} ${DBNAME}
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [ERROR] unknown variable 'set-gtid-purged=OFF'
```

Without that flag, the same select succeeds:

```bash
$ MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h ${BM_STAGING_RDS_HOST}
$ echo "select conf_value from config where conf_key='site_type'" | mysql -N ${MYSQL_ARGS} ${DBNAME}
mysql: [Warning] Using a password on the command line interface can be insecure.
staging
```
