### PR TITLE
Replace the check for new accounts from the same IP address, with a check for too many new accounts in the past 15 minutes

### DIFF
--- a/src/engine/BMInterfaceNewuser.php
+++ b/src/engine/BMInterfaceNewuser.php
@@ -117,15 +117,17 @@ class BMInterfaceNewuser {
                 return NULL;
             }
 
-            // if this is a remote connection, check whether this
-            // IP already has numerous player_verification entries
+            // If this is a remote connection, check whether there
+            // have been too many recent player creation requests.
             if (isset($_SERVER) && array_key_exists('REMOTE_ADDR', $_SERVER)) {
-                $query = 'SELECT player_id FROM player_verification WHERE ipaddr = :ipaddr';
+                $query =
+                    'SELECT player_id FROM player_verification ' .
+                    'WHERE generation_time > DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 MINUTE)';
                 $statement = self::$conn->prepare($query);
-                $statement->execute(array(':ipaddr' => $_SERVER['REMOTE_ADDR']));
+                $statement->execute();
                 $fetchResult = $statement->fetchAll();
                 if (count($fetchResult) >= 5) {
-                    $this->message = 'Too many new user requests from IP ' . $_SERVER['REMOTE_ADDR'];
+                    $this->message = 'Too many recent new user requests.  Wait a few minutes and try again.';
                     return NULL;
                 }
             }
@@ -361,15 +363,17 @@ class BMInterfaceNewuser {
                 return NULL;
             }
 
-            // if this is a remote connection, check whether this
-            // IP already has numerous player_verification entries
+           // If this is a remote connection, check whether there
+           // have been too many recent password reset requests.
             if (isset($_SERVER) && array_key_exists('REMOTE_ADDR', $_SERVER)) {
-                $query = 'SELECT player_id FROM player_reset_verification WHERE ipaddr = :ipaddr';
+                $query =
+                    'SELECT player_id FROM player_reset_verification ' .
+                    'WHERE generation_time > DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 MINUTE)';
                 $statement = self::$conn->prepare($query);
-                $statement->execute(array(':ipaddr' => $_SERVER['REMOTE_ADDR']));
+                $statement->execute();
                 $fetchResult = $statement->fetchAll();
                 if (count($fetchResult) >= 5) {
-                    $this->message = 'Too many password reset requests from IP ' . $_SERVER['REMOTE_ADDR'];
+                    $this->message = 'Too many recent password reset requests.  Wait a few minutes and try again.';
                     return NULL;
                 }
             }


### PR DESCRIPTION
* Fixes #2977 

This is the simplest fix for the issue i could think of.

We don't have a very well-defined goal in limiting the number of new user creation requests --- it's just that user creation and password reset verification are parts of the site that can be accessed without an account, so they're relatively more DoS-prone than most of the site for which you have to be logged in.

So "no more than 5 new accounts within 15 minutes" is completely arbitrary, but IMO it's better to have some speedbump than none, and the details don't matter very much.

I'm standing up a dev site for this, and also did some local testing, which i'll describe in a comment to the PR.

Dev site: https://2977-account-creation-ipaddr-check.cgolubi1.dev.buttonweavers.com/ui/