### PR TITLE
Update replay_single_game to set the correct username for container execution

### DIFF
--- a/tools/api-client/python/replaytest/replay_single_game
+++ b/tools/api-client/python/replaytest/replay_single_game
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import time
 
-USERNAME = 'ubuntu'
+USERNAME = 'root'
 
 PARENTDIR = '/srv/bmgames/chaos-test'
 GAMESDIR = '%s/archive' % (PARENTDIR)


### PR DESCRIPTION
Partially addresses #2908 

Without this fix:
```
$ /buttonmen/tools/api-client/python/replaytest/replay_single_game 183c998516ec4aaa04622691ad4e5c8439c56267.games.20240524.014140.tar.bz2 00020
sudo: unknown user: ubuntu
sudo: unable to initialize policy plugin
command failed: sudo -u ubuntu rm -f /buttonmen/test/src/api/responder99Test.php
```

With this fix:
```
$ /buttonmen/tools/api-client/python/replaytest/replay_single_game 183c998516ec4aaa04622691ad4e5c8439c56267.games.20240524.014140.tar.bz2 00020
<?php
require_once 'responderTestFramework.php';
class responder99Test extends responderTestFramework {
Updating and prepping game for replay from: ./output/game00020.pck
About to execute: sudo -u root sh -c "phpunit --bootstrap /usr/local/etc/buttonmen_phpunit.php --group fulltest_deps /buttonmen/test/src/api/ 2>&1"
PHPUnit 5.1.3 by Sebastian Bergmann and contributors.

.F                                                                  2 / 2 (100%)

Time: 4.58 seconds, Memory: 12.00Mb

There was 1 failure:

1) responder99Test::test_interface_game_00020
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
         'Berserk' => Array (...)
+        'Pappy' => Array (...)
     )
     'gameActionLog' => Array (...)
     'maxWins' => 3
     'playerDataArray' => Array (...)
     'gameChatLogCount' => 0
     'validAttackTypeArray' => Array ()
 )

/buttonmen/test/src/api/responderTestFramework.php:1181
/buttonmen/test/src/api/responder99Test.php:29

FAILURES!
Tests: 2, Assertions: 35, Failures: 1.
```