### PR TITLE
Explicitly handle the case where a player requests a non-existent forum thread

### DIFF
--- a/src/engine/BMInterfaceForum.php
+++ b/src/engine/BMInterfaceForum.php
@@ -238,7 +238,11 @@ class BMInterfaceForum extends BMInterface {
             );
             $rows = self::$db->select_rows($query, $parameters, $columnReturnTypes);
 
-            if (count($rows) != 1) {
+            if (count($rows) == 0) {
+                $this->set_message('The requested forum thread does not exist');
+                return NULL;
+            }
+            if (count($rows) > 1) {
                 $this->set_message('Forum thread loading failed');
                 error_log('Wrong number of records returned for forum_thread.id = ' . $threadId);
                 return NULL;

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -1187,9 +1187,17 @@ class responder00Test extends responderTestFramework {
         $this->assertEquals($retval['data']['boardId'], 1);
         $this->assertEquals($retval['data']['threadId'], $thread['data']['threadId']);
 
+        $realThreadId = $retval['data']['threadId'];
         $fakeThreadId = 1;
         $retval['data']['threadId'] = $fakeThreadId;
         $this->cache_json_api_output('loadForumThread', $fakeThreadId, $retval);
+
+        // Loading a non-existent thread should yield a friendly error
+        $args = array(
+            'type' => 'loadForumThread',
+            'threadId' => $realThreadId + 1,
+        );
+        $retval = $this->verify_api_failure($args, 'The requested forum thread does not exist');
     }
 
     public function test_request_loadNextNewPost() {


### PR DESCRIPTION
* Fixes #2993 

The player-visible change here is trivial --- a marginally friendlier message.  The purpose of the fix is to make it so that a player requesting a non-existent forum thread doesn't cause an error log message, which it shouldn't, because only internal errors should cause error log messages.

I don't think this needs a dev site --- i think the extra responder test stub plus the screencap i'm going to put in a comment demonstrates that it works, and it's not worth more discussion than that.  But let me know if you think more is needed!