### PR TITLE
Fix mechanism for finding the current git commit ID during archived replay testing

### DIFF
--- a/tools/api-client/python/replaytest/replay_loop
+++ b/tools/api-client/python/replaytest/replay_loop
@@ -66,6 +66,13 @@ ARCHIVE_GAMES = ('-a' in sys.argv[1:] or '--archive' in sys.argv[1:])
 LOCAL_REPLAY_GAMES = ('-l' in sys.argv[1:] or '--local-replay' in sys.argv[1:])
 SKIP_INIT_NEW_GAMES = ('-s' in sys.argv[1:] or '--skip-init' in sys.argv[1:])
 
+def read_commit_id():
+  prevcwd = os.getcwd()
+  os.chdir('/buttonmen/.git')
+  commitid = subprocess.check_output(['git', 'show', '--format=%H']).strip()
+  os.chdir(prevcwd)
+  return commitid
+
 def setup():
   global COMMITID
   global LOGF
@@ -73,9 +80,7 @@ def setup():
     os.mkdir(STATEDIR)
   os.chdir(SRCDIR)
   if ARCHIVE_GAMES:
-    f = open('/buttonmen/.git/FETCH_HEAD')
-    COMMITID = f.readline().split()[0]
-    f.close()
+    COMMITID = read_commit_id()
   LOGF = open(LOGFILE, 'a')
 
 def load_state():


### PR DESCRIPTION
I think this broke because i was previously checking out my own primary branch and then overlaying the branch under test, and now i'm checking that branch out directly.

Regardless, it's clearly more portable to ask git for the commit ID than to try to figure it out by looking at files in .git.  And with this change, `replay_loop -a` (archive) doesn't blow up. 