### PR TITLE
Containers should mount an EFS filesystem and use it for SSL certs and backups

### DIFF
--- a/deploy/docker/buttonmen_ecs_config.json
+++ b/deploy/docker/buttonmen_ecs_config.json
@@ -3,6 +3,7 @@
     "bmsite_fqdn": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
+    "filesystem_id": "FIXME",
     "log_group": "FIXME",
     "nlb_arn_port_80": "FIXME",
     "nlb_arn_port_443": "FIXME",
@@ -13,6 +14,7 @@
     "bmsite_fqdn": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
+    "filesystem_id": "FIXME",
     "log_group": "FIXME",
     "nlb_arn_port_80": "FIXME",
     "nlb_arn_port_443": "FIXME",
@@ -23,6 +25,7 @@
     "bmsite_fqdn_suffix": "FIXME",
     "network_subnet": "FIXME",
     "network_security_group": "FIXME",
+    "filesystem_id": "FIXME",
     "log_group": "FIXME",
     "dns_update_script_path": "FIXME",
     "load_database_path": "FIXME"

--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -102,6 +102,8 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'network_security_group' entry for key {key}")
   if not git_info['config'].get('log_group', None):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'log_group' entry for key {key}")
+  if not git_info['config'].get('filesystem_id', None):
+    raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'filesystem_id' entry for key {key}")
 
   # Non-dev branches always use a remote database; dev branches do if it's requested as a CLI
   git_info['config']['use_remote_database'] = args['use_remote_database_for_dev'] or key != 'development'
@@ -342,6 +344,12 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
             'protocol': 'tcp',
           },
         ],
+        'mountPoints': [
+          {
+            "containerPath": "/mnt/efs",
+            "sourceVolume": "buttonmen-efs",
+          }
+        ],
         'logConfiguration': {
           'logDriver': 'awslogs',
           'options': {
@@ -349,6 +357,14 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
             'awslogs-region': ecs_client.meta.region_name,
             'awslogs-stream-prefix': f"{bmsite_fqdn}",
           },
+        },
+      },
+    ],
+    volumes=[
+      {
+        'name': 'buttonmen-efs',
+        'efsVolumeConfiguration': {
+          'fileSystemId': git_info['config']['filesystem_id'],
         },
       },
     ],
@@ -480,11 +496,15 @@ def get_site_public_ipv4(eni_id, ec2_client):
 
 
 def configure_dns(git_info, public_ipv4):
+  bmsite_fqdn = buttonmen_site_fqdn(git_info)
   dns_update_script = git_info['config'].get('dns_update_script_path', None)
+  use_elastic_ip = git_info['config']['use_elastic_ip']
+  if use_elastic_ip:
+    print(f"Not configuring DNS for this target - it uses an elastic IP for {bmsite_fqdn}")
+    return
   if not dns_update_script:
     print("Not configuring DNS for this target - dns_update_script_path is not defined in the config file")
     return
-  bmsite_fqdn = buttonmen_site_fqdn(git_info)
   cmdargs = f"{dns_update_script} {bmsite_fqdn} {public_ipv4}"
   print(f"About to run DNS update script: {cmdargs}")
   retcode = os.system(cmdargs)

--- a/deploy/docker/startup.sh
+++ b/deploy/docker/startup.sh
@@ -10,6 +10,37 @@ set -x
 /etc/init.d/ssh start
 /etc/init.d/postfix start
 
+## Remote filesystem setup
+FQDN=$(cat /usr/local/etc/bmsite_fqdn)
+MNT_DIR="/mnt/efs/${FQDN}"
+if [ ! -e "${MNT_DIR}" ]; then
+  mkdir ${MNT_DIR}
+fi
+
+# Replace the /srv/backup in the image with a remotely-mounted one
+if [ ! -e "${MNT_DIR}/backup" ]; then
+  mkdir ${MNT_DIR}/backup
+  chown root:adm ${MNT_DIR}/backup
+  chmod 750 ${MNT_DIR}/backup
+fi
+rmdir /srv/backup
+ln -s ${MNT_DIR}/backup /srv/backup
+
+# Replace the /etc/letsencrypt in the image with a remotely-mounted one
+if [ ! -e "${MNT_DIR}/letsencrypt" ]; then
+  mkdir ${MNT_DIR}/letsencrypt
+fi
+mv /etc/letsencrypt/* ${MNT_DIR}/letsencrypt/
+rmdir /etc/letsencrypt
+ln -s ${MNT_DIR}/letsencrypt /etc/letsencrypt
+
+# If /etc/letsencrypt/live exists, there's an existing cert for
+# this domain, and we need to install it for apache.
+# (If it doesn't exist, we may not have DNS yet, so it's not safe to run certbot.)
+if [ -d /etc/letsencrypt/live ]; then
+  /usr/local/bin/apache_setup_certbot
+fi
+
 # Buttonmen services
 /etc/init.d/apache2 start
 if [ -f /etc/init.d/mysql ]; then

--- a/deploy/vagrant/modules/apache/templates/setup_certbot.erb
+++ b/deploy/vagrant/modules/apache/templates/setup_certbot.erb
@@ -18,10 +18,9 @@ if [ "${FQDN}" = "${SANDBOX_FQDN}" ]; then
   exit 0
 fi
 
-if [ -d "/etc/letsencrypt/live" ]; then
-  echo "Directory /etc/letsencrypt/live is already populated - nothing to do"
-  exit 0
+if [ -d "/etc/letsencrypt/live/${FQDN}" ]; then
+  echo "Directory /etc/letsencrypt/live is already populated; continuing in case we need to reinstall the cert to apache"
 fi
 
 echo "Running certbot to configure this site as FQDN ${FQDN}"
-/usr/bin/certbot --apache -d ${FQDN} -n --email help@buttonweavers.com --agree-tos
+/usr/bin/certbot --apache -d ${FQDN} -n --email help@buttonweavers.com --agree-tos --reinstall


### PR DESCRIPTION
Partially addresses #2908.

Testing:
* I tried this out both on a standard dev site deployment with no remote database, and on a deployment with a remote database and the EIP `rds.dev.buttonweavers.com` (both torn down now)
* In both cases, i tested the sequence:
    * Do an initial deployment
    * Do a second deployment to replace the container/task when the site already exists
    * Stop the task from within ECS so that the ECS service replaces it
* In all cases, if `/mnt/efs/${FQDN}/letsencrypt/live` didn't exist, the letsencrypt negotiation happened after startup.  If it did exist, negotiation didn't happen, and the existing cert was reused with a message like:
```
Cert not yet due for renewal
Keeping the existing certificate
```
* In the EIP case, all three of the test cases led to a fully functional site without further intervention.
* In the dev DNS case, the first two led to a fully functional site without further intervention.  In the third case, running my DNS sync script manually got the site back online (but of course it had the default database, because i haven't solved that problem for local dev databases --- see checklist on #2908).
* In all cases, `test_buttonmen_config` after deployment yields no errors
* In all cases, database backup succeeds, and the backup is stored to the EFS volume

So i assert this does what i expected it to, and solves:
* The persistent backup storage blocker
* The letsencrypt deployment limit blocker
* The need for certbot to be rerun when a dev site is replaced (but not the DNS piece, as noted above)
