### PR TITLE
Hardcode a known-working version of miniconda

### DIFF
--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -121,26 +121,28 @@ class buttonmen::server {
 
 class buttonmen::python-api-client {
 
+  $buttonmen_pyclient_miniconda_version = "py310_22.11.1-1"
+
   # Use miniconda to install python2 and python3 envs which can be used for testing
   exec {
     "bm_pyclient_download_miniconda":
-      command     => "/usr/bin/wget -O /usr/local/src/Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh",
+      command => "/usr/bin/wget -O /usr/local/src/Miniconda3-${buttonmen_pyclient_miniconda_version}-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-${buttonmen_pyclient_miniconda_version}-Linux-x86_64.sh",
       require => [ Package["wget"] ],
-      creates => "/usr/local/src/Miniconda3-latest-Linux-x86_64.sh";
+      creates => "/usr/local/src/Miniconda3-${buttonmen_pyclient_miniconda_version}-Linux-x86_64.sh";
 
     "bm_pyclient_install_miniconda":
-      command     => "/bin/bash /usr/local/src/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda",
+      command => "/bin/bash /usr/local/src/Miniconda3-${buttonmen_pyclient_miniconda_version}-Linux-x86_64.sh -b -p /opt/conda",
       require => [ Exec["bm_pyclient_download_miniconda"] ],
       creates => "/opt/conda";
 
     "bm_pyclient_create_python27":
-      command     => "/opt/conda/bin/conda create python=2.7 --file /buttonmen/tools/api-client/python/requirements.txt -n python27 -y",
+      command => "/opt/conda/bin/conda create python=2.7 --file /buttonmen/tools/api-client/python/requirements.txt -n python27 -y",
       require => [ Exec["bm_pyclient_install_miniconda"] ],
       creates => "/opt/conda/envs/python27";
 
     # The two envs don't actually depend on each other; the explicit require prevents vagrant from trying to create them simultaneously
     "bm_pyclient_create_python39":
-      command     => "/opt/conda/bin/conda create python=3.9 --file /buttonmen/tools/api-client/python/requirements.txt -n python39 -y",
+      command => "/opt/conda/bin/conda create python=3.9 --file /buttonmen/tools/api-client/python/requirements.txt -n python39 -y",
       require => [ Exec["bm_pyclient_install_miniconda"], Exec["bm_pyclient_create_python27"] ],
       creates => "/opt/conda/envs/python39";
   }


### PR DESCRIPTION
If this passes CircleCI, that's evidence that it works around the recent miniconda change and fixes #2887 (though presumably they'll eventually remove the version we're hardcoding, so we'll have to go back to using a newer version eventually).  