### PR TITLE
use a mysql-approved cnf file to hold RDS credentials to suppress CLI warnings

### DIFF
--- a/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/backup_database.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BACKUPDIR=/srv/backup
-CREDS_FILE=/usr/local/etc/buttonmen_db_creds
+CONF_FILE=/usr/local/etc/buttonmen_db.cnf
 DBNAME=buttonmen
 TODAY=`date +"%Y%m%d"`
 
@@ -15,10 +15,9 @@ fi
 
 # Look for a creds file indicating that this BM server has a remote
 # database, and in particular an admin password
-if [ -f "${CREDS_FILE}" ]; then
-  . ${CREDS_FILE}
+if [ -f "${CONF_FILE}" ]; then
   # Need to disable GTID restores to backup/restore a remote RDS MySQL DB with default args
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %> --set-gtid-purged=OFF"
+  MYSQL_ARGS="--defaults-file=${CONF_FILE} -h <%= @database_fqdn %> --set-gtid-purged=OFF"
 else
   MYSQL_ARGS="-u root"
 fi

--- a/deploy/vagrant/modules/buttonmen/templates/create_rds_database.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/create_rds_database.erb
@@ -1,13 +1,12 @@
 #!/bin/sh
 
-CREDS_FILE="/usr/local/etc/buttonmen_db_creds"
-if [ ! -f ${CREDS_FILE} ]; then
-  echo "Create a creds file in ${CREDS_FILE} and define BM_DB_ADMIN_USER and BM_DB_ADMIN_PW before using this"
+CONF_FILE="/usr/local/etc/buttonmen_db.cnf"
+if [ ! -f ${CONF_FILE} ]; then
+  echo "Create a conf file in ${CONF_FILE} and define user= and password= before using this"
   exit 1
 fi
-. ${CREDS_FILE}
 
-MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>" 
+MYSQL_ARGS="--defaults-file=${CONF_FILE} -h <%= @database_fqdn %>"
 
 mysqlshow ${MYSQL_ARGS} <%= @buttonmen_db1_name %> | grep -q "^Database: buttonmen"
 if [ "$?" = "0" ]; then

--- a/deploy/vagrant/modules/buttonmen/templates/mysql_root_cli.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/mysql_root_cli.erb
@@ -2,16 +2,17 @@
 ##### mysql_root_cli
 # Connect to the buttonmen database as the privileged user
 
-CREDS_FILE=/usr/local/etc/buttonmen_db_creds
+EXTRA_ARGS=$@
+
+CONF_FILE=/usr/local/etc/buttonmen_db.cnf
 DBNAME=buttonmen
 
-# Look for a creds file indicating that this BM server has a remote
-# database, and in particular an admin password
-if [ -f "${CREDS_FILE}" ]; then
-  . ${CREDS_FILE}
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>"
+# Look for a conf file indicating that this BM server has a remote
+# database --- that file will specify username and password for root login
+if [ -f "${CONF_FILE}" ]; then
+  MYSQL_ARGS="--defaults-file=${CONF_FILE} -h <%= @database_fqdn %> ${EXTRA_ARGS}"
 else
-  MYSQL_ARGS="-u root"
+  MYSQL_ARGS="-u root ${EXTRA_ARGS}"
 fi
 
 exec mysql ${MYSQL_ARGS} ${DBNAME}

--- a/deploy/vagrant/modules/buttonmen/templates/test_config.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/test_config.erb
@@ -1,20 +1,8 @@
 #!/bin/bash
 
-CREDS_FILE=/usr/local/etc/buttonmen_db_creds
-DBNAME=buttonmen
-
 CONFIGFILE=/var/www/ui/js/Config.js
 
-# Look for a creds file indicating that this BM server has a remote
-# database, and in particular an admin password
-if [ -f "${CREDS_FILE}" ]; then
-  . ${CREDS_FILE}
-  MYSQL_ARGS="-u ${BM_DB_ADMIN_USER} -p${BM_DB_ADMIN_PW} -h <%= @database_fqdn %>"
-else
-  MYSQL_ARGS="-u root"
-fi
-
-DB_SITE_TYPE=$(echo "select conf_value from config where conf_key='site_type'" | mysql -N ${MYSQL_ARGS} ${DBNAME})
+DB_SITE_TYPE=$(echo "select conf_value from config where conf_key='site_type'" | /usr/local/bin/mysql_root_cli -N)
 
 FILE_SITE_TYPE=$(grep "^Config.siteType" ${CONFIGFILE} | awk -F"'" '{print $2}')
 


### PR DESCRIPTION
We currently get e-mails every day from the prod and staging backup and config-test executions, because we're specifying an admin password on the CLI.  As always, i'd find it easier to contemplate staying on top of buttonmen automated e-mail if we didn't get garbage messages every day.

The simplest MySQL-approved solution for this is to use a INI-format `.cnf` file instead of a bash-format creds file, to hold the username and password.
