### PR TITLE
Standardize MySQL database field encoding

### DIFF
--- a/deploy/database/updates/scripts/02974_fix_nonascii
+++ b/deploy/database/updates/scripts/02974_fix_nonascii
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+
+from buttonmen_mysqldb import connect_buttonmen_database
+import sys
+
+DRYRUN = len(sys.argv) > 1 and sys.argv[1] == '--dry-run'
+
+if not DRYRUN:
+  confirm = raw_input("Update database for real (y/n)? ")
+  if not confirm == 'y': sys.exit(1)
+
+conn = connect_buttonmen_database()
+crs = conn.cursor()
+
+def run_update(sqlstr):
+  if DRYRUN:
+    print(sqlstr)
+  else:
+    print(sqlstr)
+    result = crs.execute(sqlstr)
+    print(result)
+
+def assert_text_field_okay(table, field):
+  print("-" * 72)
+  print("Verifying no non-utf8 entries in %s.%s" % (table, field))
+  select_sql = 'SELECT id,%s FROM %s WHERE %s IS NOT NULL' % (field, table, field)
+  result = crs.execute(select_sql)
+  rows = crs.fetchall()
+  for row in rows:
+    try:
+      row[1].decode('utf-8')
+    except UnicodeDecodeError:
+      print("Unexpectedly found a bad entry in %s.%s" % (table, field))
+      raise
+
+def check_and_update_text_field(table, field):
+  print("-" * 72)
+  print("Looking for non-utf8 entries in %s.%s" % (table, field))
+  select_sql = 'SELECT id,%s FROM %s WHERE %s IS NOT NULL' % (field, table, field)
+  result = crs.execute(select_sql)
+  rows = crs.fetchall()
+  for row in rows:
+    try:
+      row[1].decode('utf-8')
+    except UnicodeDecodeError:
+      try:
+        newstr = row[1].decode('windows-1252').encode('utf-8').replace('"', '\\"')
+        update_sql = 'UPDATE %s SET %s="%s" WHERE id=%s' % (table, field, newstr, row[0])
+        run_update(update_sql)
+      except UnicodeDecodeError:
+        print("Line couldn't be decoded using windows-1252, trying latin1: " + row[1])
+        newstr = row[1].decode('latin1').encode('utf-8').replace('"', '\\"')
+        update_sql = 'UPDATE %s SET %s="%s" WHERE id=%s' % (table, field, newstr, row[0])
+        run_update(update_sql)
+
+# Fields that shouldn't be able to have bad values, but we want to check
+assert_text_field_okay('buttonset', 'name')
+assert_text_field_okay('button', 'name')
+assert_text_field_okay('button', 'recipe')
+assert_text_field_okay('button', 'flavor_text')
+assert_text_field_okay('tag', 'name')
+assert_text_field_okay('forum_board', 'name')
+assert_text_field_okay('forum_board', 'board_color')
+assert_text_field_okay('forum_board', 'thread_color')
+assert_text_field_okay('forum_board', 'description')
+assert_text_field_okay('game_status', 'name')
+assert_text_field_okay('game_action_log', 'message')
+assert_text_field_okay('die', 'recipe')
+assert_text_field_okay('die', 'flags')
+assert_text_field_okay('die_status', 'name')
+assert_text_field_okay('tournament', 'description')
+assert_text_field_okay('player_status', 'name')
+assert_text_field_okay('player', 'name_ingame')
+assert_text_field_okay('player', 'name_irl')
+assert_text_field_okay('player', 'email')
+assert_text_field_okay('player', 'image_path')
+assert_text_field_okay('player', 'homepage')
+assert_text_field_okay('player', 'die_background')
+assert_text_field_okay('player', 'player_color')
+assert_text_field_okay('player', 'opponent_color')
+assert_text_field_okay('player', 'neutral_color_a')
+assert_text_field_okay('player', 'neutral_color_b')
+
+# Fields that might have bad values, so we want to check and possibly fix
+check_and_update_text_field('forum_thread', 'title')
+check_and_update_text_field('forum_post', 'body')
+check_and_update_text_field('game', 'description')
+check_and_update_text_field('game_chat_log', 'message')
+check_and_update_text_field('player', 'gender')
+check_and_update_text_field('player', 'pronouns')
+check_and_update_text_field('player', 'comment')
+check_and_update_text_field('player', 'vacation_message')
+    
+if not DRYRUN: 
+  conn.commit()

--- a/deploy/vagrant/modules/buttonmen/manifests/init.pp
+++ b/deploy/vagrant/modules/buttonmen/manifests/init.pp
@@ -76,6 +76,10 @@ class buttonmen::server {
       ensure => file,
       content => template("buttonmen/phpunit.php.erb");
 
+    "/usr/local/lib/python2.7/dist-packages/buttonmen_mysqldb.py":
+      ensure => file,
+      content => template("buttonmen/buttonmen_mysqldb_27.py.erb");
+
     "/srv/backup":
       ensure => directory,
       group => "adm",

--- a/deploy/vagrant/modules/buttonmen/templates/branch_database_rebuild_test.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/branch_database_rebuild_test.erb
@@ -17,7 +17,7 @@ git checkout origin/master
 
 # Check out this branch, apply all database updates files in the diff, then take a backup
 git checkout ${THISBRANCH}
-for update in $(git diff --name-only origin/master | grep deploy/database/updates/); do
+for update in $(git diff --name-only origin/master | grep deploy/database/updates/ | grep -v deploy/database/updates/scripts/); do
   echo "applying: ${update}"
   cat $update | mysql buttonmen_test
 done

--- a/deploy/vagrant/modules/buttonmen/templates/buttonmen_mysqldb_27.py.erb
+++ b/deploy/vagrant/modules/buttonmen/templates/buttonmen_mysqldb_27.py.erb
@@ -1,0 +1,25 @@
+# Connect to buttonmen database using MySQLdb
+# Connect functionality should be identical to mysql_root_cli, but
+# for use in python scripts, e.g. database update utilities
+
+HOSTNAME = "<%= @database_fqdn %>"
+CONF_FILE = "/usr/local/etc/buttonmen_db.cnf"
+DBNAME = "buttonmen"
+DEFAULT_USER = "root"
+
+import MySQLdb
+import os
+
+def connect_buttonmen_database():
+  if os.path.exists(CONF_FILE):
+    conn = MySQLdb.connect( 
+      db=DBNAME,
+      host=HOSTNAME,
+      read_default_file=CONF_FILE
+    )
+  else:
+    conn = MySQLdb.connect( 
+      db=DBNAME,
+      user=DEFAULT_USER
+    )
+  return conn

--- a/deploy/vagrant/modules/mysql/templates/buttonmen.cnf.erb
+++ b/deploy/vagrant/modules/mysql/templates/buttonmen.cnf.erb
@@ -11,3 +11,9 @@
 # * NO_AUTO_CREATE_USER - MySQL 8.0 no longer supports this
 sql_mode=NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
 default-authentication-plugin=mysql_native_password
+
+# Use latin1 encoding for text fields
+# (Note: this is just the MySQL encoding.  This setting is compatible
+# with PHP correctly encoding all text as UTF-8.  See discussion in #2974.)
+character-set-server=latin1
+collation-server=latin1_swedish_ci


### PR DESCRIPTION
* Use latin1 encoding in local databases by default
* Add script to fix wrongly-encoded fields in a live DB
* Infrastructure fixes needed for the script to run:
    * Implement generic python MySQLdb connector for buttonmen DBs
    * Fix bug where branch database test fails if update scripts are defined

This fixes #2974.

When this is deployed to prod and staging, the following actions need to be taken in addition to the deployment:
* Run the update script to repair newer entries (the third line should report no further problems):
```
sudo /buttonmen/deploy/database/updates/scripts/02974_fix_nonascii --dry-run
sudo /buttonmen/deploy/database/updates/scripts/02974_fix_nonascii
sudo /buttonmen/deploy/database/updates/scripts/02974_fix_nonascii --dry-run
```
* Update the live database for the site by:
    * Changing the DB parameter group from `default.mysql80` to `buttonmen-mysql-8-0-20241107`
    * Rebooting the DB
