### PR TITLE
Use strlen when testing validity of API string argument length

### DIFF
--- a/src/api/ApiSpec.php
+++ b/src/api/ApiSpec.php
@@ -1031,7 +1031,7 @@ class ApiSpec {
      */
     protected function verify_argument_of_type_string($arg, $argtype = array()) {
         if (is_string($arg)) {
-            $length = mb_strlen($arg, mb_detect_encoding($arg));
+            $length = strlen($arg);
             if (isset($argtype['maxlength']) && $length > $argtype['maxlength']) {
                 return FALSE;
             }

--- a/test/src/api/responder00Test.php
+++ b/test/src/api/responder00Test.php
@@ -329,6 +329,33 @@ class responder00Test extends responderTestFramework {
         $this->assertEquals(array('gameId'), array_keys($retval['data']));
         $this->assertTrue(is_numeric($retval['data']['gameId']));
         $this->assertEquals("Game " . $retval['data']['gameId'] . " created successfully.", $retval['message']);
+
+
+        // Check game creation using unicode descriptions
+	// A maximum-length unicode description should succeed,
+	// and loadGameData should report the same description that was submitted
+        $valid_description = 'ααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααα';
+        $retval = $this->verify_api_createGame(
+            array(1, 1, 1, 1, 2, 2, 2, 2),
+            'responder003', 'responder004', 'Avis', 'Avis', 3, $valid_description, NULL, 'data'
+        );
+        $this->assertEquals('ok', $retval['status'], 'Game creation should succeed');
+        $real_game_id = $retval['data']['gameId'];
+        $retval = $this->verify_api_success(
+            array('type' => 'loadGameData', 'game' => $real_game_id, 'logEntryLimit' => 10));
+        $this->assertEquals($valid_description, $retval['data']['description']);
+
+        // Adding a single unicode character to the description above should cause a clean failure
+        $too_long_description = $valid_description . 'α';
+        $args = array(
+            'type' => 'createGame',
+            'playerInfoArray' => array(array('responder003', 'Avis'),
+                                       array('responder004', 'Avis')),
+            'maxWins' => '3',
+            'description' => $too_long_description,
+        );
+        $this->verify_api_failure($args, 'Argument (description) to function createGame is invalid');
+
     }
 
     /**

--- a/test/src/ui/js/test_Overview.js
+++ b/test/src/ui/js/test_Overview.js
@@ -189,7 +189,7 @@ test("test_Overview.updateSectionHeaderCounts", function(assert) {
 
     assert.equal(
       header.text(),
-      'Active games (9)',
+      'Active games (10)',
       'activeGames section header contains count'
     );
 
@@ -206,7 +206,7 @@ test("test_Overview.updateSectionHeaderCounts", function(assert) {
 
     assert.equal(
       header.text(),
-      'Active games (8)',
+      'Active games (9)',
       'activeGames count only includes visible games'
     );
 

--- a/test/tools/api-client/python/lib/test_bmapi.py
+++ b/test/tools/api-client/python/lib/test_bmapi.py
@@ -158,12 +158,12 @@ class TestBMClient(unittest.TestCase):
   def test_react_to_new_game(self):
     r = self.obj.react_to_new_game(6, 'accept')
     self.assertEqual(r.status, 'ok')
-    self.assertEqual(r.message, 'Joined game 6')
+    self.assertEqual(r.message, 'Joined game 7')
     self.assertEqual(r.data, True)
 
-    r = self.obj.react_to_new_game(8, 'reject')
+    r = self.obj.react_to_new_game(9, 'reject')
     self.assertEqual(r.status, 'ok')
-    self.assertEqual(r.message, 'Rejected game 8')
+    self.assertEqual(r.message, 'Rejected game 9')
     self.assertEqual(r.data, True)
 
   def test_submit_turn(self):

--- a/test/tools/api-client/python/lib/test_bmutils.py
+++ b/test/tools/api-client/python/lib/test_bmutils.py
@@ -54,7 +54,7 @@ class TestBMUtils(unittest.TestCase):
   def test_wrap_load_active_games(self):
     r = self.obj.wrap_load_active_games()
     self.assertTrue(isinstance(r, list))
-    self.assertEqual(len(r), 9)
+    self.assertEqual(len(r), 10)
     self.assertEqual(sorted(r[0].keys()), WRAPPED_GAME_DATA_KEYS)
 
   def test_wrap_load_new_games(self):


### PR DESCRIPTION
* Fixes #3030 

The new responder test checks provide evidence that the fix works.  Without the fix, a similar test shows that game creation succeeds, but the description is corrupted:

```
1) responder00Test::test_request_createGame
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'αααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααα'
+'ααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααα?'

/buttonmen/test/src/api/responder00Test.php:345

FAILURES!
Tests: 2, Assertions: 74, Failures: 1.
```

I also tested manually and found that with the fix, 127 alphas succeed and 128 alphas fail cleanly.  Without the fix, i see a variety of unhelpful behavior as described in comments to #3030