### PR TITLE
Re-enabled zero option dice for CustomBM

### DIFF
--- a/src/engine/BMDieOption.php
+++ b/src/engine/BMDieOption.php
@@ -58,13 +58,6 @@ class BMDieOption extends BMDie {
 
         $int_optionArray = array();
         foreach ($optionArray as $option) {
-            if ($option === '0') {
-                // see Issue #2614
-                throw new BMExceptionUnimplementedDie(
-                    'Option die size of 0 is currently not supported.'
-                );
-            }
-
             $int_optionArray[] = self::validate_die_size($option, TRUE);
         }
 


### PR DESCRIPTION
Addresses part of #2772.

The aim of this pull request is to simply re-enable zero option dice. Since we currently have no enabled recipes involving zero option dice, this should not affect the prod site at all.

We already have a low-level test that was added as part of #2641 that checks that an option die sets correctly to zero (i.e., value = 0, max = 0, min = 0).

Thus, the direct effect of this change would be to make zero option dice available for use via CustomBM. If we do move towards adding a recipe with a zero option die, we would follow our standard procedure of testing with RandomAI, as well as adding an appropriate responder test to make sure that the zero option die works correctly.

[Dev site at: https://2773-reenable-custombm-zero-option.blackshadowshade.dev.buttonweavers.com/ui/]