### PR TITLE
When restarting mysqld during replay testing, retry the start a few times

### DIFF
--- a/tools/api-client/python/replaytest/replay_loop
+++ b/tools/api-client/python/replaytest/replay_loop
@@ -136,7 +136,15 @@ def save_state(state):
 def restart_mysqld():
   os.system('sudo killall -u mysql')
   time.sleep(2)
-  os.system('sudo /etc/init.d/mysql start')
+  retry = 0
+  while retry < 5:
+    retval = os.system('sudo /etc/init.d/mysql start')
+    if retval == 0: break
+    time.sleep(5)
+    retry += 1
+  else:
+    print("mysqld failed to start after 5 retries")
+    sys.exit(1)
   time.sleep(5)
 
 def restart_apache():


### PR DESCRIPTION
Partially addresses #2953

This addresses an issue in which sometimes mysqld takes more than 2 seconds to stop, so it hasn't stopped yet when the start is attempted, so the start fails, and the replay loop falls over and has to be manually restarted.

I've verified via a replay site that this functionality works in the happy path, and that if i substitute a broken "start" command, the failure case works --- so i didn't break the ability to run test games.  I'm letting it run to see if it helps with the problem, so we could wait a week to approve it, but also it's harmless, so if you want to just go ahead and approve it, i think that's fine too.