### PR TITLE
Improve apache log grep to only look at PHP errors

### DIFF
--- a/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
+++ b/deploy/vagrant/modules/apache/templates/monitor_apache_logs.erb
@@ -3,13 +3,5 @@
 
 /usr/sbin/logtail2 -o /var/spool/logtail/apache2_error.log \
   /var/log/apache2/error.log \
-  | grep -v "Caught exception in BMDie::create_from_string_components: Illegal die size: C" \
-  | grep -v "Caught exception in BMDie::create_from_string_components: Invalid recipe: &" \
-  | grep -v "Caught exception in BMDie::create_from_string_components: Invalid recipe: ," \
-  | grep -v "File does not exist: " \
-  | grep -v " not found or unable to stat" \
-  | grep -v " Graceful restart requested, doing restart" \
-  | grep -v " resuming normal operations" \
-  | grep -v "client denied by server configuration: " \
-  | grep -v "AH00094: Command line: '/usr/sbin/apache2'" \
-  | grep -v "client sent HTTP/1.1 request without hostname"
+  | grep '\[:error\]' \
+  | grep -v " not found or unable to stat"


### PR DESCRIPTION
I realised recently that all the errors recorded by our site PHP code contain the string `[:error]`, whereas errors thrown by other things within apache are `[core:error]` or `[authz:error]` or `[mpm_prefork:notice]` or whatever.  I only want to see the PHP errors, because the purpose of this log grep is to detect code/database problems.

Testing:
* ran this script against a couple of sites to make sure it was valid, including a replay site that had a bunch of database connection failures (and they did all show up as expected)
* did a bunch of poking through my e-mail archives of log error greps to validate the assertion that of the spurious errors i've been excluding, only `" not found or unable to stat"` shows up under `[:error]`
