### PR TITLE
Make bmapi compatible with python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,13 @@ jobs:
           name: Run QUnit tests
           command: /usr/local/bin/phantomjs --web-security=false /usr/local/etc/run-jscover-qunit.js http://localhost/test-ui/phantom-index.html
       - run:
-          name: Run python client unit tests
-          command: /usr/bin/python ./test/tools/api-client/python/lib/test_bmapi.py
+          name: Run python2 client unit tests
+          command: /opt/conda/envs/python27/bin/python ./test/tools/api-client/python/lib/test_bmapi.py
+          environment:
+            BMAPI_TEST_TYPE: circleci
+      - run:
+          name: Run python3 client unit tests
+          command: /opt/conda/envs/python39/bin/python ./test/tools/api-client/python/lib/test_bmapi.py
           environment:
             BMAPI_TEST_TYPE: circleci
       - run:

--- a/deploy/circleci/manifests/init.pp
+++ b/deploy/circleci/manifests/init.pp
@@ -19,6 +19,7 @@ node default {
   include "apache::server::circleci"
   include "php::type::circleci"
   include "mysql::server"  
+  include "buttonmen::python-api-client"
   include "buttonmen::server"
   include "javascript::type::circleci"
 }

--- a/deploy/vagrant/manifests/init.pp
+++ b/deploy/vagrant/manifests/init.pp
@@ -51,6 +51,7 @@ node default {
   include "apache::server::vagrant"
   include "php::base"
   include "mysql::server"  
+  include "buttonmen::python-api-client"
   include "buttonmen::server"
 
   # location-specific configuration

--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -118,3 +118,30 @@ class buttonmen::server {
       hour => "0";
   }
 }
+
+class buttonmen::python-api-client {
+
+  # Use miniconda to install python2 and python3 envs which can be used for testing
+  exec {
+    "bm_pyclient_download_miniconda":
+      command     => "/usr/bin/wget -O /usr/local/src/Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh",
+      require => [ Package["wget"] ],
+      creates => "/usr/local/src/Miniconda3-latest-Linux-x86_64.sh";
+
+    "bm_pyclient_install_miniconda":
+      command     => "/bin/bash /usr/local/src/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda",
+      require => [ Exec["bm_pyclient_download_miniconda"] ],
+      creates => "/opt/conda";
+
+    "bm_pyclient_create_python27":
+      command     => "/opt/conda/bin/conda create python=2.7 --file /buttonmen/tools/api-client/python/requirements.txt -n python27 -y",
+      require => [ Exec["bm_pyclient_install_miniconda"] ],
+      creates => "/opt/conda/envs/python27";
+
+    # The two envs don't actually depend on each other; the explicit require prevents vagrant from trying to create them simultaneously
+    "bm_pyclient_create_python39":
+      command     => "/opt/conda/bin/conda create python=3.9 --file /buttonmen/tools/api-client/python/requirements.txt -n python39 -y",
+      require => [ Exec["bm_pyclient_install_miniconda"], Exec["bm_pyclient_create_python27"] ],
+      creates => "/opt/conda/envs/python39";
+  }
+}

--- a/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
@@ -13,7 +13,7 @@ else
   failed_tests="${failed_tests} audit_php_files.php"
 fi
 echo
-echo "------------------------------------------------------------------------" 
+echo "------------------------------------------------------------------------"
 
 # Run audit script to verify JS unit test coverage
 echo "Auditing JS unit test coverage locations"
@@ -25,7 +25,7 @@ else
   failed_tests="${failed_tests} audit_js_unit_test_coverage"
 fi
 echo
-echo "------------------------------------------------------------------------" 
+echo "------------------------------------------------------------------------"
 
 # Run PHP unit tests
 echo "Running PHP unit tests"
@@ -38,19 +38,31 @@ else
   failed_tests="${failed_tests} buttonmen_phpunit.php"
 fi
 echo
-echo "------------------------------------------------------------------------" 
+echo "------------------------------------------------------------------------"
 
-# Run Python unit tests
-echo "Running python API client unit tests"
-env BMAPI_TEST_TYPE=vagrant_local python /buttonmen/test/tools/api-client/python/lib/test_bmapi.py
+# Run Python 2 unit tests
+echo "Running python2 API client unit tests"
+env BMAPI_TEST_TYPE=vagrant_local /opt/conda/envs/python27/bin/python /buttonmen/test/tools/api-client/python/lib/test_bmapi.py
 if [ "$?" = "0" ]; then
   echo "Passed"
 else
   echo "FAILED: make sure this passes before committing code"
-  failed_tests="${failed_tests} test_api.py"
+  failed_tests="${failed_tests} python2:test_bmapi.py"
 fi
 echo
-echo "------------------------------------------------------------------------" 
+echo "------------------------------------------------------------------------"
+
+# Run Python 3 unit tests
+echo "Running python3 API client unit tests"
+env BMAPI_TEST_TYPE=vagrant_local /opt/conda/envs/python39/bin/python /buttonmen/test/tools/api-client/python/lib/test_bmapi.py
+if [ "$?" = "0" ]; then
+  echo "Passed"
+else
+  echo "FAILED: make sure this passes before committing code"
+  failed_tests="${failed_tests} python3:test_bmapi.py"
+fi
+echo
+echo "------------------------------------------------------------------------"
 
 if [ "${failed_tests}" = "" ]; then
   echo "All checks passed"

--- a/test/tools/api-client/README
+++ b/test/tools/api-client/README
@@ -2,3 +2,6 @@ It's okay to provide generic tools "as-is", but for API clients in
 particular, we should maintain test suites which verify them against
 dummy_responder.  The point is to keep client libraries from
 bitrotting when the API changes.
+
+The tests will be run twice to make sure we maintain support for
+Python 2 and Python 3.

--- a/test/tools/api-client/python/lib/test_bmapi.py
+++ b/test/tools/api-client/python/lib/test_bmapi.py
@@ -22,11 +22,15 @@ class BMDummyClient(bmapi.BMClient):
     self.username = 'tester1'
     self.password = None
     self.cookiefile = None
+    self._setup_cookies()
 
 class TestBMClient(unittest.TestCase):
   def setUp(self):
     responder_url = TEST_URLS[TEST_TYPE]
     self.obj = BMDummyClient(responder_url)
+
+  def tearDown(self):
+    self.obj.session.close()
 
   def test_init(self):
     self.assertTrue(self.obj, "Initialized BMDummyClient object")
@@ -155,8 +159,8 @@ class TestBMClient(unittest.TestCase):
 if __name__ == '__main__':
   if (not os.getenv('BMAPI_TEST_TYPE') or
       os.getenv('BMAPI_TEST_TYPE') not in TEST_URLS):
-    raise ValueError, \
+    raise ValueError(
       "Set BMAPI_TEST_TYPE environment variable.  Valid choices: %s" % (
-      (" ".join(sorted(TEST_URLS.keys()))))
+        (" ".join(sorted(TEST_URLS.keys())))))
   TEST_TYPE = os.getenv('BMAPI_TEST_TYPE')
   unittest.main()

--- a/tools/api-client/python/README.md
+++ b/tools/api-client/python/README.md
@@ -1,10 +1,15 @@
-# Python scripts for buttonmen
+# Buttonmen API client and utilities
 
-## Replay scripts
+Buttonmen scripts were written for python2.  We are in the process of migrating them to python3.
 
-Several of the scripts in this directory are designed for use in replay testing of new code.  Here's a quick overview:
-* `replay_loop` - runs a test loop on a VM containing code under test
-* `test_log_games` - play and record new games using RandomAI
-* `prep_replay_games` - translate recorded games for PHP responderTest use
-* `update_replay_games` - translate recorded games for PHP responderTest use with optional modifications to account for known API changes
-See header comments of each individual file for details about that file's use.
+Use the scripts with a python installation that contains all modules in requirements.txt.
+
+## Libraries
+
+* bmapi.py: A minimal implementation of the Buttonweavers API, in python (python2, python3)
+* bmutils.py: Wrappers for frequently-used API methods, which may repackage the arguments and responses to be more intuitive for users (python2, python3)
+* random_ai.py: A client which can play a buttonmen game containing any implemented button skills (not strategically), by taking legal random actions until the game ends.  Used for replay testing (python2 only)
+
+## User scripts
+
+These scripts have been provided by players over time, and are not tested.  Use at your own risk.

--- a/tools/api-client/python/lib/bmutils.py
+++ b/tools/api-client/python/lib/bmutils.py
@@ -56,7 +56,7 @@ class BMClientParser(bmapi.BMClient):
   def wrap_load_button_names(self):
     retval = self.load_button_names()
     if not retval.status == 'ok':
-      raise(ValueError, "Failed to get button data, got: %s" % retval.message)
+      raise ValueError("Failed to get button data, got: %s" % retval.message)
     data = retval.data
     buttons = {}
     for i in range(len(data)):
@@ -66,7 +66,7 @@ class BMClientParser(bmapi.BMClient):
   def wrap_load_player_names(self):
     retval = self.load_player_names()
     if not retval.status == 'ok':
-      raise(ValueError, "Failed to get player data, got: " + retval.message)
+      raise ValueError("Failed to get player data, got: " + retval.message)
     data = retval.data
     players = {}
     for i in range(len(data['nameArray'])):
@@ -93,31 +93,31 @@ class BMClientParser(bmapi.BMClient):
   def wrap_load_active_games(self):
     retval = self.load_active_games()
     if not retval.status == 'ok':
-      raise(ValueError, "Failed to call loadActiveGames, got: " + retval.message)
+      raise ValueError("Failed to call loadActiveGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_load_new_games(self):
     retval = self.load_new_games()
     if not retval.status == 'ok':
-      raise (ValueError, "Failed to call loadNewGames, got: " + retval.message)
+      raise ValueError("Failed to call loadNewGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_react_to_new_game(self, game, accept):
     retval = self.react_to_new_game(game, 'accept' if accept else 'reject')
     if not retval.status == 'ok':
-      raise ValueError, "Failed to call reactToNewGame, got: " + retval.message
+      raise ValueError("Failed to call reactToNewGame, got: " + retval.message)
     return retval.data
 
   def wrap_load_completed_games(self):
     retval = self.load_completed_games()
     if not retval.status == 'ok':
-      raise(ValueError, "Failed to call loadCompletedGames, got: " + retval.message)
+      raise ValueError("Failed to call loadCompletedGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_create_game(self, pbutton, obutton='', player='', opponent='', description=''):
     retval = self.create_game(pbutton, obutton, player, opponent, description)
     if not retval.status == 'ok':
-      raise(ValueError, "Failed to call createGame, got: " + retval.message)
+      raise ValueError("Failed to call createGame, got: " + retval.message)
     return retval.data
 
   def wrap_load_game_data(self, game):
@@ -139,7 +139,7 @@ class BMClientParser(bmapi.BMClient):
         retval = self.load_game_data(game)
         # if that didn't work, raise an exception
         if not retval.status == 'ok':
-          raise(ValueError, "Failed to call loadGameData, got: " + retval.message)
+          raise ValueError("Failed to call loadGameData, got: " + retval.message)
         # if we're still here, we have the game data
         data = retval.data
         # if the game is completed
@@ -151,7 +151,7 @@ class BMClientParser(bmapi.BMClient):
     else:
       retval = self.load_game_data(game)
       if not retval.status == 'ok':
-        raise(ValueError, "Failed to call loadGameData, got: " + retval.message)
+        raise ValueError("Failed to call loadGameData, got: " + retval.message)
       data = retval.data
     # either way, at this point we have the game data in 'data', and we're
     # done doing anything cache-related

--- a/tools/api-client/python/replaytest/README.md
+++ b/tools/api-client/python/replaytest/README.md
@@ -1,0 +1,11 @@
+# Replay scripts
+
+The scripts in this directory are designed for use in replay testing of new code.  Here's a quick overview:
+* `replay_loop` - runs a test loop on a VM containing code under test
+* `test_log_games` - play and record new games using RandomAI
+* `prep_replay_games` - translate recorded games for PHP responderTest use
+* `update_replay_games` - translate recorded games for PHP responderTest use with optional modifications to account for known API changes
+* `replay_single_game` - unpack and replay a single game from a previously-recorded archive
+See header comments of each individual file for details about that file's use.
+
+These scripts assume they are being executed on a vagrant-built buttonmen server, with various configuration files, target paths, etc, installed.  No effort has been made to ensure that the scripts will work well for any other use case or in any other environment.

--- a/tools/api-client/python/replaytest/prep_replay_games
+++ b/tools/api-client/python/replaytest/prep_replay_games
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/conda/envs/python27/bin/python
 ##### prep_replay_games
 
 import sys

--- a/tools/api-client/python/replaytest/replay_loop
+++ b/tools/api-client/python/replaytest/replay_loop
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/conda/envs/python27/bin/python
 ##### replay_loop
 # This loop is designed for use on a VM which is recording games
 # for use in replay-testing of new code, or on a VM which is

--- a/tools/api-client/python/replaytest/replay_single_game
+++ b/tools/api-client/python/replaytest/replay_single_game
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/conda/envs/python27/bin/python
 ##### replay_single_test
 # This script is designed for use on a VM which is replay-testing new
 # code against recorded games.  It replays a single game from a saved

--- a/tools/api-client/python/replaytest/test_log_games
+++ b/tools/api-client/python/replaytest/test_log_games
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/conda/envs/python27/bin/python
 ##### test_log_games
 
 import os

--- a/tools/api-client/python/replaytest/update_replay_games
+++ b/tools/api-client/python/replaytest/update_replay_games
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/conda/envs/python27/bin/python
 ##### update_replay_games
 # This should have the same functionality as prep_replay_games, but
 # can be modified to adjust the API output to account for changes

--- a/tools/api-client/python/requirements.txt
+++ b/tools/api-client/python/requirements.txt
@@ -1,0 +1,3 @@
+future
+requests
+configparser


### PR DESCRIPTION
This partially reproduces Dan Langford's python3 support PR #2667

Specifically, this PR includes:
* make `bmapi.py` and `bmutils.py` syntactically compatible with python3
* move to the use of a `requirements.txt` file for dependencies
* use vagrant to install python27 and python39 on all BM sites (using miniconda for simplicity)
* update buttonmen tests of `bmapi.py` to run using both python27 and python39, either locally or via CircleCI
* move replaytest wrappers (but not `random_ai.py`) into their own directory, and update their paths to use the conda python27 installation

This PR does *not* include:
* A broader reorg of the python files for path cleanliness
* Any updates of replay scripts or `random_ai.py` to support python3 or PEP
* Any updates of the user scripts to support python3 or PEP

I skipped those things to make this PR tractable and relatively easy to review.

I tested this PR via:
* smoketest of replay testing (note: i'm going to need to slightly update my replay site builder scripts to expect the new file source locations, but since only the wrapper scripts moved, that's a trivial update)
* using the `game_info` script on a replay site to validate that `bmutils.py` works on both python versions:

```
$ /opt/conda/envs/python27/bin/python ./game_info -c /home/chaos/share/buttonmen/.bmrc -s localr3 1
responder003: dexx:           k(7) p?(X) o!(Z) G(3,17) t(5) g`(2)   
responder004: Luna & Artemis: (1) (4) (10) (20) r(2) r(2) r(8) r(8) 

$ /opt/conda/envs/python39/bin/python ./game_info -c /home/chaos/share/buttonmen/.bmrc -s localr3 1
responder003: dexx:           k(7) p?(X) o!(Z) G(3,17) t(5) g`(2)   
responder004: Luna & Artemis: (1) (4) (10) (20) r(2) r(2) r(8) r(8) 
```

After this PR is merged, my next priority for python3 will be to bring in the updates to make the other scripts work with python3, which should be a pretty small PR.