### PR TITLE
Fix repo regexp in get_buttonmen_site_ipaddr to work for staging and prod

### DIFF
--- a/deploy/docker/get_buttonmen_site_ipaddr
+++ b/deploy/docker/get_buttonmen_site_ipaddr
@@ -29,7 +29,7 @@ BUTTONMEN_ECS_CONFIG_FILE = f"{os.environ['HOME']}/.aws/buttonmen_ecs_config.jso
 def get_subprocess_output(cmdargs):
   return subprocess.check_output(cmdargs).decode()
 
-REPO_MATCH = re.compile('^origin\s+git@github.com:(\w+)/buttonmen.git \(fetch\)$')
+REPO_MATCH = re.compile('^origin\s+git@github.com:([\w-]+)/buttonmen.git \(fetch\)$')
 def get_working_directory_info():
   git_info = {
     'reponame': None,


### PR DESCRIPTION
* Fixes #2949 

With this change, `get_buttonmen_site_ipaddr` works in my staging and production working directories.

Apologies for the bother!