### PR TITLE
Log error message on API response json_encode() failure

### DIFF
--- a/src/api/ApiResponder.php
+++ b/src/api/ApiResponder.php
@@ -1050,6 +1050,13 @@ class ApiResponder {
         } else {
             header('Content-Type: application/json');
             echo json_encode($output);
+            $last_error = json_last_error();
+            if ($last_error) {
+                $last_error_msg = json_last_error_msg();
+                error_log(
+                    'Response to API call ' . var_export($args, TRUE) . ' failed json_encode(): ' . $last_error_msg
+                );
+            }
         }
     }
 


### PR DESCRIPTION
* Fixes #2983 

Testing:
* I did a bit of manual testing, which i'll describe in a comment
* There's a dev site so people can poke around --- this should be a noop; we're not aware of anything that happens on a normal site that should lead to blank pages, so i really just want a smoke test of normal site activity: https://2983-json-encode-logging.cgolubi1.dev.buttonweavers.com
* I stood up a replay site, because testing of novel games uses the API, so if anything goes wrong during gameplay, it should show up in those logs