### PR TITLE
Fixed tournament overview page for a tournament that you have cancelled and did not join

### DIFF
--- a/src/ui/js/TournamentOverview.js
+++ b/src/ui/js/TournamentOverview.js
@@ -318,15 +318,36 @@ TournamentOverview.addDismissCol = function(tournamentRow, tournamentInfo) {
   dismissTd.css('white-space', 'nowrap');
   tournamentRow.append(dismissTd);
 
-  var dismissLink = $('<a>', {
-    'text': 'Dismiss',
-    'href': '#',
-    'data-tournamentId': tournamentInfo.tournamentId,
-  });
-  dismissLink.click(TournamentOverview.formDismissTournament);
-  dismissTd.append('[')
-           .append(dismissLink)
-           .append(']');
+  var apiInfo = $.grep(
+    Api.tournaments.tournaments,
+    function(e){ return e.tournamentId === tournamentInfo.tournamentId; }
+  );
+  var hasJoinedTournament = false;
+  if (apiInfo.length > 0) {
+    hasJoinedTournament = apiInfo[0].hasJoined;
+  }
+
+  if (hasJoinedTournament) {
+    var dismissLink = $('<a>', {
+      'text': 'Dismiss',
+      'href': '#',
+      'data-tournamentId': tournamentInfo.tournamentId,
+    });
+    dismissLink.click(TournamentOverview.formDismissTournament);
+    dismissTd.append('[')
+             .append(dismissLink)
+             .append(']');
+  } else {
+    var unfollowLink = $('<a>', {
+      'text': 'Unfollow',
+      'href': '#',
+      'data-tournamentId': tournamentInfo.tournamentId,
+    });
+    unfollowLink.click(TournamentOverview.formUnfollowTournament);
+    dismissTd.append('[')
+             .append(unfollowLink)
+             .append(']');
+  }
 };
 
 TournamentOverview.formDismissTournament = function(e) {


### PR DESCRIPTION
Addresses bug mentioned in #3056 where the tournament overview page shows Dismiss instead of Unfollow for a tournament that you have created and cancelled but not joined---different to the tournament page which correctly showed Unfollow.

I have tested this locally with tournaments that I have created and cancelled immediately after (the bugged case), and tournaments that I have created, joined, and then cancelled.