### PR TITLE
Handle what amounts to a division-by-zero error when the divisor is 'None'.

### DIFF
--- a/tools/api-client/python/head-to-head
+++ b/tools/api-client/python/head-to-head
@@ -114,7 +114,7 @@ def print_record(bmconn, type, thing1, thing2):
 
   try:
     winpct = (wins / games) * 100
-  except ZeroDivisionError:
+  except (ZeroDivisionError, TypeError):
     winpct = 0
 
   print("{0} vs {1}: {2} - {3} ({4:.2f}%)".format(thing1, thing2, wins, losses, winpct))


### PR DESCRIPTION
Fixes #3017.

With this change, the command that currently throws an exception instead says
```
[20:05:30] irilyth@azazel:/home/irilyth/src/github/irilyth/buttonmen/tools/api-client/python
+$ ./head-to-head button Georgia Bauer
Georgia vs Bauer: 0 - 0 (0.00%)

```
as expected and desired.