### PR TITLE
Standardize logic in apache_setup_certbot so certbot only actually runs once per container startup/deploy

### DIFF
--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -592,8 +592,19 @@ def run_scp_command(local_path, remote_path, public_ipv4):
     raise ValueError(f"SCP-based command failed with exit code: {retcode}")
 
 def configure_container_setup_certbot(public_ipv4):
-  cmdargs = 'sudo /usr/local/bin/apache_setup_certbot'
+  cmdargs = 'sudo /usr/local/bin/apache_setup_certbot new_cert'
   run_ssh_command(cmdargs, public_ipv4)
+
+def configure_container_wait_for_mysqld(public_ipv4):
+  cmdargs = f"sudo /etc/init.d/mysql status"
+  while True:
+    try:
+      run_ssh_command(cmdargs, public_ipv4)
+      print("mysqld is running")
+      return
+    except ValueError:
+      print("...waiting for mysqld")
+      time.sleep(1)
 
 def configure_container_load_database(git_info, public_ipv4):
   load_database_path = git_info['config'].get('load_database_path', None)
@@ -614,6 +625,7 @@ def configure_container_post_install(git_info, public_ipv4):
   use_remote_database = git_info['config']['use_remote_database']
   configure_container_setup_certbot(public_ipv4)
   if not use_remote_database:
+    configure_container_wait_for_mysqld(public_ipv4)
     configure_container_load_database(git_info, public_ipv4)
     configure_container_set_site_type(git_info, public_ipv4)
 

--- a/deploy/docker/startup.sh
+++ b/deploy/docker/startup.sh
@@ -49,12 +49,8 @@ mv /etc/letsencrypt/* ${MNT_DIR}/letsencrypt/
 rmdir /etc/letsencrypt
 ln -s ${MNT_DIR}/letsencrypt /etc/letsencrypt
 
-# If /etc/letsencrypt/live exists, there's an existing cert for
-# this domain, and we need to install it for apache.
-# (If it doesn't exist, we may not have DNS yet, so it's not safe to run certbot.)
-if [ -d /etc/letsencrypt/live ]; then
-  /usr/local/bin/apache_setup_certbot
-fi
+# If there's an existing cert for this domain, install it to apache
+/usr/local/bin/apache_setup_certbot existing_cert
 
 # Buttonmen services
 /etc/init.d/apache2 start

--- a/deploy/vagrant/modules/apache/templates/setup_certbot.erb
+++ b/deploy/vagrant/modules/apache/templates/setup_certbot.erb
@@ -7,6 +7,12 @@ set -x
 FQDN_FILE=/usr/local/etc/bmsite_fqdn
 SANDBOX_FQDN="sandbox.buttonweavers.com"
 
+CONDITION=$1
+if [ "${CONDITION}" != "existing_cert" ] && [ "${CONDITION}" != "new_cert" ]; then
+  echo "Usage: apache_setup_certbot [existing_cert|new_cert]"
+  exit 1
+fi
+
 if [ ! -f "${FQDN_FILE}" ]; then
   echo "Missing dependencies - can't find file ${FQDN_FILE}"
   exit 1
@@ -18,8 +24,32 @@ if [ "${FQDN}" = "${SANDBOX_FQDN}" ]; then
   exit 0
 fi
 
-if [ -d "/etc/letsencrypt/live/${FQDN}" ]; then
-  echo "Directory /etc/letsencrypt/live is already populated; continuing in case we need to reinstall the cert to apache"
+CERT_DIR="/etc/letsencrypt/live/${FQDN}"
+
+# If we're looking for an existing cert and don't find one, exit.
+# This case is primarily for use on container startup, where DNS
+# may not be configured yet, so we don't want to ask letsencrypt for a new cert
+if [ "${CONDITION}" = "existing_cert" ]; then
+  if [ -d "${CERT_DIR}" ]; then
+    echo "Directory ${CERT_DIR} was previously created; continuing in order to reinstall the cert to apache"
+  else
+    echo "Directory ${CERT_DIR} has not yet been created; exiting so that a future script can request a new cert"
+    exit 0
+  fi
+fi
+
+# If we're looking for an new cert and find and existing one, exit.
+# This case is primarily for use after container startup, where DNS
+# has been configured, and we want to ask letsencrypt for a new cert.
+# If there's an existing cert, we expect certbot was run on container
+# startup, and don't want to risk a race condition.
+if [ "${CONDITION}" = "new_cert" ]; then
+  if [ -d "${CERT_DIR}" ]; then
+    echo "Directory ${CERT_DIR} was previously created; exiting because a previous script probably already installed this cert to apache"
+    exit 0
+  else
+    echo "Directory ${CERT_DIR} has not yet been created; continuing in order to request a new cert"
+  fi
 fi
 
 echo "Running certbot to configure this site as FQDN ${FQDN}"


### PR DESCRIPTION
* Also wait for mysqld to startup before running database-related deploy commands

* Fixes #3048
