### PR TITLE
RandomAI's max-possible-side-count calculation should treat Mad and Mood like Turbo

### DIFF
--- a/tools/api-client/python/lib/random_ai.py
+++ b/tools/api-client/python/lib/random_ai.py
@@ -1012,7 +1012,7 @@ class LoggingBMClient():
       post_trip_sides = self._next_weak_value(post_trip_sides)
     # TODO: make attack-selection in general aware of Turbo, don't
     # just hack in the max possible value
-    if 'Turbo' in die['skills']:
+    if 'Turbo' in die['skills'] or 'Mad' in die['skills'] or 'Mood' in die['skills']:
       # TODO: don't hardcode ranges, parse turboVals
       sides_part = die['recipe'].split('(')[1].split(')')[0]
       if '/' in sides_part:


### PR DESCRIPTION
Without this fix, my testing for #2067 failed with:

```python
...
Starting game 87
Traceback (most recent call last):
  File "./test_log_games", line 71, in <module>
    c.log_test_game(i, button1, button2)
  File "lib/random_ai.py", line 1820, in log_test_game
    self.next_game_action()
  File "lib/random_ai.py", line 1804, in next_game_action
    if state == 'START_TURN': self._game_action_start_turn()
  File "lib/random_ai.py", line 1668, in _game_action_start_turn
    self.loaded_data['playerDataArray'][1])
  File "lib/random_ai.py", line 1568, in _game_action_start_turn_player
    [attacker_indices, defender_indices] = getattr(self, chosenAttackFunction)(b, attackerData, defenderData)
  File "lib/random_ai.py", line 1288, in _game_action_start_turn_find_attack_Trip   
    self._is_valid_attack_of_type_Trip)
  File "lib/random_ai.py", line 777, in _find_attacker_defender_combo
    validate_fn, attacker_dice, defender_dice))
  File "lib/random_ai.py", line 1696, in bug
    raise ValueError, message
ValueError: Could not find valid attack with function=<bound method LoggingBMClient._is_valid_attack_of_type_Trip of <__main__.LoggingBMClient instance at 0x7ffa29b7d050>>, attackers=[{u'description': u'Maximum Trip Y Mad Swing Die (with 4 sides)', u'skills': [u'Maximum', u'Trip', u'Mad'], u'recipe': u'Mt(Y)&', u'value': 4, u'properties': [], u'sides': 4}], defenders=[{u'description': u'Maximum Focus 8-sided die', u'skills': [u'Maximum', u'Focus'], u'recipe': u'Mf(8)', u'value': 8, u'properties': [], u'sides': 8}, {u'description': u'Maximum Fire 13-sided die', u'skills': [u'Maximum', u'Fire'], u'recipe': u'MF(13)', u'value': 11, u'properties': [], u'sides': 13}]
```

I didn't test the fix specifically, but i don't see any reason the logic shouldn't work, and i tested that replay can still run with the fix.  And it's only touching RandomAI.