### PR TITLE
Always set site type config on container startup; only rerun remotely after loading a DB

### DIFF
--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -528,7 +528,7 @@ def configure_container_post_install(git_info, public_ipv4):
   configure_container_setup_certbot(public_ipv4)
   if not use_remote_database:
     configure_container_load_database(git_info, public_ipv4)
-  configure_container_set_site_type(git_info, public_ipv4)
+    configure_container_set_site_type(git_info, public_ipv4)
 
 
 def deploy(args):

--- a/deploy/docker/startup.sh
+++ b/deploy/docker/startup.sh
@@ -16,5 +16,8 @@ if [ -f /etc/init.d/mysql ]; then
   /etc/init.d/mysql start
 fi
 
+# Set site type so it's correct in UI JS
+/usr/local/bin/set_buttonmen_config
+
 # Container should keep running
 sleep infinity


### PR DESCRIPTION
* Partially addresses #2908, specifically "When ECS replaces a site with a remote database, set_buttonmen_config must be run"

Site: https://2908-set-config-on-startup.cgolubi1.dev.buttonweavers.com/ui/

You can see that the site is correctly configured as a "development" type site, and the config sanity check succeeds as well:

```
chaos@ip-10-0-0-8:~$ sudo /usr/local/bin/test_buttonmen_config 
chaos@ip-10-0-0-8:~$ 
```

I tested this using a local database dev site as well, and that seemed to work.