### PR TITLE
Override the rsyslog post-rotate action to work on ECS containers

### DIFF
--- a/deploy/vagrant/manifests/init.pp
+++ b/deploy/vagrant/manifests/init.pp
@@ -32,6 +32,7 @@ node default {
   include "apt::client"
   include "ntp::client"
   include "postfix::base"
+  include "syslog::base"
   include "user::buttonmen-devs"
   include "sudo::buttonmen-devs"
   include "fqdn::base"

--- a/deploy/vagrant/modules/apt/manifests/init.pp
+++ b/deploy/vagrant/modules/apt/manifests/init.pp
@@ -10,9 +10,15 @@ class apt::client {
     "bzip2": ensure => installed;
     "cron": ensure => installed;
     "openssh-server": ensure => installed;
-    "rsyslog": ensure => installed;
     "rsync": ensure => installed;
     "wget": ensure => installed;
+
+    # These packages aren't strictly needed for execution, so we
+    # can remove them if they cause a problem, but they're handy for diagnostics
+    "less": ensure => installed;
+    "lsof": ensure => installed;
+    "strace": ensure => installed;
+    "vim-tiny": ensure => installed;
   }
 
   # Configure periodic apt cron job

--- a/deploy/vagrant/modules/syslog/manifests/init.pp
+++ b/deploy/vagrant/modules/syslog/manifests/init.pp
@@ -1,0 +1,17 @@
+# Run rsyslog with a minimal configuration
+class syslog::base {
+
+  # Install the rsyslog package
+  package {
+    "rsyslog": ensure => installed;
+  }
+
+  # Replace the postrotate script with one that works on containers
+  file {
+    "/usr/lib/rsyslog/rsyslog-rotate":
+      ensure => file,
+      mode => 555,
+      content => template("syslog/rsyslog_rotate.erb"),
+      require => Package["rsyslog"];
+  }
+}

--- a/deploy/vagrant/modules/syslog/templates/rsyslog_rotate.erb
+++ b/deploy/vagrant/modules/syslog/templates/rsyslog_rotate.erb
@@ -1,0 +1,8 @@
+#!/bin/sh
+##### rsyslog-rotate
+# Replace the rsyslog-rotate script packaged with rsyslog-8.16.0-1ubuntu3.1
+# with one that works on containers that lack full access to /proc
+
+# Send SIGHUP to all processes owned by the "syslog" user, which
+# should be only rsyslogd itself
+/usr/bin/killall -HUP --user syslog


### PR DESCRIPTION
* Also install some packages that are helpful for debugging and don't exist by default on containers


Partially addresses #2908

See comment on that link - https://github.com/buttonmen-dev/buttonmen/issues/2908#issuecomment-2102692586 - for testing done.