### PR TITLE
RandomAI should handle trip attacks with ht(0) attacking die

### DIFF
--- a/tools/api-client/python/lib/random_ai.py
+++ b/tools/api-client/python/lib/random_ai.py
@@ -1041,7 +1041,7 @@ class LoggingBMClient():
 
   def _next_weak_value(self, sides):
     sizes = [1, 2, 4, 6, 8, 10, 12, 16, 20, 30]
-    if sides <= sizes[0]: return sizes[0]  # or should this return sides?
+    if sides <= sizes[0]: return sides
     return [x for x in sizes if sides > x][-1]
 
   def _generate_turbo_val_arrays(self, part_attackers, attack_type):


### PR DESCRIPTION
In testing #2800, RandomAI failed with the following crash:

```python
Starting game 96
Traceback (most recent call last):
  File "./test_log_games", line 71, in <module>
    c.log_test_game(i, button1, button2)
  File "lib/random_ai.py", line 1803, in log_test_game
    self.next_game_action()
  File "lib/random_ai.py", line 1787, in next_game_action
    if state == 'START_TURN': self._game_action_start_turn()
  File "lib/random_ai.py", line 1668, in _game_action_start_turn
    self.loaded_data['playerDataArray'][1])
  File "lib/random_ai.py", line 1581, in _game_action_start_turn_player
    retval and retval.message or "NULL"))
  File "lib/random_ai.py", line 1683, in bug
    raise ValueError, message
ValueError: API submit_turn(96, 0, 1, {'playerIdx_1_dieIdx_0': 'true', 'playerIdx_0_dieIdx_0': 'true', 'playerIdx_0_dieIdx_1': 'false'}, Trip, 4, 1641352732, {}) unexpectedly failed: Requested attack is not valid
```

Here's the game:

<img width="1150" alt="ht0" src="https://user-images.githubusercontent.com/2898207/148473532-4fe67b46-70a2-41c8-a4d7-1090cf9b822a.png">

Here's the python repl output corroborating that this is the obvious fix it looks like:

```python
>>> def _next_weak_value(sides):
...     sizes = [1, 2, 4, 6, 8, 10, 12, 16, 20, 30]
...     if sides <= sizes[0]: return sizes[0]  # or should this return sides?
...     return [x for x in sizes if sides > x][-1]
...
>>> _next_weak_value(0)
1
>>> def _next_weak_value(sides):
...     sizes = [1, 2, 4, 6, 8, 10, 12, 16, 20, 30]
...     if sides <= sizes[0]: return sides
...     return [x for x in sizes if sides > x][-1]
...
>>> _next_weak_value(0)
0
```