### PR TITLE
Fixed or removed links to cheapass.com

### DIFF
--- a/src/ui/js/About.js
+++ b/src/ui/js/About.js
@@ -52,9 +52,9 @@ About.generalInfo = function() {
   text.append(
     $('<p>').html(
       'This website is a place where people play and talk about ' +
-      '<a href="https://cheapass.com/free-games/button-men">Button Men</a>' +
+      '<a href="http://cheapass.com/free-games/button-men">Button Men</a>' +
       ', a game by ' +
-      '<a href="https://cheapass.com/">Cheapass Games</a>.'
+      '<a href="http://cheapass.com/">Cheapass Games</a>.'
     )
   );
 

--- a/src/ui/js/Login.js
+++ b/src/ui/js/Login.js
@@ -122,12 +122,12 @@ Login.getFooter = function() {
   copyright.append(
     'Button Men is copyright 1999, 2023 James Ernest and Cheapass Games: ');
   copyright.append($('<a>', {
-    'href': 'https://cheapass.com',
+    'href': 'http://cheapass.com',
     'text': 'cheapass.com',
   }));
   copyright.append(' and ');
   copyright.append($('<a>', {
-    'href': 'https://beatpeopleup.cheapass.com',
+    'href': 'http://beatpeopleup.cheapass.com',
     'text': 'beatpeopleup.cheapass.com',
   }));
   copyright.append(', and is used with permission.');

--- a/src/ui/js/Overview.js
+++ b/src/ui/js/Overview.js
@@ -532,7 +532,7 @@ Overview.pageAddIntroText = function() {
       '</span> version of ' +
       'the Buttonweavers implementation of ');
     infopar.append($('<a>', {
-      'href': 'https://cheapass.com/free-games/button-men/',
+      'href': 'http://cheapass.com/free-games/button-men/',
       'text': 'Button Men',
     }));
     infopar.append('.');

--- a/test/src/ui/js/test_Login.js
+++ b/test/src/ui/js/test_Login.js
@@ -88,9 +88,9 @@ test("test_Login.getFooter", function(assert) {
     ] ],
     [ "DIV", {}, [
       "Button Men is copyright 1999, 2023 James Ernest and Cheapass Games: ",
-      [ "A", { "href": "https://cheapass.com" }, [ "cheapass.com" ] ],
+      [ "A", { "href": "http://cheapass.com" }, [ "cheapass.com" ] ],
       " and ",
-      [ "A", { "href": "https://beatpeopleup.cheapass.com" }, [ "beatpeopleup.cheapass.com" ] ],
+      [ "A", { "href": "http://beatpeopleup.cheapass.com" }, [ "beatpeopleup.cheapass.com" ] ],
       ", and is used with permission." ]
     ] ]
   ];


### PR DESCRIPTION
Partially resolves Issue #2891 for the moment, while cheapass.com remains in flux.

This pull request deliberately does the minimal necessary to either remove dead links to cheapass.com or change them to the http version, which currently correctly redirects to https://crabfragmentlabs.com.

We may potentially need to update the links in three months or so, when things are clearer on what's going on with cheapass.com (as per email from James Ernest)