### PR TITLE
Minor fixes to docker deployment scripts

### DIFF
--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -11,7 +11,6 @@
 #   network configuration from the AWS account hosting buttonmen sites
 
 import base64
-import boto3
 import json
 import os
 import re
@@ -26,7 +25,7 @@ LOCALHOST_IPV4 = '127.0.0.1'
 def get_subprocess_output(cmdargs):
   return subprocess.check_output(cmdargs).decode()
 
-REPO_MATCH = re.compile('^origin\s+git@github.com:([\w-]+)/buttonmen.git \(fetch\)$')
+REPO_MATCH = re.compile('^origin\\s+(git@github.com:|https://github.com/)([\\w-]+)/buttonmen.git \\(fetch\\)$')
 def get_working_directory_info():
   git_info = {
     'reponame': None,
@@ -40,7 +39,7 @@ def get_working_directory_info():
   for line in output.split('\n'):
     match = REPO_MATCH.match(line)
     if not match: continue
-    git_info['reponame'] = match.group(1)
+    git_info['reponame'] = match.group(2)
   if git_info['reponame']:
     print(f"Detected buttonmen repo: {git_info['reponame']}")
   else:
@@ -156,6 +155,7 @@ def add_ecs_config(git_info, args):
 def connect_boto_clients(git_info):
   if git_info['site_type'] == 'local':
     return {}
+  import boto3
   return {
     'ec2': boto3.client('ec2'),
     'ecr': boto3.client('ecr'),

--- a/deploy/docker/get_buttonmen_site_ipaddr
+++ b/deploy/docker/get_buttonmen_site_ipaddr
@@ -17,7 +17,6 @@
 #   deployments, not a general-purpose way to get a site IP address
 #   (for the latter, see the "hello world" emails sent by new containers)
 
-import boto3
 import json
 import os
 import re
@@ -29,7 +28,7 @@ BUTTONMEN_ECS_CONFIG_FILE = f"{os.environ['HOME']}/.aws/buttonmen_ecs_config.jso
 def get_subprocess_output(cmdargs):
   return subprocess.check_output(cmdargs).decode()
 
-REPO_MATCH = re.compile('^origin\s+git@github.com:([\w-]+)/buttonmen.git \(fetch\)$')
+REPO_MATCH = re.compile('^origin\\s+(git@github.com:|https://github.com/)([\\w-]+)/buttonmen.git \\(fetch\\)$')
 def get_working_directory_info():
   git_info = {
     'reponame': None,
@@ -41,7 +40,7 @@ def get_working_directory_info():
   for line in output.split('\n'):
     match = REPO_MATCH.match(line)
     if not match: continue
-    git_info['reponame'] = match.group(1)
+    git_info['reponame'] = match.group(2)
   if not git_info['reponame']:
     raise ValueError(f"Could not detect repo name from git remote: {output}")
 
@@ -70,6 +69,7 @@ def add_ecs_config(git_info, args):
   git_info['config'] = file_config.get(key, {})
 
 def connect_boto_clients():
+  import boto3
   return {
     'ec2': boto3.client('ec2'),
     'ecr': boto3.client('ecr'),

--- a/deploy/docker/teardown_buttonmen_site
+++ b/deploy/docker/teardown_buttonmen_site
@@ -17,7 +17,6 @@
 # * this script assumes you know what you're doing and are done
 #   with the dev site - use at your own risk
 
-import boto3
 import json
 import os
 import re
@@ -29,7 +28,7 @@ BUTTONMEN_ECS_CONFIG_FILE = f"{os.environ['HOME']}/.aws/buttonmen_ecs_config.jso
 def get_subprocess_output(cmdargs):
   return subprocess.check_output(cmdargs).decode()
 
-REPO_MATCH = re.compile('^origin\s+git@github.com:(\w+)/buttonmen.git \(fetch\)$')
+REPO_MATCH = re.compile('^origin\\s+(git@github.com:|https://github.com/)([\\w-]+)/buttonmen.git \\(fetch\\)$')
 def get_working_directory_info():
   git_info = {
     'reponame': None,
@@ -41,7 +40,7 @@ def get_working_directory_info():
   for line in output.split('\n'):
     match = REPO_MATCH.match(line)
     if not match: continue
-    git_info['reponame'] = match.group(1)
+    git_info['reponame'] = match.group(2)
   if git_info['reponame']:
     print(f"Detected buttonmen repo: {git_info['reponame']}")
   else:
@@ -78,6 +77,7 @@ def add_ecs_config(git_info, args):
     raise ValueError(f"ECS config file {BUTTONMEN_ECS_CONFIG_FILE} is missing 'backup_database_path' parameter for download database backups before container delete")
 
 def connect_boto_clients():
+  import boto3
   return {
     'ec2': boto3.client('ec2'),
     'ecr': boto3.client('ecr'),


### PR DESCRIPTION
* Support parsing either SSH or HTTPS git remotes
* Fix escaping of regexps for newer python versions
* Import boto3 just-in-time because it's not needed for local containers

These changes are to support blackshadowshade's testing, and also partially cover #2973.