### PR TITLE
Tools to deploy a dev site via docker/ECS, including post-launch commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/amd64 ubuntu:16.04
+RUN mkdir /buttonmen
+WORKDIR /buttonmen
+COPY . .
+
+# Make sure log dir exists
+RUN mkdir -p build/logs
+
+# Bootstrap puppet
+RUN bash ./deploy/vagrant/bootstrap.sh
+
+# Run puppet
+RUN puppet apply --modulepath=/buttonmen/deploy/vagrant/modules /buttonmen/deploy/vagrant/manifests/init.pp
+
+CMD ["/bin/bash", "/buttonmen/deploy/docker/startup.sh"]

--- a/deploy/circleci/manifests/init.pp
+++ b/deploy/circleci/manifests/init.pp
@@ -14,6 +14,7 @@ node default {
   include "apt::client"
   include "ntp::client"
   include "postfix::base"
+  include "fqdn::base"
 
   # Node configuration needed for the circleci buttonmen server
   include "apache::server::circleci"

--- a/deploy/docker/buttonmen_ecs_config.json
+++ b/deploy/docker/buttonmen_ecs_config.json
@@ -1,0 +1,16 @@
+{
+  "production": {
+    "network_subnet": "FIXME",
+    "network_security_group": "FIXME"
+  },
+  "staging": {
+    "network_subnet": "FIXME",
+    "network_security_group": "FIXME"
+  },
+  "development": {
+    "network_subnet": "FIXME",
+    "network_security_group": "FIXME",
+    "dns_update_script_path": "FIXME"
+    "load_database_path": "FIXME"
+  }
+}

--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -1,0 +1,458 @@
+##### deploy_buttonmen_site
+# Deploy the buttonmen site represented by this working directory
+# The caller is responsible for:
+# * invoking this script using a python with boto3 available
+# * passing correct environment variables for boto3 to authenticate
+#   to the desired region (e.g. an AWS_PROFILE + ~/.aws/config,
+#   or all needed envvars, or whatever)
+# * having docker running locally and the "docker" CLI in the $PATH
+# * copying deploy/docker/buttonmen_ecs_config.json to
+#   ~/.aws/buttonmen_ecs_config.json and populating the fields with
+#   network configuration from the AWS account hosting buttonmen sites
+
+import base64
+import boto3
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+BUTTONMEN_ECS_CONFIG_FILE = f"{os.environ['HOME']}/.aws/buttonmen_ecs_config.json"
+BUTTONMEN_FQDN_BASE = 'buttonweavers.com'
+BUTTONMEN_DEVELOPMENT_SUBDOMAIN = 'dev'
+BUTTONMEN_PROD_FDQN_PREFIXES = {
+  'production': 'www',
+  'staging': 'staging',
+}
+
+def get_subprocess_output(cmdargs):
+  return subprocess.check_output(cmdargs).decode()
+
+REPO_MATCH = re.compile('^origin\s+git@github.com:(\w+)/buttonmen.git \(fetch\)$')
+def get_working_directory_info():
+  git_info = {
+    'reponame': None,
+    'branch': None,
+    'commitid': None,
+    'is_clean': True,
+  }
+
+  # Find repo name using git remote
+  output = get_subprocess_output(['git', 'remote', '-v'])
+  for line in output.split('\n'):
+    match = REPO_MATCH.match(line)
+    if not match: continue
+    git_info['reponame'] = match.group(1)
+  if git_info['reponame']:
+    print(f"Detected buttonmen repo: {git_info['reponame']}")
+  else:
+    raise ValueError(f"Could not detect repo name from git remote: {output}")
+
+  # Find branch name using git branch
+  output = get_subprocess_output(['git', 'branch'])
+  for line in output.split('\n'):
+    if not line.startswith('* '): continue
+    words = line.split()
+    assert len(words) == 2, f"Found unexpected output line {line} in git branch output: {output}"
+    git_info['branch'] = words[1]
+  if git_info['branch']:
+    print(f"Detected git branch: {git_info['branch']}")
+  else:
+    raise ValueError(f"Could not detect branch name from git branch: {output}")
+
+  # Find commit ID using git show
+  output = get_subprocess_output(['git', 'show', '--oneline'])
+  git_info['commitid'] = output.split('\n')[0].split()[0]
+  if len(git_info['commitid']) == 8:
+    print(f"Detected git short commit ID: {git_info['commitid']}")
+  else:
+    raise ValueError(f"Expected git show --oneline output to start with an 8-character identifier, but got {git_info['commitid']}: {output}")
+
+  # Determine whether the working directory is clean
+  output = get_subprocess_output(['git', 'status', '-s']).strip()
+  if len(output) > 0:
+    print(f"Working directory is not clean.  Found:\n {output}")
+    git_info['is_clean'] = False
+
+  return git_info
+
+
+def validate_vars(git_info, args):
+  if not git_info['is_clean']:
+    if args['allow_unclean_repo_deployment']:
+      print("Working directory is unclean, but deploying anyway based on CLI flags")
+    else:
+      raise ValueError("Working directory is not clean - refusing to deploy")
+
+  if git_info['reponame'] == 'buttonmen-dev':
+    if git_info['branch'] not in ['staging', 'production']:
+      raise ValueError(f"Repo is {git_info['reponame']}, but branch {git_info['branch']} is not a known staging or prod branch - refusing to deploy")
+
+
+def add_ecs_config(git_info):
+  if not os.path.exists(BUTTONMEN_ECS_CONFIG_FILE):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} does not exist - make a copy of deploy/docker/buttonmen_ecs_config.json and populate it")
+  file_config = json.load(open(BUTTONMEN_ECS_CONFIG_FILE))
+  target_config = {}
+  if git_info['reponame'] == 'buttonmen-dev':
+    key = git_info['branch']
+  else:
+    key = 'development'
+  git_info['site_type'] = key
+  git_info['config'] = file_config.get(key, {})
+  if not git_info['config'].get('network_subnet', '').startswith('subnet-'):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'network_subnet' entry for key {key}")
+  if not git_info['config'].get('network_security_group', '').startswith('sg-'):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'network_security_group' entry for key {key}")
+  # bzipped SQL is the file format output by buttonmen database backups, and is the only allowable input for dev site database loads
+  if not git_info['config'].get('load_database_path', '').endswith('.sql.bz2'):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} contains an optional 'load_database_path' entry for key {key}, which is invalid")
+
+
+def connect_boto_clients():
+  return {
+    'ec2': boto3.client('ec2'),
+    'ecr': boto3.client('ecr'),
+    'ecs': boto3.client('ecs'),
+  }
+
+
+def docker_reponame(git_info):
+  return f"buttonmen-{git_info['reponame']}/{git_info['branch']}"
+
+def docker_shorttag(git_info):
+  return f"{git_info['commitid']}"
+
+def docker_tag(git_info):
+  reponame = docker_reponame(git_info)
+  shorttag = docker_shorttag(git_info)
+  return f"{reponame}:{shorttag}"
+
+
+def find_docker_image_with_tag(tag):
+  return get_subprocess_output(['docker', 'images', tag, '--format', '{{.ID}}']).strip()
+
+
+def build_docker_image(git_info):
+  tag = docker_tag(git_info)
+
+  # Check if an image has already been created for this version
+  image_id = find_docker_image_with_tag(tag)
+  if image_id:
+    print(f"Local docker image with tag {tag} already exists: ID is {image_id}")  
+    return image_id
+
+  # Actually build the image
+  cmdargs = ['docker', 'build', '--progress', 'plain', '-t', tag, '.']
+  print(f"About to build docker image locally: {cmdargs}")
+  retcode = subprocess.call(cmdargs)
+  if retcode != 0:
+    raise ValueError(f"Image build failed: {retcode}")
+
+  image_id = find_docker_image_with_tag(tag)
+  if image_id:
+    print(f"Local docker image with tag {tag} created successfully: ID is {image_id}")  
+    return image_id
+  raise ValueError(f"Image build reported success, but no image with tag {tag} was created")
+
+
+def update_ecr_repo(reponame, ecr_client):
+  try:
+    repo_status = ecr_client.describe_repositories(repositoryNames=[reponame])
+  except ecr_client.exceptions.RepositoryNotFoundException:
+    print(f"Repository {reponame} doesn't exist - we need to create it")
+    response = ecr_client.create_repository(repositoryName=reponame)
+    repo_status = ecr_client.describe_repositories(repositoryNames=[reponame])
+  assert len(repo_status['repositories']) == 1, f"Found unexpected number of repositories in status, expected 1: {repo_status}"
+  repo_uri = repo_status['repositories'][0]['repositoryUri']
+  print(f"Found repository {reponame} with URI {repo_uri}")
+  return repo_uri
+
+
+def find_ecr_image_with_tag(reponame, shorttag, ecr_client):
+  try:
+    image_status = ecr_client.describe_images(repositoryName=reponame, imageIds=[{'imageTag': shorttag}])
+    print(f"Found ECR image, status is: {image_status['imageDetails']}")
+    return True
+  except ecr_client.exceptions.ImageNotFoundException:
+    print(f"Image with tag {shorttag} not found in repo {reponame}")
+    return None
+
+def docker_login_to_ecr(ecr_client):
+  response = ecr_client.get_authorization_token()
+  username, token = base64.b64decode(response['authorizationData'][0]['authorizationToken']).decode().split(':', 1)
+  proxy_endpoint = response['authorizationData'][0]['proxyEndpoint']
+  retcode = os.system(f"echo '{token}' | docker login --username {username} --password-stdin {proxy_endpoint}")
+  if retcode == 0:
+    print(f"Docker login to ECR endpoint {proxy_endpoint} succeeded")
+    return
+  raise ValueError(f"Docker login to ECR endpoint {proxy_endpoint} failed with exit code {retcode}")
+
+
+def tag_and_push_docker_image_to_ecr(image_id, repo_uri, shorttag):
+  repotag = f"{repo_uri}:{shorttag}"
+  cmdargs = ['docker', 'tag', image_id, repotag]
+  print(f"About to tag docker image for ECR: {cmdargs}")
+  retcode = subprocess.call(cmdargs)
+  if retcode != 0:
+    raise ValueError(f"Image tag failed: {retcode}")
+
+  cmdargs = ['docker', 'push', repotag]
+  print(f"About to push docker image to ECR: {cmdargs}")
+  retcode = subprocess.call(cmdargs)
+  if retcode != 0:
+    raise ValueError(f"Image push failed: {retcode}")
+
+
+def push_docker_image_to_ecr(git_info, image_id, ecr_client):
+  reponame = docker_reponame(git_info)
+  shorttag = docker_shorttag(git_info)
+  repo_uri = update_ecr_repo(reponame, ecr_client)
+  ecr_image_id = find_ecr_image_with_tag(reponame, shorttag, ecr_client)
+  if not ecr_image_id:
+    docker_login_to_ecr(ecr_client)
+    tag_and_push_docker_image_to_ecr(image_id, repo_uri, shorttag)
+  return repo_uri
+
+
+def ecs_task_family_name(git_info):
+  return f"buttonmen-{git_info['reponame']}-{git_info['branch']}"
+
+def ecs_service_name(git_info):
+  return ecs_task_family_name(git_info)
+
+def ecs_task_tags(git_info):
+  return [
+    { 'key': 'commit_id', 'value': docker_shorttag(git_info), },
+  ]
+
+def buttonmen_site_fqdn(git_info):
+  if git_info['reponame'] == 'buttonmen-dev':
+    return f"{BUTTONMEN_PROD_FDQN_PREFIXES[git_info['branch']]}.{BUTTONMEN_FQDN_BASE}"
+  return f"{git_info['branch']}.{git_info['reponame']}.{BUTTONMEN_DEVELOPMENT_SUBDOMAIN}.{BUTTONMEN_FQDN_BASE}".replace('_', '-')
+
+
+def update_ecs_task_definition(git_info, repo_uri, ecs_client):
+  family = ecs_task_family_name(git_info)
+  tags = ecs_task_tags(git_info)
+  image_tag = docker_shorttag(git_info)
+  image_name_tag = f"{repo_uri}:{image_tag}"
+
+  # Check if the most recent task definition in the family already matches our tag
+  try:
+    response = ecs_client.describe_task_definition(taskDefinition=family, include=['TAGS'])
+    if response['tags'] == tags:
+      print(f"Found task definition with expected tags: {response}")
+      return response['taskDefinition']['taskDefinitionArn']
+    print(f"Most recent task definition in family {family} had tags {response['tags']}, where we expected {tags}")
+  except ecs_client.exceptions.ClientException as e:
+    # If there's no matching task definition for the family, describe_task_definition() throws a generic exception
+    if "Unable to describe task definition" not in str(e):
+      print(f"Tried to catch ClientException from ecs_client.describe_task_definition(), but it didn't look right")
+      raise(e)
+    print(f"No ECS task definition with family {family} found")
+  
+  # Register a new task definition
+  print(f"About to register a new task definition with family {family} and tags {tags}")
+  ecs_client.register_task_definition(
+    family=family,
+    executionRoleArn='ecsTaskExecutionRole',
+    networkMode='awsvpc',
+    containerDefinitions=[
+      {
+        'name': "buttonmen",
+        'image': image_name_tag,
+        'linuxParameters': {
+            'initProcessEnabled': True,
+        },
+        'command': [
+          '/bin/bash',
+          '/buttonmen/deploy/docker/startup.sh',
+        ],
+      },
+    ],
+    cpu="256",
+    memory="512",
+    requiresCompatibilities=[
+      'FARGATE',
+    ],
+    tags=tags,
+  )
+
+  response = ecs_client.describe_task_definition(taskDefinition=family, include=['TAGS'])
+  assert response['tags'] == tags, f"Task definition register succeeded, but tags don't match {tags}: {response}"
+  print(f"Successfully created task definition with expected tags: {response}")
+  return response['taskDefinition']['taskDefinitionArn']
+
+
+def ecs_cluster_name(git_info):
+  return "buttonmen-dev"
+
+def ecs_network_config(git_info):
+  return {
+    'awsvpcConfiguration': {
+      'subnets': [ git_info['config']['network_subnet'] ],
+      'securityGroups': [ git_info['config']['network_security_group'] ],
+      'assignPublicIp': 'ENABLED',
+    },
+  }
+
+def update_ecs_service(git_info, task_definition_arn, ecs_client):
+  cluster = ecs_cluster_name(git_info)
+  service_name = ecs_service_name(git_info)
+  network_config = ecs_network_config(git_info)
+
+  response = ecs_client.describe_services(
+    cluster=cluster,
+    services=[service_name],
+  )
+  service_name_found = False
+  for service in response.get('services', []):
+    if service['serviceName'] == service_name:
+      service_name_found = True
+      if service['taskDefinition'] == task_definition_arn:
+        print(f"Found ECS service (arn={service['serviceArn']}) with expected task definition {task_definition_arn}")
+      else:
+        print(f"ECS service (arn={service['serviceArn']}) has stale task definition: found {service['taskDefinition']}, wanted {task_definition_arn}... updating")
+        ecs_client.update_service(
+          cluster=cluster,
+          service=service_name,
+          taskDefinition=task_definition_arn,
+          desiredCount=1,
+          networkConfiguration=network_config,
+        )
+  if not service_name_found:
+    print(f"Expected service {service_name} not found - creating it now")
+    ecs_client.create_service(
+      cluster=cluster,
+      serviceName=service_name,
+      taskDefinition=task_definition_arn,
+      desiredCount=1,
+      launchType='FARGATE',
+      networkConfiguration=network_config,
+    )
+
+  print(f"Waiting for service task to enter status: Running")
+  eni_id = None
+  while True:
+    response = ecs_client.list_tasks(
+      cluster=cluster,
+      serviceName=service_name,
+    )
+    task_statuses = ecs_client.describe_tasks(
+      cluster=cluster,
+      tasks=response['taskArns'],
+    )
+    for task_status in task_statuses['tasks']:
+      print(f"Examining task: {task_status['taskArn']}, taskDefinitionArn={task_status['taskDefinitionArn']}, desiredStatus={task_status['desiredStatus']}, lastStatus={task_status['lastStatus']}")
+      if task_status['taskDefinitionArn'] != task_definition_arn:
+        print(f"...task definition arn is not current - skipping this task")
+        continue
+      if task_status['desiredStatus'] != 'RUNNING':
+        print(f"...desired task status is not RUNNING - skipping this task")
+        continue
+      if task_status['lastStatus'] != 'RUNNING':
+        print(f"...actual task status is not RUNNING - waiting")
+        continue
+      for detail in task_status['attachments'][0]['details']:
+        if detail['name'] == 'networkInterfaceId':
+          eni_id = detail['value']
+      print(f"...task is RUNNING and has ENI {eni_id}")
+    if eni_id:
+      return eni_id
+    time.sleep(60)
+
+
+# The ECS task doesn't know its public IP directly.
+# * It belongs to the ENI attached to the container
+# * So the way to find out about it is to query the ENI, which is an EC2 resource
+def get_site_public_ipv4(eni_id, ec2_client):
+  response = ec2_client.describe_network_interfaces(
+    NetworkInterfaceIds=[eni_id],
+  )
+  public_ipv4 = response['NetworkInterfaces'][0]['Association']['PublicIp']
+  print(f"Found public IPv4 for {eni_id}: {public_ipv4}")
+  return public_ipv4
+
+
+def configure_dns(git_info, public_ipv4):
+  dns_update_script = git_info['config'].get('dns_update_script_path', None)
+  if not dns_update_script:
+    print("Not configuring DNS for this target - dns_update_script_path is not defined in the config file")
+    return
+  bmsite_fqdn = buttonmen_site_fqdn(git_info)
+  cmdargs = f"{dns_update_script} {bmsite_fqdn} {public_ipv4}"
+  print(f"About to run DNS update script: {cmdargs}")
+  retcode = os.system(cmdargs)
+  if retcode == 0:
+    print(f"DNS update succeeded succeeded")
+    return
+  raise ValueError(f"DNS update failed with exit code: {retcode}")
+
+def run_ssh_command(cmdargs, public_ipv4):
+  SSH_CMD = "ssh"
+  SSH_ARGS = "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null"
+  full_cmdargs = f'{SSH_CMD} {SSH_ARGS} {public_ipv4} "{cmdargs}"'
+  print(f"About to run: {full_cmdargs}")
+  os.system(full_cmdargs)
+
+def run_scp_command(local_path, remote_path, public_ipv4):
+  SCP_CMD = "scp"
+  SCP_ARGS = "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null"
+  full_cmdargs = f'{SCP_CMD} {SCP_ARGS} {local_path} {public_ipv4}:{remote_path}'
+  print(f"About to run: {full_cmdargs}")
+  os.system(full_cmdargs)
+
+def configure_container_populate_etc_bmsite_fqdn(git_info, public_ipv4):
+  bmsite_fqdn = buttonmen_site_fqdn(git_info)
+  cmdargs = f"sudo sh -c 'echo {bmsite_fqdn} > /usr/local/etc/bmsite_fqdn'"
+  run_ssh_command(cmdargs, public_ipv4)
+
+def configure_container_setup_certbot(public_ipv4):
+  cmdargs = 'sudo /usr/local/bin/apache_setup_certbot'
+  run_ssh_command(cmdargs, public_ipv4)
+
+def configure_container_load_database(git_info, public_ipv4):
+  load_database_path = git_info['config'].get('load_database_path', None)
+  if not load_database_path: return
+  remote_database_path = 'buttonmen.sql.bz2'
+  run_scp_command(load_database_path, remote_database_path, public_ipv4)
+  cmdargs = f"bzcat {remote_database_path} | grep -v 'SQL SECURITY DEFINER' | sudo /usr/local/bin/mysql_root_cli"
+  run_ssh_command(cmdargs, public_ipv4)
+
+def configure_container_set_site_type(git_info, public_ipv4):
+  cmdargs = f"sudo /usr/local/bin/set_buttonmen_config {git_info['site_type']}"
+  run_ssh_command(cmdargs, public_ipv4)
+
+def configure_container_post_install(git_info, public_ipv4):
+  configure_container_populate_etc_bmsite_fqdn(git_info, public_ipv4)
+  configure_container_setup_certbot(public_ipv4)
+  configure_container_load_database(git_info, public_ipv4)
+  configure_container_set_site_type(git_info, public_ipv4)
+
+
+def deploy(args):
+  git_info = get_working_directory_info()
+  validate_vars(git_info, args)
+  add_ecs_config(git_info)
+  clients = connect_boto_clients()
+  image_id = build_docker_image(git_info)
+  repo_uri = push_docker_image_to_ecr(git_info, image_id, clients['ecr'])
+  task_definition_arn = update_ecs_task_definition(git_info, repo_uri, clients['ecs'])
+  eni_id = update_ecs_service(git_info, task_definition_arn, clients['ecs'])
+  bmsite_fqdn = buttonmen_site_fqdn(git_info)
+  public_ipv4 = get_site_public_ipv4(eni_id, clients['ec2'])
+  print(f"{bmsite_fqdn} {public_ipv4}")
+  configure_dns(git_info, public_ipv4)
+  configure_container_post_install(git_info, public_ipv4)
+
+
+def parse_args(argv):
+  return {
+    'allow_unclean_repo_deployment': '-u' in argv,
+  }
+
+args = parse_args(sys.argv[1:])
+deploy(args)

--- a/deploy/docker/startup.sh
+++ b/deploy/docker/startup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+##### Services docker containers need to run
+
+set -e
+set -x
+
+# System services
+/etc/init.d/rsyslog start
+/etc/init.d/cron start
+/etc/init.d/ssh start
+/etc/init.d/postfix start
+
+# Buttonmen services
+/etc/init.d/apache2 start
+/etc/init.d/mysql start
+
+# Container should keep running
+sleep infinity

--- a/deploy/vagrant/modules/apache/manifests/init.pp
+++ b/deploy/vagrant/modules/apache/manifests/init.pp
@@ -20,12 +20,8 @@ class apache::server {
   # Monitor the error log
   include "apache::server::feature::monitor-logs"
 
-  # Install and configure letsencrypt (SSL/certbot) for AWS instances 
-  case "${ec2_services_partition}" {
-    "aws": {
-      include "apache::server::feature::letsencrypt"
-    }
-  }
+  # Install letsencrypt
+  include "apache::server::feature::letsencrypt"
 }
 
 class apache::server::vagrant {
@@ -103,6 +99,9 @@ class apache::server::feature::mod-pagespeed {
   }
 }
 
+# This configuration is only meaningful if we're on a non-sandboxed
+# site, but the logic to enforce that is within the apache_setup_certbot
+# script, so it's harmless to run this configuration anywhere
 class apache::server::feature::letsencrypt {
 
   # Install the certbot package
@@ -110,13 +109,18 @@ class apache::server::feature::letsencrypt {
     "python-certbot-apache": ensure => installed;
   }
 
+  file {
+    "/usr/local/bin/apache_setup_certbot":
+      ensure => file,
+      content => template("apache/setup_certbot.erb"),
+      mode => 0555;
+  }
+
   exec {
     # Run certbot to configure LetsEncrypt
-    # If the site has the special FQDN indicating it's a non-networked sandbox, don't run certbot
     "apache_certbot_setup":
-      command => "/usr/bin/certbot --apache -d $(/bin/cat /usr/local/etc/bmsite_fqdn) -n --email help@buttonweavers.com --agree-tos",
-      require => [ Exec["fqdn_populate_etc_file"], Package["python-certbot-apache"] ],
-      creates => "/etc/letsencrypt/live",
-      unless => "/bin/grep -q sandbox.buttonweavers.com /usr/local/etc/bmsite_fqdn";
+      command => "/usr/local/bin/apache_setup_certbot",
+      require => [ Exec["fqdn_populate_etc_file"], Package["python-certbot-apache"], File["/usr/local/bin/apache_setup_certbot"] ],
+      creates => "/etc/letsencrypt/live";
   }
 }

--- a/deploy/vagrant/modules/apache/templates/setup_certbot.erb
+++ b/deploy/vagrant/modules/apache/templates/setup_certbot.erb
@@ -1,0 +1,27 @@
+#!/bin/sh
+##### Script to safely configure certbot for LetsEncrypt
+
+set -e
+set -x
+
+FQDN_FILE=/usr/local/etc/bmsite_fqdn
+SANDBOX_FQDN="sandbox.buttonweavers.com"
+
+if [ ! -f "${FQDN_FILE}" ]; then
+  echo "Missing dependencies - can't find file ${FQDN_FILE}"
+  exit 1
+fi
+
+FQDN=$(cat /usr/local/etc/bmsite_fqdn)
+if [ "${FQDN}" = "${SANDBOX_FQDN}" ]; then
+  echo "Site is using sandbox FQDN (${SANDBOX_FQDN}) - not configuring certbot"
+  exit 0
+fi
+
+if [ -d "/etc/letsencrypt/live" ]; then
+  echo "Directory /etc/letsencrypt/live is already populated - nothing to do"
+  exit 0
+fi
+
+echo "Running certbot to configure this site as FQDN ${FQDN}"
+/usr/bin/certbot --apache -d ${FQDN} -n --email help@buttonweavers.com --agree-tos

--- a/deploy/vagrant/modules/apt/manifests/init.pp
+++ b/deploy/vagrant/modules/apt/manifests/init.pp
@@ -7,6 +7,10 @@ class apt::client {
   # Make sure generic base packages are installed, for the benefit
   # of minimal environments like CircleCI docker
   package {
+    "bzip2": ensure => installed;
+    "cron": ensure => installed;
+    "openssh-server": ensure => installed;
+    "rsyslog": ensure => installed;
     "rsync": ensure => installed;
     "wget": ensure => installed;
   }

--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -32,6 +32,11 @@ class buttonmen::server {
       content => template("buttonmen/backup_database.erb"),
       mode => 0555;
 
+    "/usr/local/bin/set_buttonmen_config":
+      ensure => file,
+      content => template("buttonmen/set_config.erb"),
+      mode => 0555;
+
     "/usr/local/bin/test_buttonmen_config":
       ensure => file,
       content => template("buttonmen/test_config.erb"),

--- a/deploy/vagrant/modules/buttonmen/templates/set_config.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/set_config.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+##### set_buttonmen_config
+# Replace the buttonmen site type configuration in both JS and DB
+
+set -e
+set -x
+
+NEW_SITE_TYPE=$1
+echo "${NEW_SITE_TYPE}" | egrep -q "^(production|staging|development)$"
+
+/bin/sed --follow-symlinks -i -e "/^Config.siteType =/s/Config.siteType.*$/Config.siteType = '"${NEW_SITE_TYPE}"';/" /var/www/ui/js/Config.js
+
+echo "update config set conf_value='"${NEW_SITE_TYPE}"' where conf_key='site_type'" | /usr/local/bin/mysql_root_cli -N
+
+exit 0

--- a/deploy/vagrant/modules/sudo/manifests/init.pp
+++ b/deploy/vagrant/modules/sudo/manifests/init.pp
@@ -1,8 +1,14 @@
 class sudo::buttonmen-devs {
+
+  package {
+    "sudo": ensure => installed;
+  }
+
   file {
     "/etc/sudoers.d/99-buttonmen-dev":
       ensure => file,
       mode => 0440,
-      content => "%admin ALL=(ALL) NOPASSWD:ALL\n";
+      content => "%admin ALL=(ALL) NOPASSWD:ALL\n",
+      require => Package["sudo"];
   }
 }

--- a/deploy/vagrant/modules/user/manifests/init.pp
+++ b/deploy/vagrant/modules/user/manifests/init.pp
@@ -1,4 +1,8 @@
 class user::buttonmen-devs {
+  group {
+    "admin": ensure => present;
+  }
+
   include "user::username::chaos"
   include "user::username::irilyth"
   include "user::username::james"


### PR DESCRIPTION
* Partially addresses #2908 

What this includes:
* It does an end-to-end creation of a site for a dev branch on ECS, assuming you have docker available on your local computer and have access to the AWS account which owns DNS for `buttonweavers.com`, with no specialized configuration or manual actions needed
* Functionality includes:
    * Create a docker image using the Dockerfile (which was patterned off our CircleCI docker config for simplicity --- agree that we should move to a newer OS, but that's not the part of the ocean we are boiling at this time)
    * Create an ECR repo for this branch if necessary, and upload the docker image we created to that repo, tagged with the branch/commit ID
    * Create an ECS service for this branch if necessary, create a new revision of a task definition using the image version we uploaded, and create/update a single task in the service to run that task definition
    * Once the container is running and has a public IP, update DNS so that the FQDN `${BRANCH_WITH_HYPHENS}.${USERNAME}.dev.buttonweavers.com` points to that container
    * Run post-install actions on the container via SSH: setup LetsEncrypt so the SSL site will work, load a database backup from the local computer if one was provided, set the site type to "development"
* Functionality we don't have yet:
    * Run database modification scripts from the PR after loading the database
    * Script teardown of the per-branch ECS service, ECR repo, and DNS name, so i don't have to pay for them
    * Support an RDS database rather than a local one (blocker for staging/prod)
    * Support an ECS service with a static IP attached to a load balancer (blocker for staging/prod)
    * Attach a remote filesystem at `/srv/backup` to which database backups are being run (blocker for staging/prod)
* The container has some convenience functionality (postfix, cron), and i was able to receive a verification e-mail for a new user, but it's pretty bare-bones, and i'm sure i'm going to discover stuff we're missing while this is under test

Testing:
* The command `env AWS_PROFILE=bm_deploy /Users/chaos/games/buttonmen/miniconda3/bin/python ./deploy/docker/deploy_buttonmen_site` was used to deploy the dev site at https://2908-docker-config.cgolubi1.dev.buttonweavers.com/ui/ using the most recent staging database i downloaded (from the last time i deployed prod in March) - please check out that dev site and see if you see anything weird about it
