### PR TITLE
Made changes to enable upgrade to PHP 7.4.33 and MySQL 8.0.31

### DIFF
--- a/deploy/amp/database_initialise.php
+++ b/deploy/amp/database_initialise.php
@@ -32,7 +32,7 @@
 
                 // recreate database
                 print "Creating database $dbname<br>";
-                $query = "CREATE DATABASE `$dbname`;".
+                $query = "CREATE DATABASE `$dbname` CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci;".
                          "CREATE USER :user@:host IDENTIFIED BY :pass;".
                          "GRANT ALL ON `$dbname`.* TO :user@:host;".
                          "FLUSH PRIVILEGES;";
@@ -107,7 +107,7 @@
         function db_connect($name) {
             print "Connecting to database $name<br>";
             $host = 'localhost';
-            $port = 8178;
+            $port = 3306;
             $user = 'root';
             $pass = 'root';
 

--- a/src/api/api_core.php
+++ b/src/api/api_core.php
@@ -27,7 +27,7 @@ function login($username, $password, $doStayLoggedIn) {
     $returnValue = FALSE;
 
     // check if the username already exists
-    if (1 == count($resultArray)) {
+    if (isset($resultArray) && (1 == count($resultArray))) {
         $result = $resultArray[0];
         $password_hashed = $result['password_hashed'];
         $status = $result['status'];

--- a/src/engine/BMAttack.php
+++ b/src/engine/BMAttack.php
@@ -425,6 +425,10 @@ abstract class BMAttack {
     protected function search_onevone($game, $attackers, $defenders, array $args = array()) {
         // Sanity check
 
+        if (!isset($attackers) || !isset($defenders)) {
+            return FALSE;
+        }
+        
         if (count($attackers) < 1 || count($defenders) < 1) {
             return FALSE;
         }

--- a/src/engine/BMInterface.php
+++ b/src/engine/BMInterface.php
@@ -2253,7 +2253,8 @@ class BMInterface {
             $sets = array();
             foreach ($rows as $row) {
                 $buttons = $this->get_button_data(NULL, $row['name']);
-                if (count($buttons) == 0) {
+                
+                if (!isset($buttons) || count($buttons) == 0) {
                     continue;
                 }
 

--- a/src/engine/BMInterfaceGameChat.php
+++ b/src/engine/BMInterfaceGameChat.php
@@ -362,7 +362,7 @@ class BMInterfaceGameChat extends BMInterface {
      * @return void
      */
     protected function save_chat_log($game) {
-        if ($game->chat['chat']) {
+        if (isset($game->chat['chat']) && $game->chat['chat']) {
             $this->db_insert_chat(
                 $game->chat['playerIdx'],
                 $game->gameId,

--- a/src/engine/BMSkillMaximum.php
+++ b/src/engine/BMSkillMaximum.php
@@ -24,7 +24,7 @@ class BMSkillMaximum extends BMSkill {
      * @return bool
      */
     public static function roll(&$args) {
-        if (!($args['die'] instanceof BMDie)) {
+        if (!isset($args['die']) || !($args['die'] instanceof BMDie)) {
             return FALSE;
         }
 

--- a/src/engine/BMSkillMood.php
+++ b/src/engine/BMSkillMood.php
@@ -60,7 +60,7 @@ class BMSkillMood extends BMSkill {
      * @return bool
      */
     protected static function does_skill_trigger_on_pre_roll($args) {
-        if (!($args['die'] instanceof BMDie)) {
+        if (!isset($args['die']) || !($args['die'] instanceof BMDie)) {
             return FALSE;
         }
 

--- a/src/engine/BMSkillWarrior.php
+++ b/src/engine/BMSkillWarrior.php
@@ -124,7 +124,7 @@ class BMSkillWarrior extends BMSkill {
      * @return bool
      */
     public static function post_roll(&$args) {
-        if (!($args['die'] instanceof BMDie)) {
+        if (!isset($args['die']) || !($args['die'] instanceof BMDie)) {
             return FALSE;
         }
 


### PR DESCRIPTION
I've just installed a new version of WAMP on the computer that I'm using to travel to Europe and the U.S.

After managing to get everything running (which was a bit of a headache, since things have changed since the wiki page was written), I noted that unit tests were failing catastrophically and the database_initialise.php script was also failing.

The major issues are that:
- PHP 7.4.x is stricter than previous versions in the way that it deals with non-existent array elements, throwing an error now (see the first point at https://www.php.net/manual/en/migration74.incompatible.php)
- MySQL 8.0.28 upwards changes the default encoding of UTF from a 3 byte to a 4 byte representation (see https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html), which causes some of our VARCHAR(255) keys to exceed the maximum key length allowed

The changes that I have made are enough to get the unit tests passing, and games creatable and playable, but there are probably instances of the above compatibility changes that I did not stumble across with my casual testing. I anticipate that there may be other areas where we end up with issues with attempted non-existent array element access. This should not hold up acceptance of this particular pull request, where all changes (except maybe the AMP database access port change) should be backward compatible. However, when we do move up to a newer version of PHP / MySQL, we'll need to do extensive testing.