### PR TITLE
Avoid putting the game in a broken state if invalid turbo settings are submitted for fire-assisted attack

### DIFF
--- a/src/engine/BMInterfaceGame.php
+++ b/src/engine/BMInterfaceGame.php
@@ -1532,13 +1532,18 @@ class BMInterfaceGame extends BMInterface {
                 $game->proceed_to_next_user_action();
 
                 if (!is_null($game->turboCache)) {
-                    $this->set_turbo_sizes(
+                    if (!$this->set_turbo_sizes(
                         $playerId,
                         $game,
                         $roundNumber,
                         'ignore',
                         $game->turboCache
-                    );
+                    )) {
+                        $this->set_message(
+                            'Setting turbo dice failed.  Cancel Fire turndown and retry the initial attack.'
+                        );
+                        return NULL;
+                    }
                 }
 
                 $this->save_game($game);


### PR DESCRIPTION
* Partially addresses #2967 

This is the simplest possible fix for the root cause.

Background:
* Fire-assisted attacks are performed in two parts, first setting up the attack for fire turndown, and then the fire turndown happens and the attack is committed
* Setting turbo values always happens after the attack is resolved.
* Because in the UI the turbo values are set on the first screen, we cache those values from `submitTurn`, and then get them out of the cache and apply them when we adjust fire dice.

The reason we get games into a broken state, is simply that the fire-adjusted path has its own implementation of applying turbo values, and it doesn't check the return value from `set_turbo_sizes()`, such that if `set_turbo_sizes()` fails, we just plow on ahead, and importantly, we plow on ahead to `save_game()`, committing the broken state in the DB.

This is the simplest possible fix --- it checks the return value, and tells the player if it failed.  And it does *work* (i'm attaching some screencaps below), because if the player abandons the fire turndown, that abandons the cached turbo values, and the player can start over.

It's not the most user-friendly --- it would be marginally more friendly if we rejected the turbo values on the initial screen, rather than making the player back their attack out.  However, i think we should stick with this, because:
* This is the first time we've heard of a player actually running into this case, and we're several years into supporting Turbo+Fire
* Detecting the problem on the first screen would require something different would require something like the `BMAttackTrip::attacker_apply_turbo()` workflow where we optimistically apply the turbo changes on cloned dice just to test them.  That's more complexity and more opportunity to introduce errors; since the player *can* rescue themselves with this fix, it doesn't seem worth it.

[dev site: https://2967-invalid-turbo-swing-fire.cgolubi1.dev.buttonweavers.com/ui/ ]