### PR TITLE
Throw a clean error when dismissing a game in which you're not a participant

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1631,7 +1631,7 @@ class BMInterfaceGame extends BMInterface {
                 'SELECT s.name AS "status", m.was_game_dismissed ' .
                 'FROM game AS g ' .
                 'INNER JOIN game_status AS s ON s.id = g.status_id ' .
-                    'LEFT JOIN game_player_map AS m ' .
+                    'INNER JOIN game_player_map AS m ' .
                     'ON m.game_id = g.id AND m.player_id = :player_id ' .
                 'WHERE g.id = :game_id';
             $parameters = array(
@@ -1645,7 +1645,7 @@ class BMInterfaceGame extends BMInterface {
             $rows = self::$db->select_rows($query, $parameters, $columnReturnTypes);
 
             if (count($rows) == 0) {
-                $this->set_message("Game $gameId does not exist");
+                $this->set_message("Game $gameId does not exist, or you are not a participant");
                 return NULL;
             }
             if (($rows[0]['status'] != 'COMPLETE') &&

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -976,7 +976,16 @@ class responder00Test extends responderTestFramework {
             $gameData['data'], array(array(0, 0), array(1, 0)),
             $real_game_id, 1, 'Power', 1, 0, '');
 
-        // now try to dismiss the game
+        // dismissing the game as a non-participant should fail
+        $_SESSION = $this->mock_test_user_login('responder005');
+        $args = array(
+            'type' => 'dismissGame',
+            'gameId' => $real_game_id,
+        );
+        $retval = $this->verify_api_failure($args, 'Game ' . $real_game_id . ' does not exist, or you are not a participant');
+        $_SESSION = $this->mock_test_user_login('responder004');
+
+        // now try to dismiss the game as responder004
         $args = array(
             'type' => 'dismissGame',
             'gameId' => $real_game_id,
@@ -990,6 +999,13 @@ class responder00Test extends responderTestFramework {
         // Hardcode a single fake game number here until we need to test dismissing in a more complex way
         $fakeGameNumber = 5;
         $this->cache_json_api_output('dismissGame', $fakeGameNumber, $retval);
+
+        // dismissing the same game again should fail
+        $args = array(
+            'type' => 'dismissGame',
+            'gameId' => $real_game_id,
+        );
+        $retval = $this->verify_api_failure($args, 'You have already dismissed game ' . $real_game_id);
     }
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Partially addresses #2827 

Note: i added the test before fixing the code, and verified that the test would catch the internal error:

```
chaos@ubuntu-xenial:/buttonmen/src$ sudo /usr/local/bin/create_buttonmen_databases && sudo -u vagrant phpunit --bootstrap /usr/local/etc/buttonmen_phpunit.php --group fulltest_deps /buttonmen/test/src/api/
buttonmen already exists
buttonmen_test already exists - recreating it
Creating buttonmen_test
Populating buttonmen_test
mysql: [Warning] Using a password on the command line interface can be insecure.
PHPUnit 5.1.3 by Sebastian Bergmann and contributors.

.Caught exception in BMInterface::dismiss_game: Found non-set value in DB when expecting integer
F                                                                  2 / 2 (100%)

Time: 1.33 seconds, Memory: 10.00Mb

There was 1 failure:

1) responder00Test::test_request_dismissGame
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Game 1 does not exist, or you are not a participant'
+'Internal error while dismissing a game'

/buttonmen/test/src/api/responderTestFramework.php:985
/buttonmen/test/src/api/responder00Test.php:1010

FAILURES!
Tests: 2, Assertions: 60, Failures: 1.
chaos@ubuntu-xenial:/buttonmen/src$
```