### PR TITLE
When an SSH- or SCP-based command fails, the whole deployment should fail

### DIFF
--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -578,14 +578,18 @@ def run_ssh_command(cmdargs, public_ipv4):
   SSH_ARGS = "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null"
   full_cmdargs = f'{SSH_CMD} {SSH_ARGS} {public_ipv4} "{cmdargs}"'
   print(f"About to run: {full_cmdargs}")
-  os.system(full_cmdargs)
+  retcode = os.system(full_cmdargs)
+  if retcode != 0:
+    raise ValueError(f"SSH-based command failed with exit code: {retcode}")
 
 def run_scp_command(local_path, remote_path, public_ipv4):
   SCP_CMD = "scp"
   SCP_ARGS = "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null"
   full_cmdargs = f'{SCP_CMD} {SCP_ARGS} {local_path} {public_ipv4}:{remote_path}'
   print(f"About to run: {full_cmdargs}")
-  os.system(full_cmdargs)
+  retcode = os.system(full_cmdargs)
+  if retcode != 0:
+    raise ValueError(f"SCP-based command failed with exit code: {retcode}")
 
 def configure_container_setup_certbot(public_ipv4):
   cmdargs = 'sudo /usr/local/bin/apache_setup_certbot'


### PR DESCRIPTION
This has been a papercut for me in standing up dev sites for awhile: sometimes a dev site fails to come up healthy, usually due to intermittent MySQL issues, and the deployment doesn't fail immediately, but just rolls through.  So i have to check for hidden failures on SSH commands, which is tedious.

This PR won't actually address the underlying flakiness problem --- i'll presumably need a new fix for that once i learn more about it --- but it'll make it easier to know when i have to retry.

I tested this by standing up a dev site, which was successful and loaded its database (i could login to it).  I've torn it down now.