### PR TITLE
Set file modes correctly when copying files from /buttonmen to /var/www

### DIFF
--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -32,6 +32,11 @@ class buttonmen::server {
       content => template("buttonmen/backup_database.erb"),
       mode => 0555;
 
+    "/usr/local/bin/sync_buttonmen_web_files":
+      ensure => file,
+      content => template("buttonmen/sync_web_files.erb"),
+      mode => 0555;
+
     "/usr/local/bin/set_buttonmen_config":
       ensure => file,
       content => template("buttonmen/set_config.erb"),
@@ -83,13 +88,9 @@ class buttonmen::server {
   }
 
   exec {
-    "buttonmen_src_rsync":
-      command => "/usr/bin/rsync -a --delete /buttonmen/src/ /var/www/",
+    "buttonmen_sync_web_files":
+      command => "/usr/local/bin/sync_buttonmen_web_files",
       require => [ Package["rsync"], Package["apache2"] ];
-
-    "buttonmen_uitest_rsync":
-      command => "/usr/bin/rsync -a --delete /buttonmen/test/src/ui/ /var/www/test-ui/",
-      require => Exec["buttonmen_src_rsync"];
   }
 
   # Create databases only if we're using local database (i.e. for dev/test sites)
@@ -104,11 +105,11 @@ class buttonmen::server {
         "buttonmen_create_databases":
           command => "/usr/local/bin/create_buttonmen_databases",
           require => [ Service["mysql"],
-                       Exec["buttonmen_src_rsync"] ];
+                       Exec["buttonmen_sync_web_files"] ];
 
         "buttonmen_set_config":
           command => "/usr/local/bin/set_buttonmen_config",
-          require => [ Exec["buttonmen_src_rsync"],
+          require => [ Exec["buttonmen_sync_web_files"],
                        File["/usr/local/bin/set_buttonmen_config"],
                        Exec["buttonmen_create_databases"] ];
       }

--- a/deploy/vagrant/modules/buttonmen/templates/sync_web_files.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/sync_web_files.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+##### sync_web_files
+# Copy latest files from the container source directory /buttonmen to /var/www
+
+CHMOD_ARG="--chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r"
+
+/usr/bin/rsync -a --delete ${CHMOD_ARG} /buttonmen/src/ /var/www/
+/usr/bin/rsync -a --delete ${CHMOD_ARG} /buttonmen/test/src/ui/ /var/www/test-ui/


### PR DESCRIPTION
* Fixes #3007 

I tested that `deploy_buttonmen_site -l` still works for me with this change.

Shadowshade, want to test that it solves your deployment problem before accepting?  With this change, you should be able to deploy a container site and it should be accessible via web UI, without any hand-modification needed.