### PR TITLE
Expand python unit testing to cover bmutils and several of the scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,16 @@ jobs:
           command: /usr/local/bin/phantomjs --web-security=false /usr/local/etc/run-jscover-qunit.js http://localhost/test-ui/phantom-index.html
       - run:
           name: Run python2 client unit tests
-          command: /opt/conda/envs/python27/bin/python ./test/tools/api-client/python/lib/test_bmapi.py
+          command: /usr/local/bin/run_buttonmen_python_tests
           environment:
             BMAPI_TEST_TYPE: circleci
+            PYTHON_VERSION: python27
       - run:
           name: Run python3 client unit tests
-          command: /opt/conda/envs/python39/bin/python ./test/tools/api-client/python/lib/test_bmapi.py
+          command: /usr/local/bin/run_buttonmen_python_tests
           environment:
             BMAPI_TEST_TYPE: circleci
+            PYTHON_VERSION: python39
       - run:
           name: Generate jdepend.xml and software metrics charts using PHP_Depend
           command: pdepend --jdepend-xml=./build/logs/jdepend.xml --jdepend-chart=./build/pdepend/dependencies.svg --overview-pyramid=build/pdepend/overview-pyramid.svg ./src

--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -47,6 +47,11 @@ class buttonmen::server {
       content => template("buttonmen/run_buttonmen_tests.erb"),
       mode => 0555;
 
+    "/usr/local/bin/run_buttonmen_python_tests":
+      ensure => file,
+      content => template("buttonmen/run_buttonmen_python_tests.erb"),
+      mode => 0555;
+
     "/usr/local/bin/audit_js_unit_test_coverage":
       ensure => file,
       content => template("buttonmen/audit_js_unit_test_coverage.erb"),

--- a/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_python_tests.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_python_tests.erb
@@ -1,0 +1,26 @@
+#!/bin/sh
+##### Run a full set of python tests for a given version of python
+
+if [ "${BMAPI_TEST_TYPE}" = "" ]; then
+  echo "Missing required environment variable BMAPI_TEST_TYPE"
+  exit 1
+fi
+
+if [ "${PYTHON_VERSION}" = "" ]; then
+  echo "Missing required environment variable PYTHON_VERSION"
+  exit 1
+fi
+
+any_failures=0
+cd /buttonmen/test/tools/api-client/python/lib
+TESTFILES=$(ls test_*.py)
+cd /buttonmen/src
+for test_script in ${TESTFILES}; do
+  echo "Running test: ${test_script}"
+  env BMAPI_TEST_TYPE=${BMAPI_TEST_TYPE} /opt/conda/envs/${PYTHON_VERSION}/bin/python /buttonmen/test/tools/api-client/python/lib/${test_script}
+  if [ "$?" != "0" ]; then
+    any_failures=1
+  fi
+done
+
+exit ${any_failures}

--- a/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/run_buttonmen_tests.erb
@@ -42,24 +42,24 @@ echo "------------------------------------------------------------------------"
 
 # Run Python 2 unit tests
 echo "Running python2 API client unit tests"
-env BMAPI_TEST_TYPE=vagrant_local /opt/conda/envs/python27/bin/python /buttonmen/test/tools/api-client/python/lib/test_bmapi.py
+env BMAPI_TEST_TYPE=vagrant_local PYTHON_VERSION=python27 /usr/local/bin/run_buttonmen_python_tests
 if [ "$?" = "0" ]; then
   echo "Passed"
 else
   echo "FAILED: make sure this passes before committing code"
-  failed_tests="${failed_tests} python2:test_bmapi.py"
+  failed_tests="${failed_tests} python2:api_client_tests"
 fi
 echo
 echo "------------------------------------------------------------------------"
 
 # Run Python 3 unit tests
 echo "Running python3 API client unit tests"
-env BMAPI_TEST_TYPE=vagrant_local /opt/conda/envs/python39/bin/python /buttonmen/test/tools/api-client/python/lib/test_bmapi.py
+env BMAPI_TEST_TYPE=vagrant_local PYTHON_VERSION=python39 /usr/local/bin/run_buttonmen_python_tests
 if [ "$?" = "0" ]; then
   echo "Passed"
 else
   echo "FAILED: make sure this passes before committing code"
-  failed_tests="${failed_tests} python3:test_bmapi.py"
+  failed_tests="${failed_tests} python3:api_client_tests"
 fi
 echo
 echo "------------------------------------------------------------------------"

--- a/test/tools/api-client/python/lib/dummy_bmapi.py
+++ b/test/tools/api-client/python/lib/dummy_bmapi.py
@@ -1,0 +1,28 @@
+##### dummy_bmapi.py
+# This is a drop-in replacement for bmapi that talks to the dummy
+# endpoint which vends canned output from responder tests
+
+import os
+import sys
+
+mydir = os.path.dirname(os.path.realpath(sys.argv[0]))
+tooldir = mydir + '/../../../../../tools/api-client/python/lib/'
+sys.path.append(tooldir)
+import bmapi
+
+TEST_URLS = {
+  'vagrant_local': 'http://localhost/api/dummy_responder',
+  'circleci': 'http://localhost/api/dummy_responder.php',
+}
+
+# Alternate BMClient which overrides rcfile processing and cookie/login
+# use, in order to work correctly for the dummy responder case
+class BMClient(bmapi.BMClient):
+  def __init__(self, test_type):
+    assert test_type in TEST_URLS, "Unknown dummy responder test type %s" % test_type
+    self.url = TEST_URLS[test_type]
+    self.username = 'tester1'
+    self.password = None
+    self.cookiefile = None
+    self.cachedir = None
+    self._setup_cookies()

--- a/test/tools/api-client/python/lib/script_test_helpers.py
+++ b/test/tools/api-client/python/lib/script_test_helpers.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+BMDIR = '/buttonmen/tools/api-client/python'
+
+DUMMY_SETUP_LINES = [
+  'import os\n',
+  'TEST_TYPE = os.getenv("BMAPI_TEST_TYPE")\n',
+  'import sys\n',
+  'sys.path.append("../../../test/tools/api-client/python/lib")\n',
+  'import dummy_bmapi\n',
+  'd = dummy_bmapi.BMClient(TEST_TYPE)\n',
+]
+
+def copy_replace_script(filename, srcline, dstlines):
+  curdir = os.getcwd()
+  os.chdir(BMDIR)
+  dst_filename = 'SUT'
+  assert not os.path.exists(dst_filename)
+  f = open(filename)
+  g = open(dst_filename, 'w')
+  for line in f.readlines():
+    if line == srcline:
+      for dstline in dstlines:
+        g.write(dstline)
+      continue
+    g.write(line)
+  g.close()
+  f.close()
+  os.chdir(curdir)
+
+def remove_script_copy(filename):
+  curdir = os.getcwd()
+  os.chdir(BMDIR)
+  dst_filename = 'SUT'
+  os.remove(dst_filename)
+  os.chdir(curdir)
+
+def execute_script_copy(tempdir, args):
+  outfile = '%s/output' % tempdir
+  curdir = os.getcwd()
+  os.chdir(BMDIR)
+  os.system('%s SUT %s > %s' % (sys.executable, ' '.join(args), outfile))
+  os.chdir(curdir)
+  f = open(outfile)
+  output = f.read()
+  f.close()
+  return output

--- a/test/tools/api-client/python/lib/test_bmutils.py
+++ b/test/tools/api-client/python/lib/test_bmutils.py
@@ -1,0 +1,139 @@
+import unittest
+
+import datetime
+import os
+import sys
+
+# Use dummy_bmapi to get a bmapi.BMClient that works for responder testing,
+# then use that with bmutils itself to test bmutils
+import dummy_bmapi
+
+mydir = os.path.dirname(os.path.realpath(sys.argv[0]))
+tooldir = mydir + '/../../../../../tools/api-client/python/lib/'
+sys.path.append(tooldir)
+import bmutils
+
+TEST_TYPE = None
+
+WRAPPED_GAME_DATA_KEYS = [
+  'gameId', 'gameState', 'inactivity', 'isAwaitingAction',
+  'myButtonName', 'nDraws', 'nLosses', 'nTargetWins', 'nWins',
+  'opponentButtonName', 'opponentId', 'opponentName', 'status',
+]
+
+class TestBMUtils(unittest.TestCase):
+  def setUp(self):
+    self.bmapi_obj = dummy_bmapi.BMClient(TEST_TYPE)
+    self.obj = bmutils.BMClientParser(None, None, client=self.bmapi_obj)
+    self.now = datetime.datetime.now().strftime('%s')
+
+  def tearDown(self):
+    self.bmapi_obj.session.close()
+
+  def test_init(self):
+    self.assertTrue(self.obj, "Initialized BMClientParser object with dummy bmapi")
+
+  def test_verify_login(self):
+    r = self.obj.verify_login()
+    self.assertEqual(r, True,
+      'verify_login returns successfully')
+
+  def test_wrap_create_game(self):
+    known_keys = [
+      'gameId',
+    ]
+    r = self.obj.wrap_create_game('Avis', 'Avis', 'tester2')
+    self.assertEqual(sorted(r.keys()), known_keys)
+    r = self.obj.wrap_create_game('Avis', 'Avis', None)
+    self.assertEqual(sorted(r.keys()), known_keys)
+    r = self.obj.wrap_create_game('Avis', None, None)
+    self.assertEqual(sorted(r.keys()), known_keys)
+    with self.assertRaises(ValueError):
+        r = self.obj.wrap_create_game(None, None, None)
+
+  def test_wrap_load_active_games(self):
+    r = self.obj.wrap_load_active_games()
+    self.assertTrue(isinstance(r, list))
+    self.assertEqual(len(r), 9)
+    self.assertEqual(sorted(r[0].keys()), WRAPPED_GAME_DATA_KEYS)
+
+  def test_wrap_load_new_games(self):
+    r = self.obj.wrap_load_new_games()
+    self.assertTrue(isinstance(r, list))
+    self.assertEqual(len(r), 0)
+
+  def test_wrap_load_completed_games(self):
+    r = self.obj.wrap_load_completed_games()
+    self.assertTrue(isinstance(r, list))
+    self.assertEqual(len(r), 4)
+    self.assertEqual(sorted(r[0].keys()), WRAPPED_GAME_DATA_KEYS)
+
+  def test_load_button_names(self):
+    r = self.obj.wrap_load_button_names()
+    known_keys = [
+      'artFilename', 'buttonId', 'buttonName', 'buttonSet', 'dieSkills',
+      'dieTypes', 'hasUnimplementedSkill', 'isTournamentLegal', 'recipe', 'tags'
+    ]
+    self.assertTrue(isinstance(r, dict))
+    self.assertTrue('CactusJack' in r)
+    testButton = r['CactusJack']
+    self.assertEqual(testButton['buttonSet'], 'Classic Fanatics')
+    self.assertEqual(testButton['dieSkills'], ['Shadow', 'Speed'])
+    self.assertEqual(testButton['dieTypes'], ['Option', 'X Swing', 'U Swing'])
+    self.assertEqual(testButton['hasUnimplementedSkill'], False)
+    self.assertEqual(testButton['isTournamentLegal'], False)
+    self.assertEqual(testButton['recipe'], 'z(8/12) (4/16) s(6/10) z(X) s(U)')
+    self.assertEqual(testButton['artFilename'], 'cactusjack.png')
+    self.assertEqual(testButton['tags'], [])
+
+  def test_wrap_load_game_data(self):
+    known_keys = [
+      'activePlayerIdx', 'creatorDataArray', 'currentPlayerIdx', 'description',
+      'dieBackgroundType', 'gameActionLog', 'gameActionLogCount',
+      'gameChatEditable', 'gameChatLog', 'gameChatLogCount',
+      'gameId', 'gameSkillsInfo', 'gameState', 'maxWins', 'opponent',
+      'player', 'playerDataArray', 'playerWithInitiativeIdx',
+      'previousGameId', 'roundNumber', 'timestamp', 'validAttackTypeArray'
+    ]
+    self.obj.username = 'responder001'
+    r = self.obj.wrap_load_game_data(101)
+    self.assertEqual(sorted(r.keys()), known_keys)
+    self.assertTrue(type(r['activePlayerIdx']) in [int, type(None)])
+    self.assertTrue(type(r['currentPlayerIdx']) in [int, type(None)])
+    self.assertEqual(r['player'], r['playerDataArray'][0])
+
+    player_data_keys = [
+      'activeDieArray', 'button', 'canStillWin', 'capturedDieArray',
+      'gameScoreArray', 'hasDismissedGame', 'isChatPrivate',
+      'isOnVacation', 'lastActionTime',
+      'optRequestArray', 'outOfPlayDieArray',
+      'playerColor', 'playerId', 'playerName',
+      'prevOptValueArray', 'prevSwingValueArray', 'roundScore', 'sideScore',
+      'swingRequestArray', 'turboSizeArray', 'waitingOnAction'
+    ]
+    self.assertEqual(sorted(r['player'].keys()), player_data_keys)
+
+
+  def test_wrap_load_player_names(self):
+    r = self.obj.wrap_load_player_names()
+    self.assertTrue(isinstance(r, dict))
+    self.assertTrue('responder003' in r.keys())
+    self.assertEqual(sorted(r['responder003'].keys()), ['status'])
+
+
+  def test_wrap_react_to_new_game(self):
+    r = self.obj.wrap_react_to_new_game(6, True)
+    self.assertEqual(r, True)
+
+    r = self.obj.wrap_react_to_new_game(8, False)
+    self.assertEqual(r, True)
+
+
+if __name__ == '__main__':
+  if (not os.getenv('BMAPI_TEST_TYPE') or
+      os.getenv('BMAPI_TEST_TYPE') not in dummy_bmapi.TEST_URLS):
+    raise ValueError(
+      "Set BMAPI_TEST_TYPE environment variable.  Valid choices: %s" % (
+        (" ".join(sorted(TEST_URLS.keys())))))
+  TEST_TYPE = os.getenv('BMAPI_TEST_TYPE')
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_buttons_with_skills.py
+++ b/test/tools/api-client/python/lib/test_buttons_with_skills.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestButtonsWithSkills(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'buttons-with-skills',
+      '  bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)\n',
+      ['  ' + x for x in script_test_helpers.DUMMY_SETUP_LINES] + [
+        '  bmconn = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('buttons-with-skills')
+
+  def test_buttons_with_skills(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["Jolt"])
+    self.assertEqual(
+      output, 
+      "Button of Loathing: Jk(13) (6) (6) (20) (R,R)\n" +
+      "devious: dv(S) (16) (16) pqr(S,S) Jm`(0) Jm`(0) Jm`(0)\n" +
+      "jimmosk: (4) %(8) g(12) JIMmo(S) k(2)\n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_create_game.py
+++ b/test/tools/api-client/python/lib/test_create_game.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestCreateGame(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'create_game',
+      'b = bmutils.BMClientParser(opts.config, opts.site)\n',
+      script_test_helpers.DUMMY_SETUP_LINES + [
+        'b = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('create_game')
+
+  def test_create_game(self):
+    # The script is interactive, and would be a bit hard to test
+    # for a couple of reasons:
+    # * only allows ACTIVE players, so tester2 and not any of the responderNNN ones
+    # * requires interactive input (could override with a flag)
+    # * sends inputs to createGame with dummy responder won't be expecting
+    # So just test script loading / help text for now
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["-h"])
+    self.assertEqual(
+      output, 
+      "Usage: SUT [options]\n\n" +
+      "Options:\n" +
+      "  -h, --help            show this help message and exit\n" +
+      "  -c CONFIG, --config=CONFIG\n" +
+      "                        config file containing site parameters\n" +
+      "  -s SITE, --site=SITE  buttonmen site to access\n" +
+      "  -o OPPONENT, --opponent=OPPONENT\n" +
+      "                        opponent to fight\n" +
+      "  -p, --play-all        create a game against each opponent you aren't\n" +
+      "                        currently playing\n" +
+      "  -l, --list-buttons    list buttons with all of the specified skills\n" +
+      "  -k, --play-skills     create a game against each opponent using buttons with\n" +
+      "                        the specified skills\n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_game_create.py
+++ b/test/tools/api-client/python/lib/test_game_create.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestGameCreate(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'game-create',
+      '  bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)\n',
+      ['  ' + x for x in script_test_helpers.DUMMY_SETUP_LINES] + [
+        '  bmconn = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('game-create')
+
+  def test_buttons_with_skills(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, [
+      "--player-button", "Avis", "--opponent", "responder004",
+      "--opponent-button", "Avis"])
+    self.assertEqual(
+      output, 
+      "Game 1 created\n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_game_data.py
+++ b/test/tools/api-client/python/lib/test_game_data.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestGameData(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'game-data',
+      '  bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)\n',
+      ['  ' + x for x in script_test_helpers.DUMMY_SETUP_LINES] + [
+        '  bmconn = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('game-data')
+
+  def test_buttons_with_skills(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["--format", "json", "1915"])
+    self.assertTrue(output.startswith('{\n "activePlayerIdx": null,'))
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_game_info.py
+++ b/test/tools/api-client/python/lib/test_game_info.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestGameInfo(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'game_info',
+      'b = bmutils.BMClientParser(opts.config, opts.site)\n',
+      script_test_helpers.DUMMY_SETUP_LINES + [
+        'b = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('game_info')
+
+  def test_game_info(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["1915"])
+    self.assertEqual(
+      output, 
+      "responder003: Pikathulhu: (6) c(6) (10) (12) c(X) \n" +
+      "responder004: Phoenix:    (4) (6) f(8) (10) f(20) \n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_head_to_head.py
+++ b/test/tools/api-client/python/lib/test_head_to_head.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestHeadToHead(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'head-to-head',
+      '  bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)\n',
+      ['  ' + x for x in script_test_helpers.DUMMY_SETUP_LINES] + [
+        '  bmconn = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('head-to-head')
+
+  def test_buttons_with_skills(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["player", "responder003", "opponent", "responder004"])
+    self.assertEqual(output, "responder003 vs opponent: 1 - 3 (25.00%)\nresponder003 vs responder004: 1 - 3 (25.00%)\n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/test/tools/api-client/python/lib/test_record.py
+++ b/test/tools/api-client/python/lib/test_record.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import unittest
+
+import script_test_helpers
+
+class TestRecord(unittest.TestCase):
+  def setUp(self):
+    script_test_helpers.copy_replace_script(
+      'record',
+      '  bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)\n',
+      ['  ' + x for x in script_test_helpers.DUMMY_SETUP_LINES] + [
+        '  bmconn = bmutils.BMClientParser(None, None, d)\n',
+      ]
+    )
+    self.tempdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    script_test_helpers.remove_script_copy('record')
+
+  def test_buttons_with_skills(self):
+    output = script_test_helpers.execute_script_copy(self.tempdir, ["player", "responder003"])
+    self.assertEqual(output, "responder003 overall record: 1 - 3 (25.00%)\n")
+
+if __name__ == '__main__':
+  if not os.getenv('BMAPI_TEST_TYPE'):
+    raise ValueError("Set BMAPI_TEST_TYPE environment variable")
+  unittest.main()

--- a/tools/api-client/python/buttons-with-skills
+++ b/tools/api-client/python/buttons-with-skills
@@ -12,7 +12,7 @@ from __future__ import division
 
 # Import regular stuff.
 
-import ConfigParser
+import configparser
 import argparse
 import os
 import sys
@@ -72,7 +72,7 @@ args = parse_arguments()
 
 try:
   bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)
-except ConfigParser.NoSectionError as e:
+except configparser.NoSectionError as e:
   print("ERROR: {0} doesn't seem to have a '{1}' section".format(args.config, args.site))
   print("(Exception: {0}: {1})".format(e.__module__, e.message))
   sys.exit(1)
@@ -84,7 +84,8 @@ if not bmconn.verify_login():
 # Create a map of letters and lowercased skill names to canonical skill names.
 
 skillmap = bmutils.SkillName
-for skill in skillmap.values():
+skillnames = [skillname for skillname in skillmap.values()]
+for skill in skillnames:
   skillmap[skill.lower()] = skill
 
 # Create a list of skills, with their names canonicalized.

--- a/tools/api-client/python/game-create
+++ b/tools/api-client/python/game-create
@@ -12,7 +12,7 @@ from __future__ import division
 
 # Import regular stuff.
 
-import ConfigParser
+import configparser
 import argparse
 import os
 import sys
@@ -67,7 +67,7 @@ args = parse_arguments()
 
 try:
   bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)
-except ConfigParser.NoSectionError as e:
+except configparser.NoSectionError as e:
   print("ERROR: {0} doesn't seem to have a '{1}' section".format(args.config, args.site))
   print("(Exception: {0}: {1})".format(e.__module__, e.message))
   sys.exit(1)

--- a/tools/api-client/python/game-data
+++ b/tools/api-client/python/game-data
@@ -8,7 +8,7 @@
 
 # Import regular stuff.
 
-import ConfigParser
+import configparser
 import argparse
 import json
 import os
@@ -50,6 +50,10 @@ def parse_arguments():
     parser.add_argument('--format',
                         choices = ['json', 'yaml'], default = 'yaml',
                         help = "output data format (default: yaml)")
+  else:
+    parser.add_argument('--format',
+                        choices = ['json'], default = 'json',
+                        help = "output data format (default: json)")
 
   # Add general optional arguments.
 
@@ -73,13 +77,13 @@ args = parse_arguments()
 
 try:
   bmconn = bmutils.BMClientParser(os.path.expanduser(args.config), args.site)
-except ConfigParser.NoSectionError as e:
-  print "ERROR: {0} doesn't seem to have a '{1}' section".format(args.config, args.site)
-  print "(Exception: {0}: {1})".format(e.__module__, e.message)
+except configparser.NoSectionError as e:
+  print("ERROR: {0} doesn't seem to have a '{1}' section".format(args.config, args.site))
+  print("(Exception: {0}: {1})".format(e.__module__, e.message))
   sys.exit(1)
 
 if not bmconn.verify_login():
-  print "ERROR: Could not log in to {0}".format(args.site)
+  print("ERROR: Could not log in to {0}".format(args.site))
   sys.exit(1)
 
 # Fetch the game data.

--- a/tools/api-client/python/head-to-head
+++ b/tools/api-client/python/head-to-head
@@ -95,7 +95,7 @@ def print_record(bmconn, type, thing1, thing2):
              type + 'NameB': thing2,
              'status': 'COMPLETE' }
 
-  result = bmconn._make_request(apicmd)
+  result = bmconn.client._make_request(apicmd)
 
   # If we don't get an ok result, print some helpful info, and give up.
 

--- a/tools/api-client/python/lib/bmutils.py
+++ b/tools/api-client/python/lib/bmutils.py
@@ -49,12 +49,24 @@ SkillName = {
   '`': 'Warrior',
 }
 
-class BMClientParser(bmapi.BMClient):
+class BMClientParser:
+  def __init__(self, rcfile, site, client=None):
+    if client:
+      self.client = client
+    else:
+      self.client = bmapi.BMClient(rcfile, site)
+    self.username = self.client.username
+    self.cachedir = self.client.cachedir
+
+  ## Wrappers which invoke a function in the client, for backwards compatibility
+
+  def verify_login(self):
+    return self.client.verify_login()
 
   ## Simple wrappers which just call a function and reflow the result
 
   def wrap_load_button_names(self):
-    retval = self.load_button_names()
+    retval = self.client.load_button_names()
     if not retval.status == 'ok':
       raise ValueError("Failed to get button data, got: %s" % retval.message)
     data = retval.data
@@ -64,7 +76,7 @@ class BMClientParser(bmapi.BMClient):
     return buttons
 
   def wrap_load_player_names(self):
-    retval = self.load_player_names()
+    retval = self.client.load_player_names()
     if not retval.status == 'ok':
       raise ValueError("Failed to get player data, got: " + retval.message)
     data = retval.data
@@ -91,31 +103,31 @@ class BMClientParser(bmapi.BMClient):
     return games
 
   def wrap_load_active_games(self):
-    retval = self.load_active_games()
+    retval = self.client.load_active_games()
     if not retval.status == 'ok':
       raise ValueError("Failed to call loadActiveGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_load_new_games(self):
-    retval = self.load_new_games()
+    retval = self.client.load_new_games()
     if not retval.status == 'ok':
       raise ValueError("Failed to call loadNewGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_react_to_new_game(self, game, accept):
-    retval = self.react_to_new_game(game, 'accept' if accept else 'reject')
+    retval = self.client.react_to_new_game(game, 'accept' if accept else 'reject')
     if not retval.status == 'ok':
       raise ValueError("Failed to call reactToNewGame, got: " + retval.message)
     return retval.data
 
   def wrap_load_completed_games(self):
-    retval = self.load_completed_games()
+    retval = self.client.load_completed_games()
     if not retval.status == 'ok':
       raise ValueError("Failed to call loadCompletedGames, got: " + retval.message)
     return self._wrap_game_list_data(retval.data)
 
   def wrap_create_game(self, pbutton, obutton='', player='', opponent='', description=''):
-    retval = self.create_game(pbutton, obutton, player, opponent, description)
+    retval = self.client.create_game(pbutton, obutton, player, opponent, description)
     if not retval.status == 'ok':
       raise ValueError("Failed to call createGame, got: " + retval.message)
     return retval.data
@@ -136,7 +148,7 @@ class BMClientParser(bmapi.BMClient):
       # otherwise (the cache didn't already have a file for this game)
       else:
         # load the game
-        retval = self.load_game_data(game)
+        retval = self.client.load_game_data(game)
         # if that didn't work, raise an exception
         if not retval.status == 'ok':
           raise ValueError("Failed to call loadGameData, got: " + retval.message)
@@ -149,7 +161,7 @@ class BMClientParser(bmapi.BMClient):
             json.dump(data, cache_fh, indent=1, sort_keys=True)
     # otherwise (we aren't using a cache directory), load the game
     else:
-      retval = self.load_game_data(game)
+      retval = self.client.load_game_data(game)
       if not retval.status == 'ok':
         raise ValueError("Failed to call loadGameData, got: " + retval.message)
       data = retval.data

--- a/tools/api-client/python/record
+++ b/tools/api-client/python/record
@@ -81,7 +81,7 @@ def print_record(bmconn, type, thing):
              type + 'NameA': thing,
              'status': 'COMPLETE' }
 
-  result = bmconn._make_request(apicmd)
+  result = bmconn.client._make_request(apicmd)
 
   # If we don't get an ok result, print some helpful info, and give up.
 


### PR DESCRIPTION
I think this pulls a good number of other pieces from #2667 in a way that's not intrusive to replay testing.

Basically what this PR does is add very bare-bones "is it on?" unit testing to bmutils and to *most* of the convenience API client utilities (everything except `monitor` and `interactive_mode.py`), and plug it into a wrapper that circleci runs on python27 and on python39.

So it fixes a couple of python3 incompatibilities in various things, but mostly it unblocks the way for people to add more functionality to the API, and more scripts, and use unit testing to verify that they are more-or-less compatible with both python versions.

The only testing i did is that the unit tests pass, but i think that's sufficient for what we're doing here --- replay testing doesn't use any of these scripts (except bmapi.py, which we handled in a previous PR).