### PR TITLE
Push changes from staging to production on 2026-08-09

### DIFF
--- a/deploy/vagrant/modules/mysql/manifests/init.pp
+++ b/deploy/vagrant/modules/mysql/manifests/init.pp
@@ -1,18 +1,56 @@
 # Configuration for a buttonmen mysql server
 class mysql::server {
 
+  # Dependency of mysql-apt-config
+  package {
+    "gnupg": ensure => installed;
+  }
+
+  # Prerequisites for upgrade to MySQL 8.4
+  file {
+    "/usr/local/etc/mysql_apt_config.dat":
+      ensure => file,
+      content => template("mysql/mysql_apt_config.dat.erb");
+
+    "/etc/init.d/mysql":
+      ensure => file,
+      mode => "0544",
+      content => template("mysql/init_mysql.erb");
+
+    "/usr/local/sbin/configure_mysql_apt":
+      ensure => file,
+      mode => "0544",
+      content => template("mysql/configure_mysql_apt.erb");
+  }
+
+  exec {
+    "mysql_configure_apt":
+      command => "/usr/local/sbin/configure_mysql_apt",
+      require => [
+        File["/usr/local/etc/mysql_apt_config.dat"],
+        File["/usr/local/sbin/configure_mysql_apt"],
+        Package["gnupg"],
+      ];
+  }
+
   # Install mysql-server only if this site doesn't use RDS
   # Always install a mysql client for e.g. database backups
   case "$database_fqdn" {
     "127.0.0.1": {
       package {
-        "mysql-server": ensure => installed;
+        "mysql-server":
+          ensure => installed,
+          install_options => ["--allow-unauthenticated", "-f"],
+          require => Exec["mysql_configure_apt"];
       }
     }
     default: {
       package {
         "mysql-server": ensure => absent;
-        "mysql-client": ensure => installed;
+        "mysql-client":
+          ensure => installed,
+          install_options => ["--allow-unauthenticated", "-f"],
+          require => Exec["mysql_configure_apt"];
       }
     }
   }

--- a/deploy/vagrant/modules/mysql/templates/buttonmen.cnf.erb
+++ b/deploy/vagrant/modules/mysql/templates/buttonmen.cnf.erb
@@ -10,7 +10,7 @@
 # * ONLY_FULL_GROUP_BY - a search in BMInterface::search_game_history violates this
 # * NO_AUTO_CREATE_USER - MySQL 8.0 no longer supports this
 sql_mode=NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
-default-authentication-plugin=mysql_native_password
+mysql_native_password=ON
 
 # Use latin1 encoding for text fields
 # (Note: this is just the MySQL encoding.  This setting is compatible

--- a/deploy/vagrant/modules/mysql/templates/configure_mysql_apt.erb
+++ b/deploy/vagrant/modules/mysql/templates/configure_mysql_apt.erb
@@ -3,11 +3,12 @@
 set -e
 set -x
 
-# Download a version of mysql-apt-config that supports Ubuntu 16.04 and MySQL 8.0
-wget -O /usr/local/src/mysql-apt-config_0.8.10-1_all.deb https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
+# Download a version of mysql-apt-config that supports Ubuntu 24.04 and MySQL 8.4
+wget -O /usr/local/src/mysql-apt-config_0.8.39-1_all.deb https://dev.mysql.com/get/mysql-apt-config_0.8.39-1_all.deb
 
-# Install mysql_apt_config using an override configuration which selects MySQL 8.0  
-DEBCONF_DB_OVERRIDE='File {/usr/local/etc/mysql_apt_config.dat}' DEBIAN_FRONTEND=noninteractive dpkg -i /usr/local/src/mysql-apt-config_0.8.10-1_all.deb
+# Install mysql_apt_config using an override configuration which selects MySQL 8.4
+DEBCONF_DB_OVERRIDE='File {/usr/local/etc/mysql_apt_config.dat}' DEBIAN_FRONTEND=noninteractive dpkg -i /usr/local/src/mysql-apt-config_0.8.39-1_all.deb
 
 # Update the apt DB to bring in the new versions
-apt-get update
+# * N.B. the --allow-unauthenticated --allow-insecure-repositories flags are for mod_pagespeed
+apt-get update --allow-unauthenticated --allow-insecure-repositories

--- a/deploy/vagrant/modules/mysql/templates/mysql_apt_config.dat.erb
+++ b/deploy/vagrant/modules/mysql/templates/mysql_apt_config.dat.erb
@@ -5,13 +5,13 @@ Owners: mysql-apt-config
 Flags: seen
 Variables:
  selected_preview = Disabled
- selected_server = mysql-8.0
+ selected_server = mysql-8.4
  selected_tools = Enabled
 
 Name: mysql-apt-config/select-server
 Template: mysql-apt-config/select-server
-Value: mysql-8.0
+Value: mysql-8.4
 Owners: mysql-apt-config
 Flags: seen
 Variables:
- server_versions = mysql-5.7, mysql-8.0, mysql-cluster-7.5, mysql-cluster-7.6
+ server_versions = mysql-8.0, mysql-8.4


### PR DESCRIPTION
This update brings these approved pulls to the production branch:

* #3099

Database updates:
```
UPDATES=
SCRIPTS=
```

Other updates:

* After performing the deployment, upgrade the RDS database attached to this service: DB engine version: 8.0.42 -> 8.4.10

Once this pull is merged, i will load the changes on www.buttonweavers.com as part of #700.
