### PR TITLE
Minimal container support for replay sites

### DIFF
--- a/deploy/docker/buttonmen_ecs_config.json
+++ b/deploy/docker/buttonmen_ecs_config.json
@@ -29,5 +29,11 @@
     "log_group": "FIXME",
     "dns_update_script_path": "FIXME",
     "load_database_path": "FIXME"
+  },
+  "replay": {
+    "network_subnet": "FIXME",
+    "network_security_group": "FIXME",
+    "filesystem_id": "FIXME",
+    "log_group": "FIXME"
   }
 }

--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -20,6 +20,7 @@ import sys
 import time
 
 BUTTONMEN_ECS_CONFIG_FILE = f"{os.environ['HOME']}/.aws/buttonmen_ecs_config.json"
+SANDBOX_FQDN = 'sandbox.buttonweavers.com'
 
 def get_subprocess_output(cmdargs):
   return subprocess.check_output(cmdargs).decode()
@@ -83,7 +84,11 @@ def validate_vars(git_info, args):
   if git_info['reponame'] == 'buttonmen-dev':
     if git_info['branch'] not in ['staging', 'production']:
       raise ValueError(f"Repo is {git_info['reponame']}, but branch {git_info['branch']} is not a known staging or prod branch - refusing to deploy")
+    if args['deploy_replay_site']:
+      raise ValueError(f"Replay testing can only be done using development branches, not {git_info['branch']}")
 
+  if args['deploy_replay_site'] and (args['use_remote_database_for_dev'] or args['use_elastic_ip_for_dev']):
+    raise ValueError(f"Replay testing cannot be combined with remote databases or elastic IPs")
 
 def add_ecs_config(git_info, args):
   if not os.path.exists(BUTTONMEN_ECS_CONFIG_FILE):
@@ -92,6 +97,8 @@ def add_ecs_config(git_info, args):
   target_config = {}
   if git_info['reponame'] == 'buttonmen-dev':
     key = git_info['branch']
+  elif args['deploy_replay_site']:
+    key = 'replay'
   else:
     key = 'development'
   git_info['site_type'] = key
@@ -106,20 +113,20 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'filesystem_id' entry for key {key}")
 
   # Non-dev branches always use a remote database; dev branches do if it's requested as a CLI
-  git_info['config']['use_remote_database'] = args['use_remote_database_for_dev'] or key != 'development'
+  git_info['config']['use_remote_database'] = args['use_remote_database_for_dev'] or key not in ['development', 'replay']
 
   if git_info['config']['use_remote_database']:
     if not git_info['config']['remote_database_fqdn']:
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'remote_database_fqdn' entry for key {key}")
     if not git_info['config']['remote_database_admin_pw']:
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'remote_database_admin_pw' entry for key {key}")
-  else:
+  elif key == 'development':
     # bzipped SQL is the file format output by buttonmen database backups, and is the only allowable input for local database loads
     if not git_info['config'].get('load_database_path', '').endswith('.sql.bz2'):
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'load_database_path' entry for key {key}")
 
   # Non-dev branches always use an elastic IP; dev branches do if it's requested as a CLI
-  git_info['config']['use_elastic_ip'] = args['use_elastic_ip_for_dev'] or key != 'development'
+  git_info['config']['use_elastic_ip'] = args['use_elastic_ip_for_dev'] or key not in ['development', 'replay']
 
   if git_info['config']['use_elastic_ip']:
     if not git_info['config'].get('bmsite_fqdn', ''):
@@ -128,7 +135,7 @@ def add_ecs_config(git_info, args):
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'nlb_arn_port_80' entry for key {key}")
     if not git_info['config'].get('nlb_arn_port_443', ''):
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'nlb_arn_port_443' entry for key {key}")
-  else:
+  elif key == 'development':
     if not git_info['config'].get('bmsite_fqdn_suffix', ''):
       raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing a valid 'bmsite_fqdn_suffix' entry for key {key}")
 
@@ -142,7 +149,8 @@ def connect_boto_clients():
 
 
 def docker_reponame(git_info):
-  return f"buttonmen-{git_info['reponame']}/{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}/{git_info['branch']}"
 
 def docker_shorttag(git_info):
   return f"{git_info['commitid']}"
@@ -170,7 +178,7 @@ def customize_vagrant(git_info):
   bmsite_fqdn = buttonmen_site_fqdn(git_info)
   database_fqdn = get_database_fqdn(git_info)
   remote_database_password = get_remote_database_password(git_info)
-  site_type = git_info['site_type']
+  site_type = (git_info['site_type'] == 'replay') and 'development' or git_info['site_type']
 
   cmdargs = ['sed', '-i', '-e', f"s/REPLACE_WITH_DATABASE_FQDN/{database_fqdn}/", './deploy/vagrant/manifests/init.pp']
   print(f"About to install {database_fqdn} as vagrant database_fqdn: {cmdargs}")
@@ -280,7 +288,8 @@ def push_docker_image_to_ecr(git_info, image_id, ecr_client):
 
 
 def ecs_task_family_name(git_info):
-  return f"buttonmen-{git_info['reponame']}-{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}-{git_info['branch']}"
 
 def ecs_service_name(git_info):
   return ecs_task_family_name(git_info)
@@ -291,10 +300,21 @@ def ecs_task_tags(git_info):
   ]
 
 def buttonmen_site_fqdn(git_info):
+  if git_info['site_type'] == 'replay':
+    return SANDBOX_FQDN
   if git_info['config']['use_elastic_ip']:
     return git_info['config']['bmsite_fqdn']
   return f"{git_info['branch']}.{git_info['reponame']}.{git_info['config']['bmsite_fqdn_suffix']}".replace('_', '-')
 
+def startup_script_path(git_info):
+  if git_info['site_type'] == 'replay':
+    return '/buttonmen/deploy/docker/startup_replay.sh'
+  return '/buttonmen/deploy/docker/startup.sh'
+
+def cloudwatch_log_prefix(git_info):
+  if git_info['site_type'] == 'replay':
+    return f"replay-{git_info['reponame']}-{git_info['branch']}"
+  return buttonmen_site_fqdn(git_info)
 
 def update_ecs_task_definition(git_info, repo_uri, ecs_client):
   family = ecs_task_family_name(git_info)
@@ -302,6 +322,8 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
   image_tag = docker_shorttag(git_info)
   image_name_tag = f"{repo_uri}:{image_tag}"
   bmsite_fqdn = buttonmen_site_fqdn(git_info)
+  startup_script = startup_script_path(git_info)
+  log_prefix = cloudwatch_log_prefix(git_info)
 
   # Check if the most recent task definition in the family already matches our tag
   try:
@@ -332,7 +354,7 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
         },
         'command': [
           '/bin/bash',
-          '/buttonmen/deploy/docker/startup.sh',
+          startup_script,
         ],
         'portMappings': [
           {
@@ -355,7 +377,7 @@ def update_ecs_task_definition(git_info, repo_uri, ecs_client):
           'options': {
             'awslogs-group': git_info['config']['log_group'],
             'awslogs-region': ecs_client.meta.region_name,
-            'awslogs-stream-prefix': f"{bmsite_fqdn}",
+            'awslogs-stream-prefix': log_prefix,
           },
         },
       },
@@ -499,6 +521,8 @@ def configure_dns(git_info, public_ipv4):
   bmsite_fqdn = buttonmen_site_fqdn(git_info)
   dns_update_script = git_info['config'].get('dns_update_script_path', None)
   use_elastic_ip = git_info['config']['use_elastic_ip']
+  if bmsite_fqdn == SANDBOX_FQDN:
+    print(f"Not configuring DNS for this target - site is using sandbox FQDN {SANDBOX_FQDN}")
   if use_elastic_ip:
     print(f"Not configuring DNS for this target - it uses an elastic IP for {bmsite_fqdn}")
     return
@@ -571,6 +595,7 @@ def deploy(args):
 def parse_args(argv):
   return {
     'allow_unclean_repo_deployment': '-u' in argv,
+    'deploy_replay_site': '-p' in argv,
     'use_remote_database_for_dev': '-r' in argv,
     'use_elastic_ip_for_dev': '-e' in argv,
   }

--- a/deploy/docker/get_buttonmen_site_ipaddr
+++ b/deploy/docker/get_buttonmen_site_ipaddr
@@ -65,7 +65,7 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} does not exist - make a copy of deploy/docker/buttonmen_ecs_config.json and populate it")
   file_config = json.load(open(BUTTONMEN_ECS_CONFIG_FILE))
   target_config = {}
-  key = 'development'
+  key = args['deploy_replay_site'] and 'replay' or 'development'
   git_info['site_type'] = key
   git_info['config'] = file_config.get(key, {})
 
@@ -77,10 +77,12 @@ def connect_boto_clients():
   }
 
 def docker_reponame(git_info):
-  return f"buttonmen-{git_info['reponame']}/{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}/{git_info['branch']}"
 
 def ecs_task_family_name(git_info):
-  return f"buttonmen-{git_info['reponame']}-{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}-{git_info['branch']}"
 
 def ecs_service_name(git_info):
   return ecs_task_family_name(git_info)
@@ -151,7 +153,9 @@ def print_ip_address(args):
     print(public_ipv4)
 
 def parse_args(argv):
-  return {}
+  return {
+    'deploy_replay_site': '-p' in argv,
+  }
 
 args = parse_args(sys.argv[1:])
 print_ip_address(args)

--- a/deploy/docker/startup_replay.sh
+++ b/deploy/docker/startup_replay.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+##### Services docker containers need to run
+
+set -e
+set -x
+
+# System services
+/etc/init.d/rsyslog start
+/etc/init.d/cron start
+/etc/init.d/ssh start
+/etc/init.d/postfix start
+
+# Host identity variables
+FQDN=$(cat /usr/local/etc/bmsite_fqdn)
+HOSTNAME_LOCALIP_PART=$(/bin/hostname | awk -F\. '{print $1}')
+
+# Buttonmen services
+/etc/init.d/apache2 start
+if [ -f /etc/init.d/mysql ]; then
+  /etc/init.d/mysql start
+fi
+
+# Set site type so it's correct in UI JS
+/usr/local/bin/set_buttonmen_config
+
+# Container should keep running
+sleep infinity

--- a/deploy/docker/teardown_buttonmen_site
+++ b/deploy/docker/teardown_buttonmen_site
@@ -71,10 +71,10 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} does not exist - make a copy of deploy/docker/buttonmen_ecs_config.json and populate it")
   file_config = json.load(open(BUTTONMEN_ECS_CONFIG_FILE))
   target_config = {}
-  key = 'development'
+  key = args['deploy_replay_site'] and 'replay' or 'development'
   git_info['site_type'] = key
   git_info['config'] = file_config.get(key, {})
-  if not 'backup_database_path' in git_info['config']:
+  if key == 'development' and not 'backup_database_path' in git_info['config']:
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing 'backup_database_path' parameter for download database backups before container delete")
 
 def connect_boto_clients():
@@ -85,7 +85,8 @@ def connect_boto_clients():
   }
 
 def docker_reponame(git_info):
-  return f"buttonmen-{git_info['reponame']}/{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}/{git_info['branch']}"
 
 def teardown_ecr_repo(git_info, ecr_client):
   reponame = docker_reponame(git_info)
@@ -100,7 +101,8 @@ def teardown_ecr_repo(git_info, ecr_client):
   print(response)
 
 def ecs_task_family_name(git_info):
-  return f"buttonmen-{git_info['reponame']}-{git_info['branch']}"
+  prefix = (git_info['site_type'] == 'replay') and 'replay' or 'buttonmen'
+  return f"{prefix}-{git_info['reponame']}-{git_info['branch']}"
 
 def ecs_service_name(git_info):
   return ecs_task_family_name(git_info)
@@ -205,6 +207,9 @@ def run_scp_download_command(remote_path, local_path, public_ipv4):
   os.system(full_cmdargs)
 
 def configure_container_backup_database(git_info, public_ipv4):
+  if git_info['site_type'] == 'replay':
+    print("Not running a database backup on a replay site")
+    return
   cmdargs = "ls /srv/backup"
   backup_files = sorted([x for x in run_ssh_command_with_output(cmdargs, public_ipv4).split('\n') if x.endswith('.sql.bz2')])
   if not backup_files:
@@ -230,7 +235,9 @@ def teardown(args):
   teardown_ecr_repo(git_info, clients['ecr'])
 
 def parse_args(argv):
-  return {}
+  return {
+    'deploy_replay_site': '-p' in argv,
+  }
 
 args = parse_args(sys.argv[1:])
 teardown(args)

--- a/tools/api-client/python/replaytest/replay_loop
+++ b/tools/api-client/python/replaytest/replay_loop
@@ -39,15 +39,15 @@ import datetime
 # Comma-separated list of button names to use in all novel tests, e.g.: 'Avis,Timea'
 PLAYER_BUTTONNAMES = None
 
-HOSTNAME = subprocess.check_output(['hostname', ]).strip()
+SITETAG = open('%s/sitetag' % os.getenv('HOME')).read().strip()
 COMMITID = None
 LOGF = None
 
-USERNAME = 'ubuntu'
+USERNAME = 'root'
 
 PARENTDIR = '/srv/bmgames/chaos-test'
 GAMESDIR = '%s/archive' % (PARENTDIR)
-STATEDIR = '%s/replay_state/%s' % (PARENTDIR, HOSTNAME)
+STATEDIR = '%s/replay_state/%s' % (PARENTDIR, SITETAG)
 STATEFILE = '%s/filesread' % (STATEDIR)
 LOGFILE = '%s/replay_loop.log' % (STATEDIR)
 SRCDIR = '/buttonmen/src'
@@ -92,6 +92,18 @@ def save_state(state):
   for l in state:
     f.write('%s\n' % l)
   f.close()
+
+def restart_mysqld():
+  os.system('sudo killall -u mysql')
+  time.sleep(2)
+  os.system('sudo /etc/init.d/mysql start')
+  time.sleep(5)
+
+def restart_apache():
+  os.system('sudo /etc/init.d/apache2 stop')
+  time.sleep(2)
+  os.system('sudo /etc/init.d/apache2 start')
+  time.sleep(5)
 
 def find_next_file(state):
   newest_file = None
@@ -149,8 +161,10 @@ def test_file(filename):
 
 def execute_responder_test(testname):
   # actually run the test, capturing output
-  prevcwd = os.getcwd()
 
+  restart_mysqld()
+
+  prevcwd = os.getcwd()
   os.chdir(SRCDIR)
 
   logfile = '%s/%s.output' % (STATEDIR, testname)
@@ -166,6 +180,11 @@ def phpunit_log_shows_success(testname):
   contents = open(logfile).read()
   return 'OK (101 tests' in contents
 
+def log_database_games(logname):
+  logpath = '%s/%s' % (STATEDIR, logname)
+  os.system('echo "select * from game" | sudo mysql_root_cli > %s' % logpath)
+  os.system('echo "select * from game_player_view" | sudo mysql_root_cli >> %s' % logpath)
+
 def test_new_games():
   # If we're running in archive mode, this will generate new games
   # and archive them for replay testing on this and other sites.
@@ -174,7 +193,9 @@ def test_new_games():
   # Regardless, this is intended to blow up if any exceptions are
   # received.
 
-  # Reset primary and test databases
+  # Restart MySQL and apache, then reset primary and test databases
+  restart_mysqld()
+  restart_apache()
   os.system('echo "drop database buttonmen" | sudo mysql')
   os.system('sudo /usr/local/bin/create_buttonmen_databases')
   os.system('cat ~/example_players.sql | sudo mysql')
@@ -194,6 +215,7 @@ def test_new_games():
     sys.exit(1)
 
   timestamp = datetime.datetime.now().strftime('%Y%m%d.%H%M%S')
+  log_database_games('new_games.%s' % timestamp)
 
   if LOCAL_REPLAY_GAMES:
     generate_responder_testfile('./prep_replay_games', TESTFILE)


### PR DESCRIPTION
* Partially addresses #2908 

This adds support for a "replay" site type, which can be invoked with a flag (`-p`) to `deploy_buttonmen_site`.

* replay sites have a simpler startup than dev/staging/prod sites --- they don't setup HTTPS, they don't have the option of using a remote database, etc
* i made some changes to replay_loop to work more consistently in the constrained container environment:
    * restart mysql and apache between test runs, for consistency
    * log information about novel games that were played, for debugging

I've tested:
* dev sites still work, and a dev and replay site can be deployed for the same branch at the same time without conflicts
* replay testing generally works, and in particular ran for 22 hours without interruption
