### PR TITLE
ECS deployment bugfix: make sure tasks exist before describing them

### DIFF
--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -341,6 +341,10 @@ def update_ecs_service(git_info, task_definition_arn, ecs_client):
       cluster=cluster,
       serviceName=service_name,
     )
+    if not response['taskArns']:
+      print(f"...waiting for tasks to be created in service {service_name}...")
+      time.sleep(5)
+      continue
     task_statuses = ecs_client.describe_tasks(
       cluster=cluster,
       tasks=response['taskArns'],


### PR DESCRIPTION
Partially addresses #2908 

Each dev branch is its own ECS service (containing a single task).  Without this change, the first time i create a dev cell for a new branch, the service is created before the task is created, and the script blows up trying to describe the empty tasks list.

I tested this change on both an ECS service with existing tasks, and an ECS service with no existing tasks.