### PR TITLE
Use ECS awslogs driver to log startup script output to cloudwatch

### DIFF
--- a/deploy/docker/buttonmen_ecs_config.json
+++ b/deploy/docker/buttonmen_ecs_config.json
@@ -3,6 +3,7 @@
     "bmsite_fqdn": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
+    "log_group": "FIXME",
     "nlb_arn_port_80": "FIXME",
     "nlb_arn_port_443": "FIXME",
     "remote_database_fqdn": "FIXME",
@@ -12,6 +13,7 @@
     "bmsite_fqdn": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
+    "log_group": "FIXME",
     "nlb_arn_port_80": "FIXME",
     "nlb_arn_port_443": "FIXME",
     "remote_database_fqdn": "FIXME",
@@ -21,7 +23,8 @@
     "bmsite_fqdn_suffix": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
-    "dns_update_script_path": "FIXME"
+    "log_group": "FIXME",
+    "dns_update_script_path": "FIXME",
     "load_database_path": "FIXME"
   }
 }

--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -100,6 +100,8 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'network_subnet' entry for key {key}")
   if not git_info['config'].get('network_security_group', '').startswith('sg-'):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'network_security_group' entry for key {key}")
+  if not git_info['config'].get('log_group', None):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'log_group' entry for key {key}")
 
   # Non-dev branches always use a remote database; dev branches do if it's requested as a CLI
   git_info['config']['use_remote_database'] = args['use_remote_database_for_dev'] or key != 'development'
@@ -284,6 +286,7 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
   tags = ecs_task_tags(git_info)
   image_tag = docker_shorttag(git_info)
   image_name_tag = f"{repo_uri}:{image_tag}"
+  bmsite_fqdn = buttonmen_site_fqdn(git_info)
 
   # Check if the most recent task definition in the family already matches our tag
   try:
@@ -326,6 +329,14 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
             'protocol': 'tcp',
           },
         ],
+        'logConfiguration': {
+          'logDriver': 'awslogs',
+          'options': {
+            'awslogs-group': git_info['config']['log_group'],
+            'awslogs-region': ecs_client.meta.region_name,
+            'awslogs-stream-prefix': f"{bmsite_fqdn}",
+          },
+        },
       },
     ],
     cpu="256",


### PR DESCRIPTION
* Partially addresses #2908 

Working test site at https://2908-cloudwatch-logs.cgolubi1.dev.buttonweavers.com/

In cloudwatch logs, i have a logstream `2908-cloudwatch-logs.cgolubi1.dev.buttonweavers.com/buttonmen/8b45298b5efc4c4dbc85b2da6e07e30b` with contents:

```
timestamp,message
1708390751890,'"+ /etc/init.d/rsyslog start"
1708390751919, * Starting enhanced syslogd rsyslogd
1708390752041,   ...done.
1708390752041,'"+ /etc/init.d/cron start"
1708390752047, * Starting periodic command scheduler cron
1708390752052,   ...done.
1708390752052,'"+ /etc/init.d/ssh start"
1708390752170, * Starting OpenBSD Secure Shell server sshd
1708390752190,   ...done.
1708390752223,'"+ /etc/init.d/postfix start"
1708390752226, * Starting Postfix Mail Transport Agent postfix
1708390753230,   ...done.
1708390753231,'"+ /etc/init.d/apache2 start"
1708390753236, * Starting Apache httpd web server apache2
1708390754929, * 
1708390754930,'"+ '[' -f /etc/init.d/mysql ']'"
1708390754930,'"+ /etc/init.d/mysql start"
1708390755040, * Starting MySQL database server mysqld
1708390759637,   ...done.
1708390759643,'"+ sleep infinity"
```