### PR TITLE
Populate SMTP SASL AUTH options for postfix

### DIFF
--- a/deploy/circleci/manifests/init.pp
+++ b/deploy/circleci/manifests/init.pp
@@ -14,7 +14,6 @@ node default {
   # Generic node configuration
   include "apt::client"
   include "ntp::client"
-  include "postfix::base"
   include "fqdn::base"
 
   # Node configuration needed for the circleci buttonmen server

--- a/deploy/docker/deploy_buttonmen_site
+++ b/deploy/docker/deploy_buttonmen_site
@@ -186,6 +186,16 @@ def get_remote_database_password(git_info):
     return git_info['config']['remote_database_admin_pw']
   return None
 
+def get_email_relay_host(git_info):
+  if git_info['config'].get('email_relay_host', None):
+    return git_info['config']['email_relay_host']
+  return 'NORELAY'
+
+def get_email_relay_sasl_creds(git_info):
+  if git_info['config'].get('email_relay_sasl_creds', None):
+    return git_info['config']['email_relay_sasl_creds']
+  return 'NOCREDS'
+
 def find_docker_image_with_tag(tag):
   return get_subprocess_output(['docker', 'images', tag, '--format', '{{.ID}}']).strip()
 
@@ -194,6 +204,8 @@ def customize_vagrant(git_info):
   bmsite_fqdn = buttonmen_site_fqdn(git_info)
   database_fqdn = get_database_fqdn(git_info)
   remote_database_password = get_remote_database_password(git_info)
+  email_relay_host = get_email_relay_host(git_info)
+  email_relay_sasl_creds = get_email_relay_sasl_creds(git_info)
   site_type = (git_info['site_type'] in ['replay', 'local']) and 'development' or git_info['site_type']
 
   cmdargs = ['sed', '-i', '-e', f"s/REPLACE_WITH_DATABASE_FQDN/{database_fqdn}/", './deploy/vagrant/manifests/init.pp']
@@ -210,6 +222,18 @@ def customize_vagrant(git_info):
 
   cmdargs = ['sed', '-i', '-e', f"s/REPLACE_WITH_BUTTONMEN_SITE_TYPE/{site_type}/", './deploy/vagrant/manifests/init.pp']
   print(f"About to install {site_type} as vagrant buttonmen_site_type: {cmdargs}")
+  retcode = subprocess.call(cmdargs)
+  if retcode != 0:
+    raise ValueError(f"Replacement failed: {retcode}")
+
+  cmdargs = ['sed', '-i', '-e', f"s/REPLACE_WITH_EMAIL_RELAY_HOST/{email_relay_host}/", './deploy/vagrant/manifests/init.pp']
+  print(f"About to install vagrant email_relay_host...")
+  retcode = subprocess.call(cmdargs)
+  if retcode != 0:
+    raise ValueError(f"Replacement failed: {retcode}")
+
+  cmdargs = ['sed', '-i', '-e', f"s/REPLACE_WITH_EMAIL_RELAY_SASL_CREDS/{email_relay_sasl_creds}/", './deploy/vagrant/manifests/init.pp']
+  print(f"About to install vagrant email_relay_sasl_creds...")
   retcode = subprocess.call(cmdargs)
   if retcode != 0:
     raise ValueError(f"Replacement failed: {retcode}")

--- a/deploy/vagrant/manifests/init.pp
+++ b/deploy/vagrant/manifests/init.pp
@@ -16,6 +16,8 @@ node default {
   $database_fqdn = "REPLACE_WITH_DATABASE_FQDN"
   $buttonmen_site_type = "REPLACE_WITH_BUTTONMEN_SITE_TYPE"
   $remote_database_password = "REPLACE_WITH_REMOTE_DATABASE_PASSWORD"
+  $email_relay_host = "REPLACE_WITH_EMAIL_RELAY_HOST"
+  $email_relay_sasl_creds = "REPLACE_WITH_EMAIL_RELAY_SASL_CREDS"
 
   $puppet_timestamp = generate('/bin/date', '+%s')
 

--- a/deploy/vagrant/modules/postfix/manifests/init.pp
+++ b/deploy/vagrant/modules/postfix/manifests/init.pp
@@ -10,6 +10,24 @@ class postfix::base {
     "postfix": ensure => running, enable => true;
   }
 
+  # Install a creds file if we are using creds
+  if "${email_relay_sasl_creds}" != "NOCREDS" {
+    file {
+      "/etc/postfix/sasl_passwd":
+        ensure => file,
+        content => template("postfix/sasl_passwd.erb"),
+        mode => 0400,
+        require => Package["postfix"];
+    }
+
+    exec {
+      "postmap_sasl_passwd":
+        command => "/usr/sbin/postmap hash:/etc/postfix/sasl_passwd",
+        refreshonly => true,
+        subscribe => File["/etc/postfix/sasl_passwd"];
+    }
+  }
+
   # Install an aliases file
   file {
     "/etc/aliases":

--- a/deploy/vagrant/modules/postfix/templates/main.cf.erb
+++ b/deploy/vagrant/modules/postfix/templates/main.cf.erb
@@ -16,8 +16,18 @@ smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-# See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
-# information on enabling SSL in the smtp client.
+<%- if @email_relay_sasl_creds != "NOCREDS" %>
+# SMTP SASL AUTH parameters for relaying remotely
+
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_security_options = noanonymous
+smtp_tls_security_level = may
+smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
+header_size_limit = 4096000
+<%- end %>
+
+# General mail options
 
 myhostname = <%= @puppet_hostname %>
 mydomain = buttonweavers.com
@@ -26,7 +36,11 @@ alias_database = hash:/etc/aliases
 myorigin = <%= @puppet_hostname %>
 masquerade_domains = $mydomain
 mydestination = <%= @puppet_hostname %>, localhost.buttonweavers.com, localhost
+<%- if @email_relay_host == "NORELAY" %>
 relayhost = 
+<%- else %>
+relayhost = [<%= @email_relay_host %>]:587
+<%- end %>
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +

--- a/deploy/vagrant/modules/postfix/templates/sasl_passwd.erb
+++ b/deploy/vagrant/modules/postfix/templates/sasl_passwd.erb
@@ -1,0 +1,2 @@
+# Postfix sasl_passwd file for relaying to remote hosts which require auth
+[<%= @email_relay_host %>]:587  <%= @email_relay_sasl_creds %>


### PR DESCRIPTION
* Allow us to configure optional SASL AUTH credentials as part of deploy_buttonmen_site
* If a relayhost is defined in the config file, postfix is configured to relay all mail to that host
* If relay credentials are defined in the config file, postfix is configured to load those credentials and use them when relaying mail via the relayhost
* If relayhost and relay credentials are not configured, nothing changes
* Stop configuring postfix at all for CircleCI hosts --- we don't need it there

-------
This PR is on the path to resolving #2915 --- here's the deal:
* I think the correct solution for that issue is to send buttonmen e-mail via SES (AWS Simple Email Service), and also apply some other configuration to the buttonweavers.com domain to make it a better e-mail citizen.  In particular, i've had good luck with SES + DKIM + DMARC making gmail willing to accept e-mail on the first try, on other domains i run.
* Ideally, we should make all of those changes at once --- specifically, we should make changes at the buttonweavers.com level to expect mail to be sent via SES, and start sending mail via SES, at approximately the same time.
* To that end, what this PR does is add the ability to configure all of the pieces that would send authenticated e-mail to SES from a buttonweavers site.  But if the configuration isn't set, nothing will change.
* That way i can deploy this normally and have the code in place turned off, and when i'm ready to pull the lever, i can do a one-off redeploy of staging and production to add SES sending as a config change rather than a code change.

Here's how i tested this:
* deployed to a dev site with the new configuration enabled.  Verified that (A) the "new site is up" e-mail, and (B) the e-mail verification for a new user, attempted to be sent to `email-smtp.us-east-1.amazonaws.com`, and were rejected because the e-mail domains involved in the message were not yet verified parts of my SES account.  I think that means the plumbing works --- the e-mail is talking to the right server and being authenticated correctly with the creds i've setup --- the server-side just isn't ready yet because i haven't migrated buttonweavers.com, which is expected
* deployed to a dev site with the new configuration disabled.  Verified that the "new site is up" e-mail and the e-mail verification for a new user were successfully sent to me in the usual way.  This shows the code is correctly a noop when the configuration isn't in place

I believe this PR is safe to accept.